### PR TITLE
Better management of Trace attribute mutability

### DIFF
--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -8,7 +8,7 @@ from astropy.nddata import NDData
 from astropy import units as u
 
 from specreduce.extract import _ap_weight_image, _to_spectrum1d_pixels
-from specreduce.tracing import FlatTrace, BaseTrace
+from specreduce.tracing import FlatTrace, Trace
 
 __all__ = ['Background']
 
@@ -77,7 +77,7 @@ class Background:
             cross-dispersion axis
         """
         def _to_trace(trace):
-            if not isinstance(trace, BaseTrace):
+            if not isinstance(trace, Trace):
                 trace = FlatTrace(self.image, trace)
 
             # TODO: this check can be removed if/when implemented as a check in FlatTrace
@@ -93,7 +93,7 @@ class Background:
             self.bkg_array = np.zeros(self.image.shape[self.disp_axis])
             return
 
-        if isinstance(self.traces, BaseTrace):
+        if isinstance(self.traces, Trace):
             self.traces = [self.traces]
 
         bkg_wimage = np.zeros_like(self.image, dtype=np.float64)

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -8,7 +8,7 @@ from astropy.nddata import NDData
 from astropy import units as u
 
 from specreduce.extract import _ap_weight_image, _to_spectrum1d_pixels
-from specreduce.tracing import Trace, FlatTrace
+from specreduce.tracing import FlatTrace, BaseTrace
 
 __all__ = ['Background']
 
@@ -77,7 +77,7 @@ class Background:
             cross-dispersion axis
         """
         def _to_trace(trace):
-            if not isinstance(trace, Trace):
+            if not isinstance(trace, BaseTrace):
                 trace = FlatTrace(self.image, trace)
 
             # TODO: this check can be removed if/when implemented as a check in FlatTrace
@@ -93,7 +93,7 @@ class Background:
             self.bkg_array = np.zeros(self.image.shape[self.disp_axis])
             return
 
-        if isinstance(self.traces, Trace):
+        if isinstance(self.traces, BaseTrace):
             self.traces = [self.traces]
 
         bkg_wimage = np.zeros_like(self.image, dtype=np.float64)

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -10,7 +10,7 @@ from astropy.modeling import Model, models, fitting
 from astropy.nddata import NDData
 
 from specreduce.core import SpecreduceOperation
-from specreduce.tracing import FlatTrace, BaseTrace
+from specreduce.tracing import FlatTrace, Trace
 from specutils import Spectrum1D
 
 __all__ = ['BoxcarExtract', 'HorneExtract', 'OptimalExtract']
@@ -88,7 +88,7 @@ def _ap_weight_image(trace, width, disp_axis, crossdisp_axis, image_shape):
 
     Parameters
     ----------
-    trace : `~specreduce.tracing.BaseTrace`, required
+    trace : `~specreduce.tracing.Trace`, required
         trace object
     width : float, required
         width of extraction aperture in pixels
@@ -139,7 +139,7 @@ class BoxcarExtract(SpecreduceOperation):
     ----------
     image : nddata-compatible image
         image with 2-D spectral image data
-    trace_object : BaseTrace
+    trace_object : Trace
         trace object
     width : float
         width of extraction aperture in pixels
@@ -154,7 +154,7 @@ class BoxcarExtract(SpecreduceOperation):
         The extracted 1d spectrum expressed in DN and pixel units
     """
     image: NDData
-    trace_object: BaseTrace
+    trace_object: Trace
     width: float = 5
     disp_axis: int = 1
     crossdisp_axis: int = 0
@@ -173,7 +173,7 @@ class BoxcarExtract(SpecreduceOperation):
         ----------
         image : nddata-compatible image
             image with 2-D spectral image data
-        trace_object : BaseTrace
+        trace_object : Trace
             trace object
         width : float
             width of extraction aperture in pixels [default: 5]
@@ -230,7 +230,7 @@ class HorneExtract(SpecreduceOperation):
         NDData object must specify uncertainty and a mask. An array
         requires use of the ``variance``, ``mask``, & ``unit`` arguments.
 
-    trace_object : `~specreduce.tracing.BaseTrace`, required
+    trace_object : `~specreduce.tracing.Trace`, required
         The associated 1D trace object created for the 2D image.
 
     disp_axis : int, optional
@@ -264,7 +264,7 @@ class HorneExtract(SpecreduceOperation):
 
     """
     image: NDData
-    trace_object: BaseTrace
+    trace_object: Trace
     bkgrd_prof: Model = field(default=models.Polynomial1D(2))
     variance: np.ndarray = field(default=None)
     mask: np.ndarray = field(default=None)
@@ -293,7 +293,7 @@ class HorneExtract(SpecreduceOperation):
             NDData object must specify uncertainty and a mask. An array
             requires use of the ``variance``, ``mask``, & ``unit`` arguments.
 
-        trace_object : `~specreduce.tracing.BaseTrace`, required
+        trace_object : `~specreduce.tracing.Trace`, required
             The associated 1D trace object created for the 2D image.
 
         disp_axis : int, optional

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -10,7 +10,7 @@ from astropy.modeling import Model, models, fitting
 from astropy.nddata import NDData
 
 from specreduce.core import SpecreduceOperation
-from specreduce.tracing import Trace, FlatTrace
+from specreduce.tracing import FlatTrace, BaseTrace
 from specutils import Spectrum1D
 
 __all__ = ['BoxcarExtract', 'HorneExtract', 'OptimalExtract']
@@ -88,7 +88,7 @@ def _ap_weight_image(trace, width, disp_axis, crossdisp_axis, image_shape):
 
     Parameters
     ----------
-    trace : `~specreduce.tracing.Trace`, required
+    trace : `~specreduce.tracing.BaseTrace`, required
         trace object
     width : float, required
         width of extraction aperture in pixels
@@ -139,7 +139,7 @@ class BoxcarExtract(SpecreduceOperation):
     ----------
     image : nddata-compatible image
         image with 2-D spectral image data
-    trace_object : Trace
+    trace_object : BaseTrace
         trace object
     width : float
         width of extraction aperture in pixels
@@ -154,7 +154,7 @@ class BoxcarExtract(SpecreduceOperation):
         The extracted 1d spectrum expressed in DN and pixel units
     """
     image: NDData
-    trace_object: Trace
+    trace_object: BaseTrace
     width: float = 5
     disp_axis: int = 1
     crossdisp_axis: int = 0
@@ -173,7 +173,7 @@ class BoxcarExtract(SpecreduceOperation):
         ----------
         image : nddata-compatible image
             image with 2-D spectral image data
-        trace_object : Trace
+        trace_object : BaseTrace
             trace object
         width : float
             width of extraction aperture in pixels [default: 5]
@@ -230,7 +230,7 @@ class HorneExtract(SpecreduceOperation):
         NDData object must specify uncertainty and a mask. An array
         requires use of the ``variance``, ``mask``, & ``unit`` arguments.
 
-    trace_object : `~specreduce.tracing.Trace`, required
+    trace_object : `~specreduce.tracing.BaseTrace`, required
         The associated 1D trace object created for the 2D image.
 
     disp_axis : int, optional
@@ -264,7 +264,7 @@ class HorneExtract(SpecreduceOperation):
 
     """
     image: NDData
-    trace_object: Trace
+    trace_object: BaseTrace
     bkgrd_prof: Model = field(default=models.Polynomial1D(2))
     variance: np.ndarray = field(default=None)
     mask: np.ndarray = field(default=None)
@@ -293,7 +293,7 @@ class HorneExtract(SpecreduceOperation):
             NDData object must specify uncertainty and a mask. An array
             requires use of the ``variance``, ``mask``, & ``unit`` arguments.
 
-        trace_object : `~specreduce.tracing.Trace`, required
+        trace_object : `~specreduce.tracing.BaseTrace`, required
             The associated 1D trace object created for the 2D image.
 
         disp_axis : int, optional

--- a/specreduce/tests/test_tracing.py
+++ b/specreduce/tests/test_tracing.py
@@ -141,3 +141,17 @@ def test_kosmos_trace():
         raise RuntimeError('Trace was erroneously calculated on all-NaN image')
 
     # could try to catch warning thrown for all-nan bins
+
+
+def test_mutability():
+    trace = FlatTrace(IM, 10)
+    assert trace.trace_pos == 10
+    assert trace.trace_pos == trace.trace[0]
+
+    trace_shifted = trace + 10
+    assert trace_shifted.trace_pos == 20
+    assert trace_shifted.trace[0] == 20
+
+    with pytest.raises(AttributeError):
+        # this attribute shouldn't be writable:
+        trace_shifted.trace_pos = 15

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -10,7 +10,7 @@ from astropy.stats import gaussian_sigma_to_fwhm
 from scipy.interpolate import UnivariateSpline
 import numpy as np
 
-__all__ = ['Trace', 'Trace', 'FlatTrace', 'ArrayTrace', 'KosmosTrace']
+__all__ = ['Trace', 'FlatTrace', 'ArrayTrace', 'KosmosTrace']
 
 
 @dataclass(init=False, frozen=True)

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -133,6 +133,19 @@ class FlatTrace(Trace):
     def trace_pos(self):
         return self._trace_pos
 
+    def shift(self, delta):
+        """
+        Shift the trace by delta pixels perpendicular to the axis being traced
+
+        Parameters
+        ----------
+        delta : float
+            Shift to be applied to the trace
+        """
+        # act on self._trace.data to ignore the mask and then re-mask when calling _bound_trace
+        object.__setattr__(self, '_trace_pos', self._trace_pos + delta)
+        super().shift(delta)
+
 
 @dataclass(init=False, frozen=True)
 class ArrayTrace(Trace):


### PR DESCRIPTION
#126 points out that you can edit attributes of the `Trace` class in such a way that they are no longer self-consistent with each other.

In this PR, I've found a way to recast the `*Trace`s as subclasses of a new `BaseTrace` (perhaps there's a better name?). These classes all use `@dataclass(frozen=True)` which enforces that their attributes are immutable for the user-facing API. Under the hood, there's a slightly ugly workaround which allows us to (re)set these "read-only" attributes via the public-facing methods like `Trace.shift`, for example. 

Happy to discuss as needed!

Fixes #126

### Tiny demo

```python
import pytest
from specreduce.utils.synth_data import make_2dspec_image
from specreduce.tracing import FlatTrace

img = make_2dspec_image()

trace = FlatTrace(img, 10)
print(trace.trace_pos, trace.trace[0])
# used to produce: 10, 10
# now produces: 10, 10

trace_shifted = trace + 10
print(trace_shifted.trace_pos, trace_shifted.trace[0])
# used to produce: 10, 20
# now produces: 20, 20

with pytest.raises(AttributeError):
    # this didn't raise an error before, but does now
    trace_shifted.trace_pos = 15
```