### PR TITLE
Fix SpecreduceOperation class

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,12 @@ Reference/API
 .. automodapi:: specreduce
     :no-inheritance-diagram:
 
+.. automodapi:: specreduce.core
+    :no-inheritance-diagram:
+
+.. automodapi:: specreduce.extract
+    :no-inheritance-diagram:
+
 .. automodapi:: specreduce.calibration_data
     :no-inheritance-diagram:
     :include-all-objects:

--- a/specreduce/__init__.py
+++ b/specreduce/__init__.py
@@ -6,4 +6,4 @@
 from ._astropy_init import *   # noqa
 # ----------------------------------------------------------------------------
 
-from specreduce.core import *
+from specreduce.core import *  # noqa

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -3,7 +3,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import inspect
-from dataclass import dataclass
+from dataclasses import dataclass
 
 __all__ = ['SpecreduceOperation']
 

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -7,13 +7,12 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from astropy import units as u
-from astropy import
+from astropy.nddata import StdDevUncertainty
 
 from specreduce.core import SpecreduceOperation
 from specutils import Spectrum1D
 
-
-__all__ = ['extract']
+__all__ = ['BoxcarExtract']
 
 
 class BoxcarExtract(SpecreduceOperation):
@@ -24,7 +23,7 @@ class BoxcarExtract(SpecreduceOperation):
     ----------
     img : nddata-compatible image
         The input image
-    trace_object
+    trace_object :
         The trace of the spectrum to be extracted TODO: define
     apwidth : int
         The width of the extraction aperture in pixels
@@ -37,9 +36,9 @@ class BoxcarExtract(SpecreduceOperation):
 
     Returns
     -------
-    spec : `specutis.Spectrum1D`
+    spec : `~specutils.Spectrum1D`
         The extracted spectrum
-    skyspec : `specutis.Spectrum1D`
+    skyspec : `~specutils.Spectrum1D`
         The sky spectrum used in the extraction process
     """
     apwidth: int = 8
@@ -64,49 +63,60 @@ class BoxcarExtract(SpecreduceOperation):
         skysubflux = np.zeros_like(trace_line)
         fluxerr = np.zeros_like(trace_line)
 
-        for i in range(0,len(trace_line)):
-            #-- first do the aperture flux
+        for i in range(0, len(trace_line)):
+            # first do the aperture flux
             # juuuust in case the trace gets too close to an edge
-            widthup = self. apwidth
-            widthdn = self. apwidth
-            if (trace_line[i]+widthup > img.shape[0]):
-                widthup = img.shape[0]-trace_line[i] - 1
-            if (trace_line[i]-widthdn < 0):
+            widthup = self.apwidth / 2
+            widthdn = self.apwidth / 2
+            if (trace_line[i] + widthup > img.shape[0]):
+                widthup = img.shape[0] - trace_line[i] - 1
+            if (trace_line[i] - widthdn < 0):
                 widthdn = trace_line[i] - 1
 
             # simply add up the total flux around the trace_line +/- width
             onedspec[i] = np.nansum(img[int(trace_line[i]-widthdn):int(trace_line[i]+widthup+1), i])
 
-            #-- now do the sky fit
+            # now do the sky fit
             itrace_line = int(trace_line[i])
-            y = np.append(np.arange(itrace_line-self. apwidth-self.skysep-self.skywidth, itrace_line-self. apwidth-self.skysep),
-                          np.arange(itrace_line+self. apwidth+self.skysep+1, itrace_line+self. apwidth+self.skysep+self.skywidth+1))
+            y = np.append(
+                np.arange(
+                    itrace_line - self.apwidth - self.skysep - self.skywidth,
+                    itrace_line - self.apwidth - self.skysep
+                ),
+                np.arange(
+                    itrace_line + self.apwidth + self.skysep + 1,
+                    itrace_line + self.apwidth + self.skysep + self.skywidth + 1
+                )
+            )
 
-            z = img[y,i]
-            if (self.skydeg>0):
+            z = img[y, i]
+            if (self.skydeg > 0):
                 # fit a polynomial to the sky in this column
-                pfit = np.polyfit(y,z,self.skydeg)
+                pfit = np.polyfit(y, z, self.skydeg)
                 # define the aperture in this column
-                ap = np.arange(trace_line[i]-self. apwidth, trace_line[i]+self. apwidth+1)
+                ap = np.arange(
+                    trace_line[i] - self.apwidth,
+                    trace_line[i] + self.apwidth + 1
+                )
                 # evaluate the polynomial across the aperture, and sum
                 skysubflux[i] = np.nansum(np.polyval(pfit, ap))
-            elif (self.skydeg==0):
-                skysubflux[i] = np.nanmean(z)*(self. apwidth*2.0 + 1)
+            elif (self.skydeg == 0):
+                skysubflux[i] = np.nanmean(z) * (self.apwidth * 2.0 + 1)
 
-            #-- finally, compute the error in this pixel
-            sigB = np.nanstd(z) # stddev in the background data
-            N_B = np.float(len(y)) # number of bkgd pixels
-            N_A = self. apwidth * 2. + 1 # number of aperture pixels
+            # finally, compute the error in this pixel
+            sigB = np.nanstd(z)  # stddev in the background data
+            N_B = np.float(len(y))  # number of bkgd pixels
+            N_A = self. apwidth * 2. + 1  # number of aperture pixels
 
             # based on aperture phot err description by F. Masci, Caltech:
             # http://wise2.ipac.caltech.edu/staff/fmasci/ApPhotUncert.pdf
             fluxerr[i] = np.sqrt(np.nansum((onedspec[i]-skysubflux[i])) +
                                  (N_A + N_A**2. / N_B) * (sigB**2.))
 
-        spec = Spectrum1D(spectral_axis=np.arange(len(onedspec))*u.pixel,
+        spec = Spectrum1D(spectral_axis=np.arange(len(onedspec)) * u.pixel,
                           flux=onedspec * img.unit,
                           uncertainty=StdDevUncertainty(fluxerr))
-        skyspec = Spectrum1D(spectral_axis=np.arange(len(onedspec))*u.pixel,
+        skyspec = Spectrum1D(spectral_axis=np.arange(len(onedspec)) * u.pixel,
                              flux=skysubflux * img.unit)
 
         return spec, skyspec
@@ -119,9 +129,34 @@ class BoxcarExtract(SpecreduceOperation):
         plt.clim(np.percentile(self.last_img, (5, 98)))
 
         plt.plot(np.arange(len(trace_line)), trace_line, c='C0')
-        plt.fill_between(np.arange(len(trace_line)), trace_line + self. apwidth, trace_line-self. apwidth, color='C0', alpha=0.5)
-        plt.fill_between(np.arange(len(trace_line)), trace_line + self. apwidth + self.skysep, trace_line + self. apwidth + self.skysep + self.skywidth, color='C1', alpha=0.5)
-        plt.fill_between(np.arange(len(trace_line)), trace_line - self. apwidth - self.skysep, trace_line - self. apwidth - self.skysep - self.skywidth, color='C1', alpha=0.5)
-        plt.ylim(np.min(trace_line - (self. apwidth + self.skysep + self.skywidth)*2), np.max(trace_line + (self. apwidth + self.skysep + self.skywidth)*2))
-        
+        plt.fill_between(
+            np.arange(len(trace_line)),
+            trace_line + self.apwidth,
+            trace_line - self.apwidth,
+            color='C0',
+            alpha=0.5
+        )
+        plt.fill_between(
+            np.arange(len(trace_line)),
+            trace_line + self.apwidth + self.skysep,
+            trace_line + self.apwidth + self.skysep + self.skywidth,
+            color='C1',
+            alpha=0.5
+        )
+        plt.fill_between(
+            np.arange(len(trace_line)),
+            trace_line - self.apwidth - self.skysep,
+            trace_line - self.apwidth - self.skysep - self.skywidth,
+            color='C1',
+            alpha=0.5
+        )
+        plt.ylim(
+            np.min(
+                trace_line - (self.apwidth + self.skysep + self.skywidth) * 2
+            ),
+            np.max(
+                trace_line + (self.apwidth + self.skysep + self.skywidth) * 2
+            )
+        )
+
         return fig

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -75,7 +75,7 @@ class BoxcarExtract(SpecreduceOperation):
 
             # simply add up the total flux around the trace_line +/- width
             onedspec[i] = np.nansum(
-                img[int(trace_line[i] - widthdn):int(trace_line[i] + widthup+ 1 ), i]
+                img[int(trace_line[i] - widthdn):int(trace_line[i] + widthup + 1), i]
             )
 
             # now do the sky fit


### PR DESCRIPTION
This PR picks up work from the orphaned PR #53 and fixes the obvious bugs/makes code cleanups to at least get tests to pass. There is more work to be done to add tests and flesh out extraction methods as well as add more infrastructure that the extraction methods need (like trace information). This PR gives that work a cleaner starting point.