### PR TITLE
Found cause of background "overlap" error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,9 @@
 Bug Fixes
 ^^^^^^^^^
 
-- Improved errors/warnings when background region extends beyond bounds of image. [#127]
-
+- Improved errors/warnings when background region extends beyond bounds of image [#127]
+- Fixed boxcar weighting bug that often resulted in peak pixels having weight
+  above 1 and erroneously triggered overlapping background errors [#125]
 
 1.1.0
 -----

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -59,14 +59,10 @@ def _get_boxcar_weights(center, hwidth, npix):
         w0 = hwidth - (center - fullpixels[0])
         if w0 >= 0:
             weights[fullpixels[0] - 1] = w0
-        else:  # does this scenario happen anymore given the adjustment to w0?
-            weights[fullpixels[0]] = 1 + w0
     if fullpixels[1] < npix:
         w1 = hwidth - (fullpixels[1] - center)
         if w1 >= 0:
             weights[fullpixels[1]] = w1
-        else:  # does this scenario happen anymore given the adjustment to w1?
-            weights[fullpixels[1]] = 1 + w1
 
     return weights
 

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -45,6 +45,10 @@ def _get_boxcar_weights(center, hwidth, npix):
     """
     weights = np.zeros(npix)
 
+    # shift center from integer to pixel space, where pixel N is [N-0.5, N+0.5),
+    # not [N, N+1). a pixel's integer index corresponds to its middle, not edge
+    center += 0.5
+
     # pixels given full weight because they sit entirely within the aperture
     fullpixels = [max(0, int(np.ceil(center - hwidth))),
                   min(int(np.floor(center + hwidth)), npix)]

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -56,13 +56,9 @@ def _get_boxcar_weights(center, hwidth, npix):
 
     # pixels at the edges of the boxcar with partial weight, if any
     if fullpixels[0] > 0:
-        w0 = hwidth - (center - fullpixels[0])
-        if w0 >= 0:
-            weights[fullpixels[0] - 1] = w0
+        weights[fullpixels[0] - 1] = hwidth - (center - fullpixels[0])
     if fullpixels[1] < npix:
-        w1 = hwidth - (fullpixels[1] - center)
-        if w1 >= 0:
-            weights[fullpixels[1]] = w1
+        weights[fullpixels[1]] = hwidth - (fullpixels[1] - center)
 
     return weights
 

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -55,13 +55,13 @@ def _get_boxcar_weights(center, hwidth, npix):
         w0 = hwidth - (center - fullpixels[0])
         if w0 >= 0:
             weights[fullpixels[0] - 1] = w0
-        else: # does this scenario happen given adjustment made to w0?
+        else:  # does this scenario happen anymore given the adjustment to w0?
             weights[fullpixels[0]] = 1 + w0
     if fullpixels[1] < npix:
         w1 = hwidth - (fullpixels[1] - center)
         if w1 >= 0:
             weights[fullpixels[1]] = w1
-        else: # does this scenario happen given adjustment made to w1?
+        else:  # does this scenario happen anymore given the adjustment to w1?
             weights[fullpixels[1]] = 1 + w1
 
     return weights

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -56,7 +56,7 @@ def test_boxcar_extraction():
 
     trace.set_position(14.3)
     spectrum = boxcar(width=4.7)
-    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 67.0))
+    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 67.15))
 
 
 def test_boxcar_outside_image_condition():

--- a/specreduce/tests/test_tracing.py
+++ b/specreduce/tests/test_tracing.py
@@ -100,8 +100,8 @@ def test_kosmos_trace():
     tg = KosmosTrace(img, peak_method='gaussian')
     tc = KosmosTrace(img, peak_method='centroid')
     tm = KosmosTrace(img, peak_method='max')
-    # traces should all be close to 100 (note this passes with the current set values, but if
-    # changing the seed, noise, etc, then this test might need to be updated)
+    # traces should all be close to 100
+    # (values may need to be updated on changes to seed, noise, etc.)
     assert np.max(abs(tg.trace-100)) < sigma_pix
     assert np.max(abs(tc.trace-100)) < 3 * sigma_pix
     assert np.max(abs(tm.trace-100)) < 6 * sigma_pix
@@ -115,6 +115,14 @@ def test_kosmos_trace():
     guess = int(nrows/2)
     img_win_nans = img.copy()
     img_win_nans[guess - window:guess + window] = np.nan
+
+    # ensure a low bin number is rejected
+    with pytest.raises(ValueError, match='bins must be >= 4'):
+        KosmosTrace(img, bins=3)
+
+    # ensure number of bins greater than number of dispersion pixels is rejected
+    with pytest.raises(ValueError, match=r'bins must be <*'):
+        KosmosTrace(img, bins=ncols)
 
     # error on trace of otherwise valid image with all-nan window around guess
     try:


### PR DESCRIPTION
Addresses the overlapping background regions error described in part of #101.

I think the real issue lies with `_get_boxcar_weights()`, not `Background` or its interaction with `KosmosTrace`. In short, that function gives some pixels weights above 1, and `Background` assumes that any pixel with a value above 1 got that way due to overlapping regions. That's not the case here.

For example, take the image from the code block in #101. The aperture center of the image's first column as found by `KosmosTrace` is 26.79. The code snippet referencing the overlap error sets the background's separation to 5, so the first `center` given to `_get_boxcar_weights()` is 21.79. The half-width of the aperture defined in the snippet is 1 pixel, and the image is 34 pixels across in its cross-dispersion direction. On `main`, this combination of inputs gives a peak weight above 1:

```
# _get_boxcar_weights(center=21.79, hwidth=1, npix=34) (on main)
array([0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  ,
       0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.71,
       **1.29**, 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  ,
       0.  ])
```

Using the modified function in this branch, the peak weight is 1:

```
# _get_boxcar_weights(center=21.79, hwidth=1, npix=34) (in PR)
array([0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  ,
       0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.21, **1. ** ,
       0.79, 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  , 0.  ,
       0.  ])
```
<br />

For a simpler example, define the aperture `center` as 27.5 and `hwidth` as 0.5. I expect all the weight to fall onto one pixel, the 27th (zero-indexed). That's what I see with my modifications:

```
# _get_boxcar_weights(center=27.5, hwidth=0.5, npix=34) (in PR)
array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., **1. **, 0., 0., 0., 0., 0., 0.])
```

On `main`, the weights are instead divided evenly onto the 27th and 28th pixels:
```
# _get_boxcar_weights(center=27.5, hwidth=0.5, npix=34) (on main)
array([0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. ,
       0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. ,
       0. , 0.5, 0.5, 0. , 0. , 0. , 0. , 0. ])
```
<br />

Does this make sense to others? If so, are there any ramifications for `BoxcarExtract` since we thought it was working properly?