### PR TITLE
Remove Cython Pin: Building on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@ requires = ["setuptools",
             "wheel",
             "extension-helpers",
             "oldest-supported-numpy",
-            "cython==0.29.14"]
+            "cython"]
 
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
For context: Developing Specreduce in a Windows 11 (22000.376) environment with Python 3.9.7 (tags/v3.9.7:1016ef3, Aug 30 2021, 20:19:38) [MSC v.1929 64 bit (AMD64)] on win32

I ran into the same issue described over in https://github.com/cython/cython/issues/3941 with cython 0.29.14 building on Windows. Looks like the most recent version (0.29.16) builds properly on my Windows environment. I couldn't find record of the reasoning behind the pinning, but I was hoping we could get that removed?

Thanks!