### PR TITLE
changelog entry for (already merged) KosmosTrace peak_method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+1.1.0 (unreleased)
+------------------
+
+New Features
+^^^^^^^^^^^^
+
+- ``peak_method`` as an optional argument to ``KosmosTrace`` [#115]
+
+
 1.0.0
 -----
 


### PR DESCRIPTION
This PR adds a missing changelog entry from #115.