### PR TITLE
Correct license path in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,4 +22,4 @@ set of Python utilities that can be used to reduce and calibrate spectroscopic d
 License
 -------
 
-Specreduce is licensed under a 3-clause BSD style license. Please see the licences/LICENSE.rst file.
+Specreduce is licensed under a 3-clause BSD style license. Please see the licenses/LICENSE.rst file.


### PR DESCRIPTION
I noticed the path to the license in the README went Commonwealth-style for a moment.