### PR TITLE
Added changelog entry for HorneExtract API change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ New Features
 API Changes
 ^^^^^^^^^^^
 
+- ``HorneExtract`` no longer requires ``mask`` and ``unit`` arguments [#105]
 - ``BoxcarExtract`` and ``HorneExtract`` now accept parameters (and require the image and trace)
   at initialization, and allow overriding any input parameters when calling [#117]
 


### PR DESCRIPTION
I am prepping a release and noticed I didn't do this in #105.