### PR TITLE
Add citation and Zenodo badge

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,6 +20,11 @@ authors:
     family-names: Conroy
     affiliation: STScI
     orcid: 'https://orcid.org/0000-0002-5442-8550'
+  - given-names: Erik
+    family-names: Tollerud
+    email: erik.tollerud@gmail.com
+    affiliation: Space Telescope Science Institute
+    orcid: 'https://orcid.org/0000-0002-9599-310X'
 identifiers:
   - type: doi
     value: 10.5281/zenodo.6608788

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,6 +16,10 @@ authors:
     email: te.pickering@gmail.com
     affiliation: MMT Observatory
     orcid: 'https://orcid.org/0000-0002-9427-5448'
+  - given-names: Kyle
+    family-names: Conroy
+    affiliation: STScI
+    orcid: 'https://orcid.org/0000-0002-5442-8550'
 identifiers:
   - type: doi
     value: 10.5281/zenodo.6608788

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: Specreduce
+message: >-
+  If you use Specreduce for work/research presented
+  in a publication (whether directly, or as a
+  dependency to another package), please cite the
+  Zenodo DOI for the appropriate version of
+  Specreduce.
+type: software
+authors:
+  - given-names: Timothy
+    family-names: Pickering
+    email: te.pickering@gmail.com
+    affiliation: MMT Observatory
+    orcid: 'https://orcid.org/0000-0002-9427-5448'
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.6608788
+    description: 'Version 1.0.0: First Official Release'

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,10 @@ Specreduce
     :target: http://specreduce.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.6608788.svg
+   :target: https://doi.org/10.5281/zenodo.6608788
+   :alt: Zenodo DOI 10.5281/zenodo.6608788
+
 .. image:: http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat
     :target: http://www.astropy.org/
 


### PR DESCRIPTION
A Zenodo DOI has been created for the `1.0.0` release and a badge pointing to that added to the `README` file. A `CITATION.cff` file has been added here that points to that DOI. I have thus far only added myself as an author in that file. I encourage other contributors to add their information to it either by editing the file directly in this PR or adding it later in a separate PR. 

Closes #108.