### PR TITLE
extract: more consistent API compared to other steps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ New Features
 
 - ``peak_method`` as an optional argument to ``KosmosTrace`` [#115]
 
+API Changes
+^^^^^^^^^^^
+
+- ``BoxcarExtract`` and ``HorneExtract`` now accept parameters (and require the image and trace)
+  at initialization, and allow overriding any input parameters when calling. [#117]
+
 
 1.0.0
 -----
@@ -15,8 +21,8 @@ New Features
 
 - Added ``Trace`` classes
 - Added basic synthetic data routines
-- Added ``BoxcarExtraction``
-- Added ``HorneExtraction``, a.k.a. ``OptimalExtraction``
+- Added ``BoxcarExtract``
+- Added ``HorneExtract``, a.k.a. ``OptimalExtract``
 - Added basic ``Background`` subtraction
 
 Bug Fixes

--- a/notebook_sandbox/compare_extractions.ipynb
+++ b/notebook_sandbox/compare_extractions.ipynb
@@ -175,9 +175,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bxc = BoxcarExtract()\n",
-    "bxc_result1d_slice = bxc(img, trace, 14)\n",
-    "bxc_result1d_whole = bxc(img, trace, nrows)"
+    "bxc = BoxcarExtract(img, trace)\n",
+    "bxc_result1d_slice = bxc(width=14)\n",
+    "bxc_result1d_whole = bxc(width=nrows)"
    ]
   },
   {
@@ -187,8 +187,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hrn = HorneExtract()\n",
-    "hrn_result1d_whole = hrn(img, trace, variance=variance,\n",
+    "hrn = HorneExtract(img, trace)\n",
+    "hrn_result1d_whole = hrn(variance=variance,\n",
     "                         mask=mask, unit=u.DN) # whole image is aperture"
    ]
   },
@@ -213,8 +213,8 @@
     "var_obj = VarianceUncertainty(variance)\n",
     "img_obj = CCDData(img, uncertainty=var_obj, mask=mask, unit=u.DN)\n",
     "\n",
-    "hrn2 = HorneExtract()\n",
-    "hrn2_result1d_whole = hrn(img_obj, trace)"
+    "hrn2 = HorneExtract(img_obj, trace)\n",
+    "hrn2_result1d_whole = hrn()"
    ]
   },
   {

--- a/notebook_sandbox/jwst_boxcar/boxcar_extraction.ipynb
+++ b/notebook_sandbox/jwst_boxcar/boxcar_extraction.ipynb
@@ -516,8 +516,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "boxcar = BoxcarExtract()\n",
-    "spectrum = boxcar(image-bg, auto_trace, width=ext_width)"
+    "boxcar = BoxcarExtract(image-bg, auto_trace)\n",
+    "spectrum = boxcar(width=ext_width)"
    ]
   },
   {


### PR DESCRIPTION
This PR refactors the extract classes to allow initializing the dataclass and/or calling the call method.

Before:

```
ext = specreduce.extract.BoxcarExtract()
spectrum = ext(img, trace, width)
```

After:

```
ext = specreduce.extract.BoxcarExtract(img, trace)
spectrum = ext(width)
```

or

```
ext = specreduce.extract.BoxcarExtract(img, trace, width=5)
ext.width = 10
spectrum = ext.spectrum # shortcut to ext() in order to be consistent with Background
```

Note that `img` and `trace` are now required arguments when initializing the object, but any parameter can be set or changed when initializing, by setting the attribute, or when calling.

**TODO before merging**:
- [x] update examples to always pass `img`/`trace` or change to not require anything so that the API does not change
- [ ] if we do require `img`/`trace` this breaks public API so might need a version bump