### PR TITLE
Better handled Spectrum1D images across classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,9 @@ API Changes
 - Renamed KosmosTrace as FitTrace, a conglomerate class for traces that are fit
 to images instead of predetermined [#128]
 - The default number of bins for FitTrace is now its associated image's number
-of dispersion pixels instead of 20. Its default peak_method is now 'max'. [#128]
+of dispersion pixels instead of 20. Its default peak_method is now 'max' [#128]
+- All operations now accept Spectrum1D and Quantity-type images. All accepted
+image types are now processed internally as Spectrum1D objects [#146]
 
 Bug Fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ to images instead of predetermined [#128]
 - The default number of bins for FitTrace is now its associated image's number
 of dispersion pixels instead of 20. Its default peak_method is now 'max' [#128]
 - All operations now accept Spectrum1D and Quantity-type images. All accepted
-image types are now processed internally as Spectrum1D objects [#146]
+image types are now processed internally as Spectrum1D objects [#144]
+- All operations' ``image`` attributes are now coerced Spectrum1D objects [#144]
 
 Bug Fixes
 ^^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     astropy
-    specutils
+    specutils>=1.7
     synphot
     matplotlib
     photutils

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ github_project = astropy/specreduce
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
     astropy

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
     astropy
-    specutils>=1.7
+    specutils>=1.9.1
     synphot
     matplotlib
     photutils

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -27,7 +27,7 @@ class Background:
 
     Parameters
     ----------
-    image : `~astropy.nddata.NDData` or array-like
+    image : `~astropy.nddata.NDData`-like or array-like
         image with 2-D spectral image data
     traces : List
         list of trace objects (or integers to define FlatTraces) to
@@ -60,7 +60,7 @@ class Background:
 
         Parameters
         ----------
-        image : `~astropy.nddata.NDData` or array-like
+        image : `~astropy.nddata.NDData`-like or array-like
             image with 2-D spectral image data
         traces : List
             list of trace objects (or integers to define FlatTraces) to
@@ -88,13 +88,17 @@ class Background:
 
         if self.width < 0:
             raise ValueError("width must be positive")
-
         if self.width == 0:
             self.bkg_array = np.zeros(self.image.shape[self.disp_axis])
             return
 
         if isinstance(self.traces, Trace):
             self.traces = [self.traces]
+
+        if isinstance(self.image, NDData):
+            # NOTE: should the NDData structure instead be preserved?
+            # (NDData includes Spectrum1D under its umbrella)
+            self.image = self.image.data
 
         bkg_wimage = np.zeros_like(self.image, dtype=np.float64)
         for trace in self.traces:
@@ -150,7 +154,7 @@ class Background:
 
         Parameters
         ----------
-        image : nddata-compatible image
+        image : `~astropy.nddata.NDData`-like or array-like
             image with 2-D spectral image data
         trace_object: Trace
             estimated trace of the spectrum to center the background traces
@@ -183,7 +187,7 @@ class Background:
 
         Parameters
         ----------
-        image : nddata-compatible image
+        image : `~astropy.nddata.NDData`-like or array-like
             image with 2-D spectral image data
         trace_object: Trace
             estimated trace of the spectrum to center the background traces

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -324,6 +324,4 @@ class Background(_ImageParser):
         """
         Subtract the background from an image.
         """
-        # NOTE: will not be called until specutils PR #988 is merged, released,
-        # and pinned here
         return self.sub_image(image)

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass, field
 import numpy as np
 from astropy.nddata import NDData
 from astropy.units import UnitTypeError
-from astropy import units as u
 from specutils import Spectrum1D
 
 from specreduce.core import _ImageParser

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -1,13 +1,86 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import inspect
+import numpy as np
+
+from astropy import units as u
+from astropy.nddata import VarianceUncertainty
 from dataclasses import dataclass
+from specutils import Spectrum1D
 
 __all__ = ['SpecreduceOperation']
 
 
+class _ImageParser:
+    """
+    Coerces images from accepted formats to Spectrum1D objects for
+    internal use in specreduce's operation classes.
+
+    Fills any and all of uncertainty, mask, units, and spectral axis
+    that are missing in the provided image with generic values.
+    Accepted image types are:
+
+        - `~specutils.spectra.spectrum1d.Spectrum1D` (preferred)
+        - `~astropy.nddata.ccddata.CCDData`
+        - `~astropy.nddata.ndddata.NDDData`
+        - `~astropy.units.quantity.Quantity`
+        - `~numpy.ndarray`
+    """
+    def _parse_image(self, image, disp_axis=1):
+        """
+        Convert all accepted image types to a consistently formatted
+        Spectrum1D object.
+
+        Parameters
+        ----------
+        image : `~astropy.nddata.NDData`-like or array-like, required
+            The image to be parsed. If None, defaults to class' own
+            image attribute.
+        disp_axis : int, optional
+            The index of the image's dispersion axis. Should not be
+            changed until operations can handle variable image
+            orientations. [default: 1]
+        """
+
+        # would be nice to handle (cross)disp_axis consistently across
+        # operations (public attribute? private attribute? argument only?) so
+        # it can be called from self instead of via kwargs...
+
+        if image is None:
+            # useful for Background's instance methods
+            return self.image
+
+        if isinstance(image, np.ndarray):
+            img = image
+        elif isinstance(image, u.quantity.Quantity):
+            img = image.value
+        else:  # NDData, including CCDData and Spectrum1D
+            img = image.data
+
+        # mask and uncertainty are set as None when they aren't specified upon
+        # creating a Spectrum1D object, so we must check whether these
+        # attributes are absent *and* whether they are present but set as None
+        if getattr(image, 'mask', None) is not None:
+            mask = image.mask
+        else:
+            mask = np.ma.masked_invalid(img).mask
+
+        if getattr(image, 'uncertainty', None) is not None:
+            uncertainty = image.uncertainty
+        else:
+            uncertainty = VarianceUncertainty(np.ones(img.shape))
+
+        unit = getattr(image, 'unit', u.Unit('DN'))  # or u.Unit()?
+
+        spectral_axis = getattr(image, 'spectral_axis',
+                                np.arange(img.shape[disp_axis]) * u.pix)
+
+        return Spectrum1D(img * unit, spectral_axis=spectral_axis,
+                          uncertainty=uncertainty, mask=mask)
+
+
 @dataclass
-class SpecreduceOperation:
+class SpecreduceOperation(_ImageParser):
     """
     An operation to perform as part of a spectroscopic reduction pipeline.
 

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -70,7 +70,7 @@ class _ImageParser:
         else:
             uncertainty = VarianceUncertainty(np.ones(img.shape))
 
-        unit = getattr(image, 'unit', u.Unit('DN'))  # or u.Unit()?
+        unit = getattr(image, 'unit', u.Unit('DN'))
 
         spectral_axis = getattr(image, 'spectral_axis',
                                 np.arange(img.shape[disp_axis]) * u.pix)

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -117,12 +117,6 @@ def _ap_weight_image(trace, width, disp_axis, crossdisp_axis, image_shape):
     return wimage
 
 
-def _to_spectrum1d_pixels(fluxes):
-    # TODO: add wavelength units, uncertainty and mask to spectrum1D object
-    return Spectrum1D(spectral_axis=np.arange(len(fluxes)) * u.pixel,
-                      flux=fluxes)
-
-
 @dataclass
 class BoxcarExtract(SpecreduceOperation):
     """
@@ -515,7 +509,8 @@ class HorneExtract(SpecreduceOperation):
         extraction = result * norms
 
         # convert the extraction to a Spectrum1D object
-        return _to_spectrum1d_pixels(extraction * unit)
+        return Spectrum1D(extraction * unit,
+                          spectral_axis=self.image.spectral_axis)
 
 
 @dataclass

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -258,7 +258,7 @@ class HorneExtract(SpecreduceOperation):
     unit : `~astropy.units.Unit` or str, optional
         (Only used if ``image`` is not an NDData object.)
         The associated unit for the data in ``image``. If blank,
-        fluxes are interpreted as unitless. [default: None]
+        fluxes are interpreted in DN. [default: None]
 
     """
     image: NDData
@@ -307,7 +307,7 @@ class HorneExtract(SpecreduceOperation):
         unit : `~astropy.units.Unit` or str, optional
             (Only used if ``image`` is not an NDData object.)
             The associated unit for the data in ``image``. If blank,
-            fluxes are interpreted as unitless.
+            fluxes are interpreted in DN.
         disp_axis : int, optional
             The index of the image's dispersion axis. Should not be
             changed until operations can handle variable image
@@ -381,7 +381,7 @@ class HorneExtract(SpecreduceOperation):
         variance = VarianceUncertainty(variance)
 
         unit = getattr(image, 'unit',
-                       u.Unit(unit) if unit is not None else u.Unit())
+                       u.Unit(unit) if unit is not None else u.Unit('DN'))
 
         spectral_axis = getattr(image, 'spectral_axis',
                                 np.arange(img.shape[disp_axis]) * u.pix)
@@ -434,7 +434,7 @@ class HorneExtract(SpecreduceOperation):
         unit : `~astropy.units.Unit` or str, optional
             (Only used if ``image`` is not an NDData object.)
             The associated unit for the data in ``image``. If blank,
-            fluxes are interpreted as unitless.
+            fluxes are interpreted in DN.
 
 
         Returns

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -9,7 +9,7 @@ from astropy import units as u
 from astropy.modeling import Model, models, fitting
 from astropy.nddata import NDData, VarianceUncertainty
 
-from specreduce.core import _ImageParser, SpecreduceOperation
+from specreduce.core import SpecreduceOperation
 from specreduce.tracing import Trace, FlatTrace
 from specutils import Spectrum1D
 

--- a/specreduce/tests/test_background.py
+++ b/specreduce/tests/test_background.py
@@ -55,20 +55,17 @@ def test_background():
     bg = Background(image, trace, width=bkg_width)
 
     # test that image subtraction works
-    # NOTE: uncomment sub1 test once Spectrum1D and Background subtraction works
-    # (meaning specutils PR #988 is merged, released, and pinned here)
-    # sub1 = image - bg1
+    sub1 = image - bg1
     sub2 = bg1.sub_image(image)
     sub3 = bg1.sub_image()
-    # assert np.allclose(sub1.flux, sub2.flux)
+    assert np.allclose(sub1.flux, sub2.flux)
     assert np.allclose(sub2.flux, sub3.flux)
 
-    # NOTE: uncomment sub4 test once Spectrum1D and Background subtraction works
-    # sub4 = image_um - bg4
+    sub4 = image_um - bg4
     sub5 = bg4.sub_image(image_um)
     sub6 = bg4.sub_image()
-    assert np.allclose(sub2.flux, sub5.flux)
-    # assert np.allclose(sub4.flux, sub5.flux)
+    assert np.allclose(sub1.flux, sub4.flux)
+    assert np.allclose(sub4.flux, sub5.flux)
     assert np.allclose(sub5.flux, sub6.flux)
 
     bkg_spec = bg1.bkg_spectrum()

--- a/specreduce/tests/test_background.py
+++ b/specreduce/tests/test_background.py
@@ -38,15 +38,15 @@ def test_background():
     bg1 = Background(image, [trace-bkg_sep, trace+bkg_sep], width=bkg_width)
     bg2 = Background.two_sided(image, trace, bkg_sep, width=bkg_width)
     bg3 = Background.two_sided(image, trace_pos, bkg_sep, width=bkg_width)
-    assert np.allclose(bg1.bkg_array, bg2.bkg_array)
-    assert np.allclose(bg1.bkg_array, bg3.bkg_array)
+    assert np.allclose(bg1.bkg_image().flux, bg2.bkg_image().flux)
+    assert np.allclose(bg1.bkg_image().flux, bg3.bkg_image().flux)
 
     bg4 = Background(image_um, [trace-bkg_sep, trace+bkg_sep], width=bkg_width)
     bg5 = Background.two_sided(image_um, trace, bkg_sep, width=bkg_width)
     bg6 = Background.two_sided(image_um, trace_pos, bkg_sep, width=bkg_width)
-    assert np.allclose(bg1.bkg_array, bg4.bkg_array)
-    assert np.allclose(bg1.bkg_array, bg5.bkg_array)
-    assert np.allclose(bg1.bkg_array, bg6.bkg_array)
+    assert np.allclose(bg1.bkg_image().flux, bg4.bkg_image().flux)
+    assert np.allclose(bg1.bkg_image().flux, bg5.bkg_image().flux)
+    assert np.allclose(bg1.bkg_image().flux, bg6.bkg_image().flux)
 
     # test that creating a one_sided background works
     Background.one_sided(image, trace, bkg_sep, width=bkg_width)

--- a/specreduce/tests/test_background.py
+++ b/specreduce/tests/test_background.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 
 import astropy.units as u
-from astropy.nddata import CCDData, VarianceUncertainty
+from astropy.nddata import VarianceUncertainty
 from specutils import Spectrum1D
 
 from specreduce.background import Background
@@ -43,11 +43,13 @@ def test_background():
     bg = Background(image, trace, width=bkg_width)
 
     # test that image subtraction works
-    sub1 = image - bg1
+    # NOTE: uncomment sub1 test once Spectrum1D and Background subtraction works
+    # (meaning specutils PR #988 is merged, released, and pinned here)
+    # sub1 = image - bg1
     sub2 = bg1.sub_image(image)
     sub3 = bg1.sub_image()
-    assert np.allclose(sub1.flux, sub2.flux)
-    assert np.allclose(sub1.flux, sub3.flux)
+    # assert np.allclose(sub1.flux, sub2.flux)
+    assert np.allclose(sub2.flux, sub3.flux)
 
     bkg_spec = bg1.bkg_spectrum()
     assert isinstance(bkg_spec, Spectrum1D)

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -116,10 +116,10 @@ def test_horne_image_validation():
         ext = extract(image=image.data, variance=err, mask=mask)
 
     # an array-type image given without mask and unit arguments is fine
-    # and produces an extraction with unitless flux and spectral axis in pixels
+    # and produces an extraction with flux in DN and spectral axis in pixels
     err = np.ones_like(image)
     ext = extract(image=image.data, variance=err, mask=None, unit=None)
-    assert ext.unit == u.Unit()
+    assert ext.unit == u.Unit('DN')
     assert np.all(ext.spectral_axis
                   == np.arange(image.shape[extract.disp_axis]) * u.pix)
 

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -144,7 +144,6 @@ def test_horne_variance_errors():
     # single negative value raises error
     err = image.uncertainty.array
     err[0][0] = -1
-    mask = np.zeros_like(image)
     with pytest.raises(ValueError, match='variance must be fully positive'):
         # remember variance, mask, and unit args are only checked if image
         # object doesn't have those attributes (e.g., numpy and Quantity arrays)

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import astropy.units as u
-from astropy.nddata import CCDData
+from astropy.nddata import CCDData, VarianceUncertainty, UnknownUncertainty
 
 from specreduce.extract import BoxcarExtract, HorneExtract, OptimalExtract
 from specreduce.tracing import FlatTrace, ArrayTrace
@@ -79,7 +79,7 @@ def test_boxcar_array_trace():
     assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 75.))
 
 
-def test_horne_array_validation():
+def test_horne_image_validation():
     #
     # Test HorneExtract scenarios specific to its use with an image of
     # type `~numpy.ndarray` (instead of the default `~astropy.nddata.NDData`).
@@ -88,47 +88,65 @@ def test_horne_array_validation():
     extract = OptimalExtract(image.data, trace)  # equivalent to HorneExtract
 
     # an array-type image must come with a variance argument
-    with pytest.raises(ValueError, match=r'.*array.*variance.*specified.*'):
+    with pytest.raises(ValueError, match=r'.*variance must be specified.*'):
         ext = extract()
+
+    # an NDData-type image can't have an empty uncertainty attribute
+    with pytest.raises(ValueError, match=r'.*NDData object lacks uncertainty'):
+        ext = extract(image=image)
+
+    # an NDData-type image's uncertainty must be of type VarianceUncertainty
+    # or type StdDevUncertainty
+    with pytest.raises(ValueError, match=r'.*unexpected uncertainty type.*'):
+        err = UnknownUncertainty(np.ones_like(image))
+        image.uncertainty = err
+        ext = extract(image=image)
 
     # an array-type image must have the same dimensions as its variance argument
     with pytest.raises(ValueError, match=r'.*shapes must match.*'):
+        # remember variance, mask, and unit args are only checked if image
+        # object doesn't have those attributes (e.g., numpy and Quantity arrays)
         err = np.ones_like(image[0])
-        ext = extract(variance=err)
+        ext = extract(image=image.data, variance=err)
 
     # an array-type image must have the same dimensions as its mask argument
     with pytest.raises(ValueError, match=r'.*shapes must match.*'):
         err = np.ones_like(image)
         mask = np.zeros_like(image[0])
-        ext = extract(variance=err, mask=mask)
+        ext = extract(image=image.data, variance=err, mask=mask)
 
     # an array-type image given without mask and unit arguments is fine
-    # and produces a unitless result
+    # and produces an extraction with unitless flux and spectral axis in pixels
     err = np.ones_like(image)
-    ext = extract(variance=err)
+    ext = extract(image=image.data, variance=err, mask=None, unit=None)
     assert ext.unit == u.Unit()
+    assert np.all(ext.spectral_axis
+                  == np.arange(image.shape[extract.disp_axis]) * u.pix)
 
 
 def test_horne_variance_errors():
     trace = FlatTrace(image, 3.0)
 
-    # all zeros are treated as non-weighted (give non-zero fluxes)
-    err = np.zeros_like(image)
-    mask = np.zeros_like(image)
-    extract = HorneExtract(image.data, trace, variance=err, mask=mask, unit=u.Jy)
+    # all zeros are treated as non-weighted (i.e., as non-zero fluxes)
+    image.uncertainty = VarianceUncertainty(np.zeros_like(image))
+    image.mask = np.zeros_like(image)
+    extract = HorneExtract(image, trace)
     ext = extract.spectrum
     assert not np.all(ext == 0)
 
-    # single zero value adjusts mask (does not raise error)
+    # single zero value adjusts mask and does not raise error
     err = np.ones_like(image)
-    err[0] = 0
-    mask = np.zeros_like(image)
-    ext = extract(variance=err, mask=mask, unit=u.Jy)
-    assert not np.all(ext == 0)
+    err[0][0] = 0
+    image.uncertainty = VarianceUncertainty(err)
+    ext = extract(image)
+    assert not np.all(ext == 1)
 
     # single negative value raises error
-    err = np.ones_like(image)
-    err[0] = -1
+    err = image.uncertainty.array
+    err[0][0] = -1
     mask = np.zeros_like(image)
     with pytest.raises(ValueError, match='variance must be fully positive'):
-        ext = extract(variance=err, mask=mask, unit=u.Jy)
+        # remember variance, mask, and unit args are only checked if image
+        # object doesn't have those attributes (e.g., numpy and Quantity arrays)
+        ext = extract(image=image.data, variance=err,
+                      mask=image.mask, unit=u.Jy)

--- a/specreduce/tests/test_image_parsing.py
+++ b/specreduce/tests/test_image_parsing.py
@@ -1,0 +1,104 @@
+import numpy as np
+
+from astropy import units as u
+from astropy.io import fits
+from astropy.nddata import CCDData, NDData, VarianceUncertainty
+from astropy.utils.data import download_file
+
+from specreduce.extract import HorneExtract
+from specreduce.tracing import FlatTrace
+from specutils import Spectrum1D, SpectralAxis
+
+# fetch test image
+fn = download_file('https://stsci.box.com/shared/static/exnkul627fcuhy5akf2gswytud5tazmw.fits',
+                   cache=True)
+
+# duplicate image in all accepted formats
+# (one Spectrum1D variant has a physical spectral axis; the other is in pixels)
+img = fits.getdata(fn).T
+flux = img * u.MJy / u.sr
+sax = SpectralAxis(np.linspace(14.377, 3.677, flux.shape[-1]) * u.um)
+unc = VarianceUncertainty(np.random.rand(*flux.shape))
+
+all_images = {}
+all_images['arr'] = img
+all_images['s1d'] = Spectrum1D(flux, spectral_axis=sax, uncertainty=unc)
+all_images['s1d_pix'] = Spectrum1D(flux, uncertainty=unc)
+all_images['ccd'] = CCDData(img, uncertainty=unc, unit=flux.unit)
+all_images['ndd'] = NDData(img, uncertainty=unc, unit=flux.unit)
+all_images['qnt'] = img * flux.unit
+
+# save default values used for spectral axis and uncertainty when they are not
+# available from the image object or provided by the user
+sax_def = np.arange(img.shape[1]) * u.pix
+unc_def = np.ones_like(img)
+
+
+# (for use inside tests)
+def compare_images(key, collection, compare='s1d'):
+    # was input converted to Spectrum1D?
+    assert isinstance(collection[key], Spectrum1D), (f"image '{key}' not "
+                                                     "of type Spectrum1D")
+
+    # do key's fluxes match its comparison's fluxes?
+    assert np.allclose(collection[key].data,
+                       collection[compare].data), (f"images '{key}' and "
+                                                   f"'{compare}' have unequal "
+                                                   "flux values")
+
+    # if the image came with a spectral axis, was it kept? if not, was the
+    # default spectral axis in pixels applied?
+    sax_provided = hasattr(all_images[key], 'spectral_axis')
+    assert np.allclose(collection[key].spectral_axis,
+                       (all_images[key].spectral_axis if sax_provided
+                        else sax_def)), (f"spectral axis of image '{key}' does "
+                                         f"not match {'input' if sax_provided else 'default'}")
+
+    # if the image came with an uncertainty, was it kept? if not, was the
+    # default uncertainty created?
+    unc_provided = hasattr(all_images[key], 'uncertainty')
+    assert np.allclose(collection[key].uncertainty.array,
+                       (all_images[key].uncertainty.array if unc_provided
+                        else unc_def)), (f"uncertainty of image '{key}' does "
+                                         f"not match {'input' if unc_provided else 'default'}")
+
+    # were masks created despite none being given? (all indices should be False)
+    assert (getattr(collection[key], 'mask', None)
+            is not None), f"no mask was created for image '{key}'"
+    assert np.all(collection[key].mask == 0), ("mask not all False "
+                                               f"for image '{key}'")
+
+
+# test consistency of general image parser results
+def test_parse_general():
+    all_images_parsed = {k: FlatTrace._parse_image(object, im)
+                         for k, im in all_images.items()}
+
+    for key in all_images_parsed.keys():
+        compare_images(key, all_images_parsed)
+
+
+# use verified general image parser results to check HorneExtract's image parser
+def test_parse_horne():
+    # HorneExtract's parser is more stringent than the general one, hence the
+    # separate test. Given proper inputs, both should produce the same results.
+    images_collection = {k: {} for k in all_images.keys()}
+
+    for key, col in images_collection.items():
+        img = all_images[key]
+        col['general'] = FlatTrace._parse_image(object, img)
+
+        if hasattr(all_images[key], 'uncertainty'):
+            defaults = {}
+        else:
+            # save default values of attributes used in general parser when
+            # they are not available from the image object. HorneExtract always
+            # requires a variance, so it's chosen here to be on equal footing
+            # with the general case
+            defaults = {'variance': unc_def,
+                        'mask': np.ma.masked_invalid(img).mask,
+                        'unit': getattr(img, 'unit', u.DN)}
+
+        col[key] = HorneExtract._parse_image(object, img, **defaults)
+
+        compare_images(key, col, compare='general')

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -5,11 +5,9 @@ from dataclasses import dataclass, field
 import warnings
 
 from astropy.modeling import Model, fitting, models
-from astropy.nddata import NDData, VarianceUncertainty
+from astropy.nddata import NDData
 from astropy.stats import gaussian_sigma_to_fwhm
 from astropy.utils.decorators import deprecated
-from astropy import units as u
-from specutils import Spectrum1D
 import numpy as np
 
 from specreduce.core import _ImageParser


### PR DESCRIPTION
I made changes to `Background` and the `Trace` classes in particular.

I created ~an `__init__()`~ a private method for `Trace` and put the check for `Spectrum1D` there so it can be propagated out to the children classes through `super()`. I'm not sure if I should be using `__post_init__()` instead.

I didn't realize that `Spectrum1D` is a child class of `NDData`, so most of the checks for the latter in `Background` and the extraction classes already captured them. I added code in `Background` to fix #129 and made the docstrings on image typing consistent across all classes.

I hope this fixes #130, but I wasn't able to reproduce the strange behavior with units reported there.