### PR TITLE
HorneExtract: require variance array to be fully positive

### DIFF
--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -266,6 +266,14 @@ class HorneExtract(SpecreduceOperation):
             # create image
             img = np.ma.array(image, mask=mask)
 
+        if np.all(variance == 0):
+            # technically would result in infinities, but since they're all zeros
+            # we can just do the unweighted case by overriding with all ones
+            variance = np.ones_like(variance)
+
+        if np.any(variance <= 0):
+            raise ValueError("variance must be fully positive")
+
         # co-add signal in each image column
         ncols = img.shape[crossdisp_axis]
         xd_pixels = np.arange(ncols)  # y plot dir / x spec dir

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -87,12 +87,19 @@ def test_horne_variance_errors():
     # all zeros are treated as non-weighted (give non-zero fluxes)
     err = np.zeros_like(image)
     mask = np.zeros_like(image)
-    ext = extract(image.data, trace, variance=err, mask=np.zeros_like(err), unit=u.Jy)
+    ext = extract(image.data, trace, variance=err, mask=mask, unit=u.Jy)
     assert not np.all(ext == 0)
 
-    # single non-positive value raises error
+    # single zero value adjusts mask (does not raise error)
     err = np.ones_like(image)
     err[0] = 0
+    mask = np.zeros_like(image)
+    ext = extract(image.data, trace, variance=err, mask=mask, unit=u.Jy)
+    assert not np.all(ext == 0)
+
+    # single negative value raises error
+    err = np.ones_like(image)
+    err[0] = -1
     mask = np.zeros_like(image)
     with pytest.raises(ValueError, match='variance must be fully positive'):
         ext = extract(image.data, trace, variance=err, mask=mask, unit=u.Jy)

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -1,9 +1,10 @@
 import numpy as np
+import pytest
 
 import astropy.units as u
 from astropy.nddata import CCDData
 
-from specreduce.extract import BoxcarExtract
+from specreduce.extract import BoxcarExtract, HorneExtract
 from specreduce.tracing import FlatTrace, ArrayTrace
 
 
@@ -16,7 +17,7 @@ for j in range(image.shape[0]):
 image = CCDData(image, unit=u.Jy)
 
 
-def test_extraction():
+def test_boxcar_extraction():
     #
     # Try combinations of extraction center, and even/odd
     # extraction aperture sizes.
@@ -57,7 +58,7 @@ def test_extraction():
     assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 67.0))
 
 
-def test_outside_image_condition():
+def test_boxcar_outside_image_condition():
     #
     # Trace is such that extraction aperture lays partially outside the image
     #
@@ -68,7 +69,7 @@ def test_outside_image_condition():
     assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 32.0))
 
 
-def test_array_trace():
+def test_boxcar_array_trace():
     boxcar = BoxcarExtract()
 
     trace_array = np.ones_like(image[1]) * 15.
@@ -77,3 +78,21 @@ def test_array_trace():
 
     spectrum = boxcar(image, trace)
     assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 75.))
+
+
+def test_horne_variance_errors():
+    extract = HorneExtract()
+    trace = FlatTrace(image, 3.0)
+
+    # all zeros are treated as non-weighted (give non-zero fluxes)
+    err = np.zeros_like(image)
+    mask = np.zeros_like(image)
+    ext = extract(image.data, trace, variance=err, mask=np.zeros_like(err), unit=u.Jy)
+    assert not np.all(ext == 0)
+
+    # single non-positive value raises error
+    err = np.ones_like(image)
+    err[0] = 0
+    mask = np.zeros_like(image)
+    with pytest.raises(ValueError, match='variance must be fully positive'):
+        ext = extract(image.data, trace, variance=err, mask=mask, unit=u.Jy)


### PR DESCRIPTION
This PR requires the input `variance` to HorneExtract to be fully positive, and raises an error if it is not.  As an exception, the case of _all_ zeros, is treated as unweighted by internally defaulting to `variance = np.ones_like(variance)`.  In the future, we may want more advanced logic for handling cases with some values being zero, but for now leave it to the user to adjust the input `variance` and/or `mask`.

Closes #103 