### PR TITLE
logic to detect background regions extending beyond image limits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,14 @@
-1.1.0 (unreleased)
+1.2.0 (unreleased)
 ------------------
+
+Bug Fixes
+^^^^^^^^^
+
+- Improved errors/warnings when background region extends beyond bounds of image. [#127]
+
+
+1.1.0
+-----
 
 New Features
 ^^^^^^^^^^^^

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -87,6 +88,13 @@ class Background:
         bkg_wimage = np.zeros_like(self.image, dtype=np.float64)
         for trace in self.traces:
             trace = _to_trace(trace)
+            if (np.any(trace.trace.data >= self.image.shape[self.crossdisp_axis]) or
+                    np.any(trace.trace.data < 0)):
+                raise ValueError("center of background window goes beyond image boundaries")
+            elif (np.any(trace.trace.data + self.width/2. >= self.image.shape[self.crossdisp_axis])
+                  or np.any(trace.trace.data - self.width/2. < 0)):
+                warnings.warn("background window extends beyond image boundaries")
+            # pass trace.trace.data to ignore any mask on the trace
             bkg_wimage += _ap_weight_image(trace,
                                            self.width,
                                            self.disp_axis,

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -71,7 +71,8 @@ def _ap_weight_image(trace, width, disp_axis, crossdisp_axis, image_shape):
     # loop in dispersion direction and compute weights.
     for i in range(image_shape[disp_axis]):
         # TODO trace must handle transposed data (disp_axis == 0)
-        wimage[:, i] = _get_boxcar_weights(trace[i], hwidth, image_sizes)
+        # pass trace.trace.data[i] to avoid any mask if part of the regions is out-of-bounds
+        wimage[:, i] = _get_boxcar_weights(trace.trace.data[i], hwidth, image_sizes)
 
     return wimage
 

--- a/specreduce/tests/test_background.py
+++ b/specreduce/tests/test_background.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 
 import astropy.units as u
@@ -42,3 +43,13 @@ def test_background():
     sub3 = bg1.sub_image()
     assert np.allclose(sub1, sub2)
     assert np.allclose(sub1, sub3)
+
+
+def test_oob():
+    # image.shape (30, 10)
+    with pytest.warns(match="background window extends beyond image boundaries"):
+        Background.two_sided(image, 25, 4, width=3)
+
+    with pytest.raises(ValueError,
+                       match="center of background window goes beyond image boundaries"):
+        Background.two_sided(image, 25, 6, width=3)

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -51,7 +51,7 @@ class Trace:
             Shift to be applied to the trace
         """
         # act on self.trace.data to ignore the mask and then re-mask when calling _bound_trace
-        self.trace = self.trace.data + delta
+        self.trace = np.asarray(self.trace.data) + delta
         self._bound_trace()
 
     def _bound_trace(self):

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -50,7 +50,8 @@ class Trace:
         delta : float
             Shift to be applied to the trace
         """
-        self.trace += delta
+        # act on self.trace.data to ignore the mask and then re-mask when calling _bound_trace
+        self.trace = self.trace.data + delta
         self._bound_trace()
 
     def _bound_trace(self):


### PR DESCRIPTION
This PR adds logic to check if a background region extends beyond the image limits.  In the case where the center of the window (of any of the background traces) falls off the image at any dispersion "column", an error is raised.  If any part of the window falls off the image, a warning is raised.

This (in addition to #125) should address #101.

Following the case in #101:

```
from pathlib import Path
from zipfile import ZipFile

from astropy.io import fits
from astropy.table import Table
from astropy.utils.data import download_file

from jwst import datamodels

from specreduce.extract import BoxcarExtract
from specreduce.tracing import FlatTrace, KosmosTrace
from specreduce.background import Background

import tempfile

zipped_datapath = Path(download_file('https://stsci.box.com/shared/static/qdj79y7rv99wuui2hot0l3kg5ohq0ah9.zip', cache=True))
data_dir = Path(tempfile.gettempdir())
with ZipFile(zipped_datapath, 'r') as sample_data_zip:
    sample_data_zip.extractall(data_dir)

s2dfile = str(data_dir / "nirspec_fssim_d1_s2d.fits")
s2d = datamodels.open(s2dfile)
image = s2d.slits[0].data
```

the following used to raise a cryptic integer error, but now raises a helpful error message ("center of background window goes beyond image boundaries"):
```
bg = Background.two_sided(image, trace, separation=7, width=2)
```

and the following now raises a warning ("background window extends beyond image boundaries"):
```
bg = Background.two_sided(image, trace, separation=6, width=2)
```

this last example currently raises an error that the regions overlap, but testing this branch locally on top of #125 should show that this case succeeds in creating the background after raising the warning.