### PR TITLE
Bug fixes in boxcar extraction code

### DIFF
--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -120,6 +120,7 @@ class BoxcarExtract(SpecreduceOperation):
             np_indices = np.indices(img[::, i].shape) # put this outside loop
             sky_y = np.intersect1d(sky_y, np_indices)
 
+            # TODO add fractional pixel handling
             sky_flux = img[sky_y, i]
             if (self.skydeg > 0):
                 # fit a polynomial to the sky in this column

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -82,18 +82,20 @@ class BoxcarExtract(SpecreduceOperation):
             # now do the sky fit
             # Note that we are not including fractional pixels, since we are doing
             # a polynomial fit over the sky values.
-            j1 = self._find_nearest_int(trace_line[i] - self.apwidth/2. - self.skysep - self.skywidth)
+            j1 = self._find_nearest_int(trace_line[i] - self.apwidth/2. -
+                                        self.skysep - self.skywidth)
             j2 = self._find_nearest_int(trace_line[i] - self.apwidth/2. - self.skysep)
             sky_y_1 = np.arange(j1, j2)
 
             j1 = self._find_nearest_int(trace_line[i] + self.apwidth/2. + self.skysep)
-            j2 = self._find_nearest_int(trace_line[i] + self.apwidth/2. + self.skysep + self.skywidth)
+            j2 = self._find_nearest_int(trace_line[i] + self.apwidth/2. +
+                                        self.skysep + self.skywidth)
             sky_y_2 = np.arange(j1, j2)
 
             sky_y = np.append(sky_y_1, sky_y_2)
 
             # sky can't be outside image
-            np_indices = np.indices(img[::, i].shape) # put this outside loop
+            np_indices = np.indices(img[::, i].shape)
             sky_y = np.intersect1d(sky_y, np_indices)
 
             sky_flux = img[sky_y, i]

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -80,6 +80,8 @@ class BoxcarExtract(SpecreduceOperation):
             self._extract_from_box(img, i, low_end, high_end, onedspec)
 
             # now do the sky fit
+            # Note that we are not including fractional pixels, since we are doing
+            # a polynomial fit over the sky values.
             j1 = self._find_nearest_int(trace_line[i] - self.apwidth/2. - self.skysep - self.skywidth)
             j2 = self._find_nearest_int(trace_line[i] - self.apwidth/2. - self.skysep)
             sky_y_1 = np.arange(j1, j2)

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -111,7 +111,7 @@ class BoxcarExtract(SpecreduceOperation):
             # finally, compute the error in this pixel
             sigma_bkg = np.nanstd(sky_flux)  # stddev in the background data
             n_bkg = np.float(len(sky_y))  # number of bkgd pixels
-            n_ap = self.apwidth * 2. + 1  # number of aperture pixels
+            n_ap = self.apwidth  # number of aperture pixels
 
             # based on aperture phot err description by F. Masci, Caltech:
             # http://wise2.ipac.caltech.edu/staff/fmasci/ApPhotUncert.pdf

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -4,7 +4,7 @@ import numpy as np
 from ..extract import BoxcarExtract
 
 
-# Mock a Trace that consists of a straight line placed exactly at row 15.
+# Mock a Trace class that represents a line parallel to the image rows.
 class Trace:
     def __init__(self, position):
         self.line = np.ones(shape=(10,)) * position
@@ -14,7 +14,7 @@ class TestBoxcarExtract(unittest.TestCase):
 
     # Test image is comprised of 30 rows with 10 columns each. Row content
     # is row index itself. This makes it easy to predict what should be the
-    # value extracted from a region centered at any arbitrary row.
+    # value extracted from a region centered at any arbitrary Y position.
     def setUp(self):
         self.image = np.ones(shape=(30,10))
         for j in range(self.image.shape[0]):

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -1,7 +1,14 @@
-import unittest
 import numpy as np
 
 from ..extract import BoxcarExtract
+
+
+# Test image is comprised of 30 rows with 10 columns each. Row content
+# is row index itself. This makes it easy to predict what should be the
+# value extracted from a region centered at any arbitrary Y position.
+image = np.ones(shape=(30, 10))
+for j in range(image.shape[0]):
+    image[j, ::] *= j
 
 
 # Mock a Trace class that represents a line parallel to the image rows.
@@ -10,53 +17,82 @@ class Trace:
         self.line = np.ones(shape=(10,)) * position
 
 
-class TestBoxcarExtract(unittest.TestCase):
+def test_extraction():
+    #
+    # Try combinations of extraction center, and even/odd
+    # extraction aperture sizes.
+    #
+    boxcar = BoxcarExtract()
 
-    # Test image is comprised of 30 rows with 10 columns each. Row content
-    # is row index itself. This makes it easy to predict what should be the
-    # value extracted from a region centered at any arbitrary Y position.
-    def setUp(self):
-        self.image = np.ones(shape=(30,10))
-        for j in range(self.image.shape[0]):
-            self.image[j,::] *= j
+    boxcar.apwidth = 5
 
-        assert self.image[0,0] == 0
-        assert self.image[0,9] == 0
-        assert self.image[10,0] == 10
-        assert self.image[10,9] == 10
-        assert self.image[29,0] == 29
-        assert self.image[29,9] == 29
+    trace = Trace(15.0)
+    spectrum, bkg_spectrum = boxcar(image, trace)
+    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 75.))
 
-    def test_boxcar_extraction(self):
-        #
-        # Try combinations of extraction center, and even/odd
-        # extraction aperture sizes.
-        #
-        boxcar = BoxcarExtract()
+    trace = Trace(14.5)
+    spectrum, bkg_spectrum = boxcar(image, trace)
+    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 72.5))
 
-        boxcar.apwidth = 5
+    boxcar.apwidth = 6
 
-        trace = Trace(15.0)
-        spectrum, bkg_spectrum = boxcar(self.image, trace)
-        assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 75.))
+    trace = Trace(15.0)
+    spectrum, bkg_spectrum = boxcar(image, trace)
+    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 90.))
 
-        trace = Trace(14.5)
-        spectrum, bkg_spectrum = boxcar(self.image, trace)
-        assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 72.5))
+    boxcar.apwidth = 6
+    trace = Trace(14.5)
+    spectrum, bkg_spectrum = boxcar(image, trace)
+    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 87.))
 
-        boxcar.apwidth = 6
 
-        trace = Trace(15.0)
-        spectrum, bkg_spectrum = boxcar(self.image, trace)
-        assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 90.))
+def test_sky_extraction():
+    #
+    # Try combinations of sky extraction parameters
+    #
+    boxcar = BoxcarExtract()
 
-        boxcar.apwidth = 6
-        trace = Trace(14.5)
-        spectrum, bkg_spectrum = boxcar(self.image, trace)
-        assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 87.))
+    boxcar.apwidth = 5.
+    boxcar.skysep: int = 2
+    boxcar.skywidth = 5.
 
-        # TODO
-        # Sky extraction should result in a total flux of 45+123=168
-        # Here, both positioning and sizing seem to be wrong.
-        print(bkg_spectrum.flux.value[0])
-        # assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 168))
+    trace = Trace(15.0)
+    spectrum, bkg_spectrum = boxcar(image, trace)
+    assert np.allclose(bkg_spectrum.flux.value, np.full_like(bkg_spectrum.flux.value, 75.))
+
+    trace = Trace(14.5)
+    spectrum, bkg_spectrum = boxcar(image, trace)
+    assert np.allclose(bkg_spectrum.flux.value, np.full_like(bkg_spectrum.flux.value, 70.))
+
+    boxcar.skydeg = 1
+
+    trace = Trace(15.0)
+    spectrum, bkg_spectrum = boxcar(image, trace)
+    assert np.allclose(bkg_spectrum.flux.value, np.full_like(bkg_spectrum.flux.value, 75.))
+
+    trace = Trace(14.5)
+    spectrum, bkg_spectrum = boxcar(image, trace)
+    assert np.allclose(bkg_spectrum.flux.value, np.full_like(bkg_spectrum.flux.value, 70.))
+
+    boxcar.skydeg = 2
+
+    trace = Trace(15.0)
+    spectrum, bkg_spectrum = boxcar(image, trace)
+    assert np.allclose(bkg_spectrum.flux.value, np.full_like(bkg_spectrum.flux.value, 75.))
+
+    trace = Trace(14.5)
+    spectrum, bkg_spectrum = boxcar(image, trace)
+    assert np.allclose(bkg_spectrum.flux.value, np.full_like(bkg_spectrum.flux.value, 70.))
+
+    boxcar.apwidth = 7.
+    boxcar.skysep: int = 3
+    boxcar.skywidth = 8.
+
+    trace = Trace(15.0)
+    spectrum, bkg_spectrum = boxcar(image, trace)
+    assert np.allclose(bkg_spectrum.flux.value, np.full_like(bkg_spectrum.flux.value, 105.))
+
+    trace = Trace(14.5)
+    spectrum, bkg_spectrum = boxcar(image, trace)
+    assert np.allclose(bkg_spectrum.flux.value, np.full_like(bkg_spectrum.flux.value, 98.))
+

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -96,3 +96,17 @@ def test_sky_extraction():
     spectrum, bkg_spectrum = boxcar(image, trace)
     assert np.allclose(bkg_spectrum.flux.value, np.full_like(bkg_spectrum.flux.value, 98.))
 
+
+def test_outside_image_condition():
+    #
+    # Trace is such that one of the sky regions lays partially outside the image
+    #
+    boxcar = BoxcarExtract()
+
+    boxcar.apwidth = 5.
+    boxcar.skysep: int = 2
+    boxcar.skywidth = 5.
+
+    trace = Trace(22.0)
+    spectrum, bkg_spectrum = boxcar(image, trace)
+    assert np.allclose(bkg_spectrum.flux.value, np.full_like(bkg_spectrum.flux.value, 99.375))

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -1,11 +1,10 @@
 import unittest
 import numpy as np
 
-from extract import BoxcarExtract
+from ..extract import BoxcarExtract
 
 
-# Mock a Trace that consists of a straight line
-# placed exactly at row 15.
+# Mock a Trace that consists of a straight line placed exactly at row 15.
 class Trace:
     def __init__(self):
         self.line = np.ones(shape=(10,)) * 15
@@ -13,8 +12,9 @@ class Trace:
 
 class TestBoxcarExtract(unittest.TestCase):
 
-    # test image is comprised of 30 rows with 10
-    # columns each. Row content is row index itself.
+    # Test image is comprised of 30 rows with 10 columns each. Row content
+    # is row index itself. This makes it easy to predict what should be the
+    # value extracted from a region centered at any arbitrary row.
     def setUp(self):
         self.image = np.ones(shape=(30,10))
         for j in range(self.image.shape[0]):
@@ -38,12 +38,13 @@ class TestBoxcarExtract(unittest.TestCase):
 
         spectrum, bkg_spectrum = boxcar(self.image, self.trace)
 
-        # the source extraction should result in a total flux of 75:
+        # Source extraction should result in a total flux of 75:
         # 13+14+15+16+17. Integer truncation/rounding issues create a
         # non-symmetrical extraction region around the trace.
         print(spectrum.flux.value[0])
         # assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 75))
 
-        # the source extraction should result in a total flux of 45+123=168
+        # Sky extraction should result in a total flux of 45+123=168
+        # Here, both positioning and sizing seem to be wrong.
         print(bkg_spectrum.flux.value[0])
         # assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 168))

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -34,16 +34,25 @@ def test_extraction():
     spectrum, bkg_spectrum = boxcar(image, trace)
     assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 72.5))
 
+    trace = Trace(14.7)
+    spectrum, bkg_spectrum = boxcar(image, trace)
+    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 73.5))
+
     boxcar.apwidth = 6
 
     trace = Trace(15.0)
     spectrum, bkg_spectrum = boxcar(image, trace)
     assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 90.))
 
-    boxcar.apwidth = 6
     trace = Trace(14.5)
     spectrum, bkg_spectrum = boxcar(image, trace)
     assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 87.))
+
+    boxcar.apwidth = 4.5
+
+    trace = Trace(15.0)
+    spectrum, bkg_spectrum = boxcar(image, trace)
+    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 67.5))
 
 
 def test_sky_extraction():

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -1,0 +1,49 @@
+import unittest
+import numpy as np
+
+from extract import BoxcarExtract
+
+
+# Mock a Trace that consists of a straight line
+# placed exactly at row 15.
+class Trace:
+    def __init__(self):
+        self.line = np.ones(shape=(10,)) * 15
+
+
+class TestBoxcarExtract(unittest.TestCase):
+
+    # test image is comprised of 30 rows with 10
+    # columns each. Row content is row index itself.
+    def setUp(self):
+        self.image = np.ones(shape=(30,10))
+        for j in range(self.image.shape[0]):
+            self.image[j,::] *= j
+
+        assert self.image[0,0] == 0
+        assert self.image[0,9] == 0
+        assert self.image[10,0] == 10
+        assert self.image[10,9] == 10
+        assert self.image[29,0] == 29
+        assert self.image[29,9] == 29
+
+        self.trace = Trace()
+
+    def test_boxcar_apertures(self):
+        boxcar = BoxcarExtract()
+
+        boxcar.apwidth = 5
+        boxcar.skysep = 1
+        boxcar.skywidth = 5
+
+        spectrum, bkg_spectrum = boxcar(self.image, self.trace)
+
+        # the source extraction should result in a total flux of 75:
+        # 13+14+15+16+17. Integer truncation/rounding issues create a
+        # non-symmetrical extraction region around the trace.
+        print(spectrum.flux.value[0])
+        # assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 75))
+
+        # the source extraction should result in a total flux of 45+123=168
+        print(bkg_spectrum.flux.value[0])
+        # assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 168))


### PR DESCRIPTION
This PR implements bug fixes to specreduce's BoxcarExtract code:

- code that avoids taking a slice outside the image array;
- correct positioning of the sky extraction apertures;
- code that handles fractional pixels
- adds a default units (DN) to the extracted flux array, when units are not present (otherwise it's not accepted as part of a Spectrum1D instance).

With those fixes in place, the class can be used in data like the one in here: https://github.com/ibusko/dat_pyinthesky/blob/spectral_extraction_tests/jdat_notebooks/spectral_extraction_tests/specreduce_extract_jwst.ipynb, where the spectrum positioning and the presence of negative background regions make the bugs very visible. 

A unit test was added as well.
