### PR TITLE
Correct default mask for array images in HorneExtract

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,13 @@ API Changes
 ^^^^^^^^^^^
 
 - ``BoxcarExtract`` and ``HorneExtract`` now accept parameters (and require the image and trace)
-  at initialization, and allow overriding any input parameters when calling. [#117]
+  at initialization, and allow overriding any input parameters when calling [#117]
 
+Bug Fixes
+^^^^^^^^^
+
+- Corrected the default mask created in ``HorneExtract``/``OptimalExtract``
+  when a user doesn't specify one and gives their image as a numpy array [#118]
 
 1.0.0
 -----

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -333,7 +333,7 @@ class HorneExtract(SpecreduceOperation):
 
             # check optional arguments, filling them in if absent
             if mask is None:
-                mask = np.ma.masked_invalid(image)
+                mask = np.ma.masked_invalid(image).mask
             elif image.shape != mask.shape:
                 raise ValueError('image and mask shapes must match.')
 

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -84,28 +84,28 @@ def test_horne_array_validation():
     # Test HorneExtract scenarios specific to its use with an image of
     # type `~numpy.ndarray` (instead of the default `~astropy.nddata.NDData`).
     #
-    extract = OptimalExtract()  # alias of Horne; behavior shouldn't change
     trace = FlatTrace(image, 15.0)
+    extract = OptimalExtract(image.data, trace)  # equivalent to HorneExtract
 
     # an array-type image must come with a variance argument
     with pytest.raises(ValueError, match=r'.*array.*variance.*specified.*'):
-        ext = extract(image.data, trace)
+        ext = extract()
 
     # an array-type image must have the same dimensions as its variance argument
     with pytest.raises(ValueError, match=r'.*shapes must match.*'):
         err = np.ones_like(image[0])
-        ext = extract(image.data, trace, variance=err)
+        ext = extract(variance=err)
 
     # an array-type image must have the same dimensions as its mask argument
     with pytest.raises(ValueError, match=r'.*shapes must match.*'):
         err = np.ones_like(image)
         mask = np.zeros_like(image[0])
-        ext = extract(image.data, trace, variance=err, mask=mask)
+        ext = extract(variance=err, mask=mask)
 
     # an array-type image given without mask and unit arguments is fine
     # and produces a unitless result
     err = np.ones_like(image)
-    ext = extract(image.data, trace, variance=err)
+    ext = extract(variance=err)
     assert ext.unit == u.Unit()
 
 


### PR DESCRIPTION
When `HorneExtract`/`OptimalExtract` is given a `numpy` array as an image and no mask, it tries to create its own mask using `np.ma.masked_invalid(image)`. They are currently written as if that object itself is the mask, when it's actually in that object's `mask` attribute. This pull request makes the switch.