### PR TITLE
BUG: fix passing single Trace object to Background

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ API Changes
 Bug Fixes
 ^^^^^^^^^
 
+- Fixed passing a single ``Trace`` object to ``Background`` [#146]
+
 
 1.2.0
 -----

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -93,6 +93,9 @@ class Background:
             self.bkg_array = np.zeros(self.image.shape[self.disp_axis])
             return
 
+        if isinstance(self.traces, Trace):
+            self.traces = [self.traces]
+
         bkg_wimage = np.zeros_like(self.image, dtype=np.float64)
         for trace in self.traces:
             trace = _to_trace(trace)

--- a/specreduce/tests/test_background.py
+++ b/specreduce/tests/test_background.py
@@ -38,6 +38,9 @@ def test_background():
     # test that creating a one_sided background works
     Background.one_sided(image, trace, bkg_sep, width=bkg_width)
 
+    # test that passing a single trace works
+    bg = Background(image, trace, width=bkg_width)
+
     # test that image subtraction works
     sub1 = image - bg1
     sub2 = bg1.sub_image(image)


### PR DESCRIPTION
* `Background(image, trace, width)` used to expect `trace` to be an iterable and interpret it as a list of floats, each representing a trace (and therefore raise an error about window overlaps).  This syntax is now handled as expected: as a single background window, equivalent to `Background(image, [trace], width)`.