### PR TITLE
Attempt to fix the astropy.tests.pytest_plugins bug

### DIFF
--- a/docs/process/NIR_arcs.rst
+++ b/docs/process/NIR_arcs.rst
@@ -3,6 +3,8 @@ Near-IR, multi-slit arcs
 ************************
 
 .. figure:: NIR_MOS_arc.svg
+   :height: 1200
+   :width: 600
    :scale: 50 %
    :alt: DR flowchart for MOS wavelength calibration.
 

--- a/docs/process/NIR_flats.rst
+++ b/docs/process/NIR_flats.rst
@@ -3,6 +3,8 @@ Near-IR, multi-slit flats
 *************************
 
 .. figure:: NIR_MOS_trace.svg
+   :height: 1200
+   :width: 600
    :scale: 50 %
    :alt: DR flowchart for MOS slit traces.
 
@@ -11,6 +13,8 @@ Near-IR, multi-slit flats
 
 
 .. figure:: NIR_MOS_flat.svg
+   :height: 1200
+   :width: 600
    :scale: 50 %
    :alt: DR flowchart for multi-slit lamp flat processing.
 

--- a/docs/process/NIR_science_data.rst
+++ b/docs/process/NIR_science_data.rst
@@ -7,6 +7,8 @@ spectra with a single detector array.
 
 
 .. figure:: NIR_MOS_science.svg
+   :height: 1200
+   :width: 600
    :scale: 50 %
    :alt: DR flowchart for MOS science data.
 

--- a/specreduce/conftest.py
+++ b/specreduce/conftest.py
@@ -2,7 +2,27 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
-from astropy.tests.pytest_plugins import *
+import os
+
+from astropy.version import version as astropy_version
+if astropy_version < '3.0':
+    from astropy.tests.pytest_plugins import *
+    del pytest_report_header
+else:
+    from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+
+
+def pytest_configure(config):
+
+    config.option.astropy_header = True
+
+    PYTEST_HEADER_MODULES.pop('Pandas', None)
+    PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
+
+    from .version import version, astropy_helpers_version
+    packagename = os.path.basename(os.path.dirname(__file__))
+    TESTED_VERSIONS[packagename] = version
+    TESTED_VERSIONS['astropy_helpers'] = astropy_helpers_version
 
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions


### PR DESCRIPTION
Attempting to patch the astropy.tests.pytest-plugins bug in order for all PR's to pass the Travis CI tests. Because currently as the tests are failing as we have the following error thrown: 

```
ImportError while loading conftest '/tmp/specreduce-test-31trorr0/lib/python3.7/site-packages/specreduce/conftest.py'.
specreduce/conftest.py:5: in <module>
    from astropy.tests.pytest_plugins import *
E   ModuleNotFoundError: No module named 'astropy.tests.pytest_plugins'
The command "$MAIN_CMD $SETUP_CMD" exited with 4.
```