### PR TITLE
Update citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,6 +20,10 @@ authors:
     family-names: Conroy
     affiliation: STScI
     orcid: 'https://orcid.org/0000-0002-5442-8550'
+  - given-names: O. Justin
+    family-names: Otor
+    affiliation: Space Telescope Science Institute
+    orcid: 'https://orcid.org/0000-0002-4679-5692'
   - given-names: Erik
     family-names: Tollerud
     email: erik.tollerud@gmail.com


### PR DESCRIPTION
I missed #110 and am rectifying it here. I'm assuming @tepickering and @eteq are respectively first and last on purpose, with the middle going in alphabetical order. Do we have such a system for this file?