### PR TITLE
Add GitHub Actions workflow to automatically publish to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,47 @@
+name: Publish to PyPI and TestPyPI
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-n-publish:
+    name: Build and publish to PyPI and TestPyPI
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 🐍 3.9
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.9
+
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This PR adds a workflow that publishes test packages to the TestPyPI index upon every push to `main` and release packages to the main PyPI index when a release tag is pushed. It uses the PyPA-maintained action for managing the upload process. For now, the authentication tokens are attached to my PyPI accounts. If they need to be changed, we would simply need to delete the current ones and create new ones with the same names, `PYPI_API_TOKEN` and `TEST_PYPI_API_TOKEN`, containing the new tokens. 