### PR TITLE
Release prep

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -33,6 +33,7 @@ jobs:
         .
 
     - name: Publish distribution 📦 to Test PyPI
+      if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -33,7 +33,7 @@ jobs:
         .
 
     - name: Publish distribution 📦 to Test PyPI
-      if: startsWith(github.ref, 'refs/tags')
+      if: ${{ startsWith(github.ref, 'refs/tags') && contains(github.ref_name, 'test') }}
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
@@ -41,7 +41,7 @@ jobs:
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags')
+      if: ${{ startsWith(github.ref, 'refs/tags') && !contains(github.ref_name, 'test') }}
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ New Features
 - Added basic ``Background`` subtraction
 
 Bug Fixes
+^^^^^^^^^
 
 - Update ``codecov-action`` to ``v2``
 - Change default branch from ``master`` to ``main``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,17 @@
+1.0.0 (unreleased)
+------------------
+
+New Features
+^^^^^^^^^^^^
+
+- Added ``Trace`` classes
+- Added basic synthetic data routines
+- Added ``BoxcarExtraction``
+- Added ``HorneExtraction``, a.k.a. ``OptimalExtraction``
+- Added basic ``Background`` subtraction
+
+Bug Fixes
+
+- Update ``codecov-action`` to ``v2``
+- Change default branch from ``master`` to ``main``
+- Test fixes; bump CI to python 3.8 and 3.9 and deprecate support for 3.7

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Specreduce
 
 .. image:: https://github.com/astropy/specreduce/workflows/Python%20Tests/badge.svg
     :target: https://github.com/astropy/specreduce/actions
-    :alt: Python Integration Test Status
+    :alt: CI Status
 
 .. image:: https://readthedocs.org/projects/specreduce/badge/?version=latest
     :target: http://specreduce.readthedocs.io/en/latest/?badge=latest
@@ -18,4 +18,4 @@ set of Python utilities that can be used to reduce and calibrate spectroscopic d
 License
 -------
 
-Specreduce is licensed under a 3-clause BSD style license. Please see the LICENSE.rst file.
+Specreduce is licensed under a 3-clause BSD style license. Please see the licences/LICENSE.rst file.


### PR DESCRIPTION
This PR fixes an issue in pushing packages to PyPI with the default versions that `setuptools_scm` creates. Tags will need to be created for packages to be published. If the tag contains `test`, it will publish to the Test PyPI index. Otherwise it will publish to the main one. We want to reserve the latter for official releases.

A `CHANGES.txt` file is also added here and contains a basic list of what has been added recently. Feel free to edit and add more details.