### PR TITLE
Added kosmos trace algorithm

### DIFF
--- a/licenses/KOSMOS_LICENSE
+++ b/licenses/KOSMOS_LICENSE
@@ -1,0 +1,23 @@
+# NOTE: This license applies only to code used in the KosmosTrace class.
+
+MIT License
+
+Copyright (c) 2019 James Davenport
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/specreduce/tests/test_tracing.py
+++ b/specreduce/tests/test_tracing.py
@@ -1,7 +1,8 @@
 import numpy as np
 
+from astropy.modeling import models
 from specreduce.utils.synth_data import make_2dspec_image
-from specreduce.tracing import Trace, FlatTrace, ArrayTrace
+from specreduce.tracing import Trace, FlatTrace, ArrayTrace, KosmosTrace
 
 IM = make_2dspec_image()
 
@@ -62,3 +63,61 @@ def test_array_trace():
     assert(t_short[0] == 550.)
     assert(np.ma.is_masked(t_short[-1]))
     assert(t_short.shape[0] == IM.shape[1])
+
+
+# test KOSMOS trace algorithm
+def test_kosmos_trace():
+    # create image (process adapted from compare_extractions.ipynb)
+    np.random.seed(7)
+    nrows = 200
+    ncols = 160
+    sigma_pix = 4
+    sigma_noise = 1
+
+    col_model = models.Gaussian1D(amplitude=1, mean=nrows/2, stddev=sigma_pix)
+    noise = np.random.normal(scale=sigma_noise, size=(nrows, ncols))
+
+    index_arr = np.tile(np.arange(nrows), (ncols, 1))
+    img = col_model(index_arr.T) + noise
+
+    # calculate trace on normal image
+    t = KosmosTrace(img)
+
+    # test shifting
+    shift_up = int(-img.shape[0]/4)
+    t_shift_up = t.trace + shift_up
+
+    shift_out = img.shape[0]
+    t_shift_out = t_shift_up + shift_out
+
+    t.shift(shift_up)
+    assert np.sum(t.trace == t_shift_up) == t.trace.size, 'valid shift failed'
+
+    t.shift(shift_out)
+    assert t.trace.mask.all(), 'invalid values not masked'
+
+    # create same-shaped variations of image with invalid values
+    img_all_nans = np.tile(np.nan, (nrows, ncols))
+
+    window = 10
+    guess = int(nrows/2)
+    img_win_nans = img.copy()
+    img_win_nans[guess - window : guess + window] = np.nan
+
+    # error on trace of otherwise valid image with all-nan window around guess
+    try:
+        t_win_nans = KosmosTrace(img_win_nans, guess=guess, window=window)
+    except ValueError as e:
+        print(f"All-NaN window error message: {e}")
+    else:
+        raise RuntimeError('Trace was erroneously calculated on all-NaN window')
+
+    # error on trace of all-nan image
+    try:
+        t_all_nans = KosmosTrace(img_all_nans)
+    except ValueError as e:
+        print(f"All-NaN image error message: {e}")
+    else:
+        raise RuntimeError('Trace was erroneously calculated on all-NaN image')
+
+    # could try to catch warning thrown for all-nan bins

--- a/specreduce/tests/test_tracing.py
+++ b/specreduce/tests/test_tracing.py
@@ -88,7 +88,6 @@ def test_kosmos_trace():
     t_shift_up = t.trace + shift_up
 
     shift_out = img.shape[0]
-    t_shift_out = t_shift_up + shift_out
 
     t.shift(shift_up)
     assert np.sum(t.trace == t_shift_up) == t.trace.size, 'valid shift failed'
@@ -102,11 +101,11 @@ def test_kosmos_trace():
     window = 10
     guess = int(nrows/2)
     img_win_nans = img.copy()
-    img_win_nans[guess - window : guess + window] = np.nan
+    img_win_nans[guess - window:guess + window] = np.nan
 
     # error on trace of otherwise valid image with all-nan window around guess
     try:
-        t_win_nans = KosmosTrace(img_win_nans, guess=guess, window=window)
+        KosmosTrace(img_win_nans, guess=guess, window=window)
     except ValueError as e:
         print(f"All-NaN window error message: {e}")
     else:
@@ -114,7 +113,7 @@ def test_kosmos_trace():
 
     # error on trace of all-nan image
     try:
-        t_all_nans = KosmosTrace(img_all_nans)
+        KosmosTrace(img_all_nans)
     except ValueError as e:
         print(f"All-NaN image error message: {e}")
     else:

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -193,8 +193,9 @@ class KosmosTrace(Trace):
         if (self.window is not None
             and (self.window > img.shape[self._disp_axis]
                  or self.window < 1)):
-            raise ValueError(f"window must be >= 2 and less than {self.image.shape[self.disp_axis]} "
-                             "the length of the image's spatial direction")
+            raise ValueError(f"window must be >= 2 and less than "
+                             "{self.image.shape[self.disp_axis]} the length of the "
+                             "image's spatial direction")
         elif self.window is not None and not isinstance(self.window, int):
             warnings.warn('TRACE: Converting window to int')
             self.window = int(self.window)

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -1,11 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from dataclasses import dataclass
+import warnings
 
-import numpy as np
+from astropy.modeling import CompoundModel, fitting, models
 from astropy.nddata import CCDData
+from scipy.interpolate import UnivariateSpline
+import numpy as np
 
-__all__ = ['Trace', 'FlatTrace', 'ArrayTrace']
+__all__ = ['Trace', 'FlatTrace', 'ArrayTrace', 'KosmosTrace']
 
 
 @dataclass
@@ -110,3 +113,163 @@ class ArrayTrace(Trace):
                 padding = np.ma.MaskedArray(np.ones(nx - nt) * self.trace[-1], mask=True)
                 self.trace = np.ma.hstack([self.trace, padding])
         self._bound_trace()
+
+
+@dataclass
+class KosmosTrace(Trace):
+    """
+    Trace the spectrum aperture in an image.
+
+    Chops image up in bins along the dispersion (wavelength) direction,
+    fits a Gaussian within each bin to determine the trace's spatial
+    center. Finally, draws a cubic spline through the bins to up-sample
+    trace along every pixel in the dispersion direction.
+
+    (The original version of this algorithm is sourced from James
+     Davenport's `kosmos` repository.)
+
+    Parameters
+    ----------
+    image : CCDData or array-like, required
+        The image over which to run the trace. Assumes cross-dispersion
+        (spatial) direction is axis 0 and dispersion (wavelength)
+        direction is axis 1.
+    bins : int, optional
+        The number of bins in the dispersion (wavelength) into which to
+        divide the image. Use fewer if KosmosTrace is having
+        difficulty, such as with faint targets. Minimum bin size is 4.
+        [default: 20]
+    guess : int, optional
+        A guess at the trace's location in the cross-dispersion
+        (spatial) direction. If set, overrides the normal max peak
+        finder. Good for tracing a fainter source if multiple traces
+        are present. [default: None]
+    window : int, optional
+        Fit the trace to a region with size `window * 2` aroudn the
+        guess position. Useful for tracing faint sources if multiple
+        traces are present, but potentially bad if the trace is
+        substantially bent or warped. [default: None]
+
+    Improvements Needed
+    -------------------
+    1) switch to astropy models for Gaussian (done)
+    2) return info about trace width (?)
+    3) add re-fit trace functionality (or break off into other method)
+    4) add other interpolation modes besides spline, maybe via
+        specutils.manipulation methods?
+    """
+    image : CCDData
+    bins : int = 20
+    guess : float = None
+    window : int = None
+    disp_axis = 1
+    def __post_init__(self,
+                      # Saxis=0, Waxis=1, display=False
+                      ):
+        if self.bins < 4:
+            raise ValueError('bins must be >= 4')
+        if not isinstance(self.bins, int):
+            warnings.warn('TRACE: Converting bins to int')
+            self.bins = int(self.bins)
+
+        if (self.window is not None
+            and (self.window > self.image.shape[self.disp_axis]
+                 or self.window < 1)):
+            raise ValueError("window must be >= 2 and less than the length of "
+                             "the image's spatial direction")
+        elif self.window is not None and not isinstance(self.window, int):
+            warnings.warn('TRACE: Converting window to int')
+            self.window = int(self.window)
+
+        # set max peak location by user choice or wavelength with max avg flux
+        ztot = np.nansum(self.image, axis=1) / self.image.shape[1]
+        peak_y = self.guess if self.guess is not None else np.nanargmax(ztot)
+        # (peak finder can be bad if multiple objects are on slit...)
+
+        # guess the peak width as the FWHM, roughly converted to gaussian sigma
+        yy = np.arange(len(ztot))
+        yy_above_half_max = np.sum(ztot > (np.nanmax(ztot) / 2))
+        width_guess = yy_above_half_max / 2.355
+
+        # enforce some (maybe sensible?) rules about trace peak width
+        width_guess = (2 if width_guess < 2
+                       else 25 if width_guess > 25
+                       else width_guess)
+
+        # fit a Gaussian to peak for fall-back answer, but don't use yet
+        g1d_init = models.Gaussian1D(amplitude=np.nanmax(ztot),
+                                     mean=peak_y, stddev=width_guess)
+        offset_init = models.Const1D(np.nanmedian(ztot))
+        profile = g1d_init + offset_init
+
+        fitter = fitting.LevMarLSQFitter()
+        popt_tot = fitter(profile, yy, ztot)
+
+        # restrict fit to window (if one exists)
+        ilum2 = (yy if self.window is None
+                 else yy[np.arange(peak_y - self.window,
+                                   peak_y + self.window, dtype=int)])
+
+        x_bins = np.linspace(0, self.image.shape[self.disp_axis],
+                             self.bins + 1, dtype=int)
+        y_bins = np.tile(np.nan, self.bins)
+
+        for i in range(self.bins):
+            # repeat earlier steps to create gaussian fit for each bin
+            z_i = np.nansum(self.image[ilum2, x_bins[i]:x_bins[i+1]],
+                            axis=self.disp_axis)
+            peak_y_i = ilum2[np.nanargmax(z_i)]
+
+            yy_i_above_half_max = np.sum(z_i > (np.nanmax(z_i) / 2))
+            width_guess_i = yy_i_above_half_max / 2.355
+            width_guess_i = (2 if width_guess_i < 2
+                             else 25 if width_guess_i > 25
+                             else width_guess_i)
+
+            # save initial parameter guesses in case off issues with fits
+            pguess = CompoundModel(
+                '+',
+                models.Gaussian1D(amplitude=np.nanmax(z_i),
+                                  mean=peak_y_i, stddev=width_guess_i),
+                models.Const1D(np.nanmedian(z_i)))
+
+            try:
+                g1d_init_i = models.Gaussian1D(amplitude=np.nanmax(z_i),
+                                               mean=peak_y_i,
+                                               stddev=width_guess_i)
+                offset_init_i = models.Const1D(np.nanmedian(z_i))
+
+                profile_i = g1d_init_i + offset_init_i
+                popt_i = fitter(profile_i, ilum2, z_i)
+
+                # if gaussian fits off chip, then fall back to previous answer
+                if not ilum2.min() <= popt_i.mean_0 <= ilum2.max():
+                    y_bins[i] = popt_tot.mean_0.value
+                else:
+                    y_bins[i] = popt_i.mean_0.value
+                    popt_tot = popt_i
+
+            except RuntimeError:
+                # NOTE: would this happen? if not, pguess and try/except are unneeded
+                warnings.warn(f"TRACE: Fitting bin {i} caused RuntimeError; "
+                              "reverting to initial guess")
+                popt_i = pguess_i
+
+        # recenter bin positions
+        x_bins = (x_bins[:-1] + x_bins[1:]) / 2
+
+        # interpolate the fitted trace over the entire wavelength axis
+        y_finite = np.where(np.isfinite(y_bins))[0]
+        if y_finite.size > 0:
+            x_bins = x_bins[y_finite]
+            y_bins = y_bins[y_finite]
+
+            # run a cubic spline through the bins; interpolate over wavelengths
+            ap_spl = UnivariateSpline(x_bins, y_bins, k=3, s=0)
+            trace_x = np.arange(self.image.shape[self.disp_axis])
+            trace_y = ap_spl(trace_x)
+        else:
+            warnings.warn("TRACE ERROR: No valid points found in trace")
+            trace_y = np.tile(np.nan, len(x_bins))
+
+        self.trace = np.ma.masked_invalid(trace_y)

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -5,6 +5,7 @@ import warnings
 
 from astropy.modeling import CompoundModel, fitting, models
 from astropy.nddata import CCDData
+from astropy.stats import gaussian_sigma_to_fwhm
 from scipy.interpolate import UnivariateSpline
 import numpy as np
 
@@ -163,7 +164,7 @@ class KosmosTrace(Trace):
     guess: float = None
     window: int = None
     disp_axis = 1
-    
+
     def __post_init__(self,
                       # Saxis=0, Waxis=1, display=False
                       ):
@@ -190,7 +191,7 @@ class KosmosTrace(Trace):
         # guess the peak width as the FWHM, roughly converted to gaussian sigma
         yy = np.arange(len(ztot))
         yy_above_half_max = np.sum(ztot > (np.nanmax(ztot) / 2))
-        width_guess = yy_above_half_max / 2.355
+        width_guess = yy_above_half_max / gaussian_sigma_to_fwhm
 
         # enforce some (maybe sensible?) rules about trace peak width
         width_guess = (2 if width_guess < 2
@@ -222,7 +223,7 @@ class KosmosTrace(Trace):
             peak_y_i = ilum2[np.nanargmax(z_i)]
 
             yy_i_above_half_max = np.sum(z_i > (np.nanmax(z_i) / 2))
-            width_guess_i = yy_i_above_half_max / 2.355
+            width_guess_i = yy_i_above_half_max / gaussian_sigma_to_fwhm
             width_guess_i = (2 if width_guess_i < 2
                              else 25 if width_guess_i > 25
                              else width_guess_i)

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -158,11 +158,12 @@ class KosmosTrace(Trace):
     4) add other interpolation modes besides spline, maybe via
         specutils.manipulation methods?
     """
-    image : CCDData
-    bins : int = 20
-    guess : float = None
-    window : int = None
+    image: CCDData
+    bins: int = 20
+    guess: float = None
+    window: int = None
     disp_axis = 1
+    
     def __post_init__(self,
                       # Saxis=0, Waxis=1, display=False
                       ):
@@ -253,7 +254,7 @@ class KosmosTrace(Trace):
                 # NOTE: would this happen? if not, pguess and try/except are unneeded
                 warnings.warn(f"TRACE: Fitting bin {i} caused RuntimeError; "
                               "reverting to initial guess")
-                popt_i = pguess_i
+                popt_i = pguess
 
         # recenter bin positions
         x_bins = (x_bins[:-1] + x_bins[1:]) / 2

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -190,12 +190,16 @@ class KosmosTrace(Trace):
         if self.bins < 4:
             raise ValueError('bins must be >= 4')
 
+        cols = img.shape[self.disp_axis]
+        if self.bins >= cols:
+            raise ValueError(f"bins must be < {cols}, the length of the "
+                             "image's spatial direction")
+
         if (self.window is not None
             and (self.window > img.shape[self._disp_axis]
                  or self.window < 1)):
-            raise ValueError("window must be >= 2 and less than "
-                             f"{self.image.shape[self.disp_axis]} the length of the "
-                             "image's spatial direction")
+            raise ValueError(f"window must be >= 2 and less than {xx}, the "
+                             "length of the image's spatial direction")
         elif self.window is not None and not isinstance(self.window, int):
             warnings.warn('TRACE: Converting window to int')
             self.window = int(self.window)

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -162,7 +162,7 @@ class KosmosTrace(Trace):
     bins: int = 20
     guess: float = None
     window: int = None
-    _cross_disp_axis = 0
+    _crossdisp_axis = 0
     _disp_axis = 1
 
     def __post_init__(self):
@@ -177,7 +177,7 @@ class KosmosTrace(Trace):
         if img.mask.all():
             raise ValueError('image is fully masked. Check for invalid values')
 
-        if self._cross_disp_axis != 0:
+        if self._crossdisp_axis != 0:
             raise ValueError('cross-dispersion axis must equal 0')
 
         if self._disp_axis != 1:
@@ -205,7 +205,7 @@ class KosmosTrace(Trace):
         # NOTE: peak finder can be bad if multiple objects are on slit
 
         # guess the peak width as the FWHM, roughly converted to gaussian sigma
-        yy = np.arange(img.shape[self._cross_disp_axis])
+        yy = np.arange(img.shape[self._crossdisp_axis])
         yy_above_half_max = np.sum(ztot > (ztot.max() / 2))
         width_guess = yy_above_half_max / gaussian_sigma_to_fwhm
 

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -165,9 +165,7 @@ class KosmosTrace(Trace):
     window: int = None
     disp_axis = 1
 
-    def __post_init__(self,
-                      # Saxis=0, Waxis=1, display=False
-                      ):
+    def __post_init__(self):
         if not isinstance(self.bins, int):
             warnings.warn('TRACE: Converting bins to int')
             self.bins = int(self.bins)

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -190,7 +190,7 @@ class KosmosTrace(Trace):
         if self.bins < 4:
             raise ValueError('bins must be >= 4')
 
-        cols = img.shape[self.disp_axis]
+        cols = img.shape[self._disp_axis]
         if self.bins >= cols:
             raise ValueError(f"bins must be < {cols}, the length of the "
                              "image's spatial direction")

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -163,9 +163,12 @@ class KosmosTrace(Trace):
     bins: int = 20
     guess: float = None
     window: int = None
-    disp_axis = 1
+    _disp_axis = 1
 
     def __post_init__(self):
+        if self._disp_axis != 1:
+            raise ValueError('dispersion axis must equal 1')
+
         if not isinstance(self.bins, int):
             warnings.warn('TRACE: Converting bins to int')
             self.bins = int(self.bins)
@@ -173,7 +176,7 @@ class KosmosTrace(Trace):
             raise ValueError('bins must be >= 4')
 
         if (self.window is not None
-            and (self.window > self.image.shape[self.disp_axis]
+            and (self.window > self.image.shape[self._disp_axis]
                  or self.window < 1)):
             raise ValueError("window must be >= 2 and less than the length of "
                              "the image's spatial direction")
@@ -210,14 +213,14 @@ class KosmosTrace(Trace):
                  else yy[np.arange(peak_y - self.window,
                                    peak_y + self.window, dtype=int)])
 
-        x_bins = np.linspace(0, self.image.shape[self.disp_axis],
+        x_bins = np.linspace(0, self.image.shape[self._disp_axis],
                              self.bins + 1, dtype=int)
         y_bins = np.tile(np.nan, self.bins)
 
         for i in range(self.bins):
             # repeat earlier steps to create gaussian fit for each bin
             z_i = np.nansum(self.image[ilum2, x_bins[i]:x_bins[i+1]],
-                            axis=self.disp_axis)
+                            axis=self._disp_axis)
             peak_y_i = ilum2[np.nanargmax(z_i)]
 
             yy_i_above_half_max = np.sum(z_i > (np.nanmax(z_i) / 2))
@@ -266,7 +269,7 @@ class KosmosTrace(Trace):
 
             # run a cubic spline through the bins; interpolate over wavelengths
             ap_spl = UnivariateSpline(x_bins, y_bins, k=3, s=0)
-            trace_x = np.arange(self.image.shape[self.disp_axis])
+            trace_x = np.arange(self.image.shape[self._disp_axis])
             trace_y = ap_spl(trace_x)
         else:
             warnings.warn("TRACE ERROR: No valid points found in trace")

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -193,8 +193,8 @@ class KosmosTrace(Trace):
         if (self.window is not None
             and (self.window > img.shape[self._disp_axis]
                  or self.window < 1)):
-            raise ValueError(f"window must be >= 2 and less than "
-                             "{self.image.shape[self.disp_axis]} the length of the "
+            raise ValueError("window must be >= 2 and less than "
+                             f"{self.image.shape[self.disp_axis]} the length of the "
                              "image's spatial direction")
         elif self.window is not None and not isinstance(self.window, int):
             warnings.warn('TRACE: Converting window to int')

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 import warnings
 
-from astropy.modeling import CompoundModel, fitting, models
+from astropy.modeling import fitting, models
 from astropy.nddata import CCDData, NDData
 from astropy.stats import gaussian_sigma_to_fwhm
 from scipy.interpolate import UnivariateSpline

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -136,10 +136,10 @@ class KosmosTrace(Trace):
         (spatial) direction is axis 0 and dispersion (wavelength)
         direction is axis 1.
     bins : int, optional
-        The number of bins in the dispersion (wavelength) into which to
-        divide the image. Use fewer if KosmosTrace is having
-        difficulty, such as with faint targets. Minimum bin size is 4.
-        [default: 20]
+        The number of bins in the dispersion (wavelength) direction
+        into which to divide the image. Use fewer if KosmosTrace is
+        having difficulty, such as with faint targets.
+        Minimum bin size is 4. [default: 20]
     guess : int, optional
         A guess at the trace's location in the cross-dispersion
         (spatial) direction. If set, overrides the normal max peak

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -145,7 +145,7 @@ class KosmosTrace(Trace):
         finder. Good for tracing a fainter source if multiple traces
         are present. [default: None]
     window : int, optional
-        Fit the trace to a region with size `window * 2` aroudn the
+        Fit the trace to a region with size `window * 2` around the
         guess position. Useful for tracing faint sources if multiple
         traces are present, but potentially bad if the trace is
         substantially bent or warped. [default: None]
@@ -167,11 +167,11 @@ class KosmosTrace(Trace):
     def __post_init__(self,
                       # Saxis=0, Waxis=1, display=False
                       ):
-        if self.bins < 4:
-            raise ValueError('bins must be >= 4')
         if not isinstance(self.bins, int):
             warnings.warn('TRACE: Converting bins to int')
             self.bins = int(self.bins)
+        if self.bins < 4:
+            raise ValueError('bins must be >= 4')
 
         if (self.window is not None
             and (self.window > self.image.shape[self.disp_axis]

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -193,8 +193,8 @@ class KosmosTrace(Trace):
         if (self.window is not None
             and (self.window > img.shape[self._disp_axis]
                  or self.window < 1)):
-            raise ValueError("window must be >= 2 and less than the length of "
-                             "the image's spatial direction")
+            raise ValueError(f"window must be >= 2 and less than {self.image.shape[self.disp_axis]} "
+                             "the length of the image's spatial direction")
         elif self.window is not None and not isinstance(self.window, int):
             warnings.warn('TRACE: Converting window to int')
             self.window = int(self.window)

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -198,7 +198,7 @@ class KosmosTrace(Trace):
         if (self.window is not None
             and (self.window > img.shape[self._disp_axis]
                  or self.window < 1)):
-            raise ValueError(f"window must be >= 2 and less than {xx}, the "
+            raise ValueError(f"window must be >= 2 and less than {cols}, the "
                              "length of the image's spatial direction")
         elif self.window is not None and not isinstance(self.window, int):
             warnings.warn('TRACE: Converting window to int')


### PR DESCRIPTION
I ported a trace algorithm from the `KOSMOS` repository's [apextract.py](https://github.com/jradavenport/kosmos/blob/fca3b87f59825d8078f13bbbcc03b6c782ad3c21/kosmos/apextract.py). I refactored much of it and took on one of wishlist requests of using `astropy.modeling`'s `Gaussian1D` instead of a custom function to create Gaussians. The fits end up being slightly different, but I have a local notebook where I've verified that the calculated inputs to the respective fitters are the same in this version and the original.

I wrote it as a descendant of `Trace` instead of as a class method of `ArrayTrace` as suggested in the [tracing discussion](https://github.com/astropy/specreduce/issues/83#issuecomment-1049078655). `ArrayTrace` requires an initial array, while the `KOSMOS` implementation can run with no guess or just a float. I didn't think requiring an array when it wasn't needed made sense, though we can change the format if I've missed something.

The original has arguments for specifying wavelength and spatial directions that I commented out since it seems that's still up for discussion. I also left out functionality for displaying the trace after the calculation.