### PR TITLE
DOC: Turn on nitpicky

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,7 +169,7 @@ github_issues_url = 'https://github.com/{0}/issues/'.format(setup_cfg['github_pr
 
 # -- Turn on nitpicky mode for sphinx (to warn about references not found) ----
 #
-# nitpicky = True
+nitpicky = True
 # nitpick_ignore = []
 #
 # Some warnings are impossible to suppress, and you can list specific references


### PR DESCRIPTION
Maybe this is why broken ref links not triggering failure in RTD.