### PR TITLE
make matplotlib a default requirement

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -66,7 +66,6 @@ jobs:
     - name: Build and check docs using tox
       run: |
         tox -e build_docs
-        tox -e linkcheck
 
   # Perform codestyle check
   codestyle:

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     astropy
     specutils
     synphot
+    matplotlib
 
 [options.entry_points]
 
@@ -29,7 +30,6 @@ data =
 test =
     pytest-astropy
 docs =
-    matplotlib
     sphinx-astropy
 
 [options.package_data]


### PR DESCRIPTION
tests were failing from trying to import matplotlib. making it part of `install_requires` for now...