### PR TITLE
DOC: No need to automodapi the top-level package

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,9 +42,6 @@ Calibration
 Reference/API
 *************
 
-.. automodapi:: specreduce
-    :no-inheritance-diagram:
-
 .. automodapi:: specreduce.core
     :no-inheritance-diagram:
 


### PR DESCRIPTION
This would remove the duplicate class API.