### PR TITLE
MNT: Remove dead code from APE 17

### DIFF
--- a/specreduce/_astropy_init.py
+++ b/specreduce/_astropy_init.py
@@ -1,25 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import os
+from astropy.tests.runner import TestRunner
 
-__all__ = ['__version__']
-
-# this indicates whether or not we are in the package's setup.py
-try:
-    _ASTROPY_SETUP_
-except NameError:
-    import builtins
-    builtins._ASTROPY_SETUP_ = False
+__all__ = ['__version__', 'test']
 
 try:
     from .version import version as __version__
 except ImportError:
     __version__ = ''
 
-
-if not _ASTROPY_SETUP_:  # noqa
-    import os
-
-    # Create the test function for self test
-    from astropy.tests.runner import TestRunner
-    test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
-    test.__test__ = False
-    __all__ += ['test']
+# Create the test function for self test
+test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
+test.__test__ = False


### PR DESCRIPTION
I think this stuff is left over from astropy-helpers days.

Also see https://github.com/astropy/astropy-APEs/blob/main/APE17.rst