### PR TITLE
Introducing spectral extractions for non-flat traces

### DIFF
--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -177,7 +177,6 @@ def test_horne_non_flat_trace():
     # all zeros are treated as non-weighted (give non-zero fluxes)
     err = 0.1 * np.ones_like(rolled)
     mask = np.zeros_like(rolled).astype(bool)
-    extract = HorneExtract(rolled, exact_trace, variance=err, mask=mask, unit=u.Jy)
 
     # unroll the trace using the Horne extract utility function for alignment:
     unrolled = _align_along_trace(rolled, n_rows // 2 - trace_offset)

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -2,9 +2,16 @@ import numpy as np
 import pytest
 
 import astropy.units as u
+<<<<<<< HEAD
 from astropy.nddata import CCDData, VarianceUncertainty, UnknownUncertainty
+=======
+from astropy.nddata import CCDData
+from astropy.tests.helper import assert_quantity_allclose
+>>>>>>> 12316d2 (Adding test coverage for Horne extraction with non-flat traces)
 
-from specreduce.extract import BoxcarExtract, HorneExtract, OptimalExtract
+from specreduce.extract import (
+    BoxcarExtract, HorneExtract, OptimalExtract, _align_along_trace
+)
 from specreduce.tracing import FlatTrace, ArrayTrace
 
 
@@ -149,3 +156,46 @@ def test_horne_variance_errors():
         # object doesn't have those attributes (e.g., numpy and Quantity arrays)
         ext = extract(image=image.data, variance=err,
                       mask=image.mask, unit=u.Jy)
+
+
+def test_horne_non_flat_trace():
+    # create a synthetic "2D spectrum" and its non-flat trace
+    n_rows, n_cols = (10, 50)
+    original = np.zeros((n_rows, n_cols))
+    original[n_rows // 2] = 1
+
+    # create small offsets along each column to specify a non-flat trace
+    trace_offset = np.polyval([2e-3, -0.01, 0], np.arange(n_cols)).astype(int)
+    exact_trace = n_rows // 2 - trace_offset
+
+    # re-index the array with the offsets applied to the trace (make it non-flat):
+    rows = np.broadcast_to(np.arange(n_rows)[:, None], original.shape)
+    cols = np.broadcast_to(np.arange(n_cols), original.shape)
+    roll_rows = np.mod(rows + trace_offset[None, :], n_rows)
+    rolled = original[roll_rows, cols]
+
+    # all zeros are treated as non-weighted (give non-zero fluxes)
+    err = 0.1 * np.ones_like(rolled)
+    mask = np.zeros_like(rolled).astype(bool)
+    extract = HorneExtract(rolled, exact_trace, variance=err, mask=mask, unit=u.Jy)
+
+    # unroll the trace using the Horne extract utility function for alignment:
+    unrolled = _align_along_trace(rolled, n_rows // 2 - trace_offset)
+
+    # ensure that mask is correctly unrolled back to its original alignment:
+    np.testing.assert_allclose(unrolled, original)
+
+    # Extract the spectrum from the non-flat image+trace
+    extract_non_flat = HorneExtract(
+        rolled, ArrayTrace(rolled, exact_trace),
+        variance=err, mask=mask, unit=u.Jy
+    )()
+
+    # Also extract the spectrum from the image after alignment with a flat trace
+    extract_flat = HorneExtract(
+        unrolled, FlatTrace(unrolled, n_rows // 2),
+        variance=err, mask=mask, unit=u.Jy
+    )()
+
+    # ensure both extractions are equivalent:
+    assert_quantity_allclose(extract_non_flat.flux, extract_flat.flux)


### PR DESCRIPTION
### Description 

This PR implements Horne spectral extraction with non-flat traces. For a demo, see [this example notebook](https://gist.github.com/bmorris3/428a0b012305fd6742c944f2c3c11a04).

specreduce Horne extractions currently support flat traces. In the flat trace case, the sum of the spectrum in the dispersion dimension produces a flux profile in the spatial dimension, which we fit with a (1D) Gaussian. The model profile is used to construct a kernel, which applies weights to each pixel in the extracted 1D spectrum.

For a non-flat trace, the profile in the will be "smeared" when summed in the dispersion dimension, which is not accurately approximated by a Gaussian. Less flat traces will produce poorer kernels, and less accurate spectral extractions. 

The trick used here to support non-flat traces is to roll the pixels along the spatial dimension until the trace is flat, and then perform the extraction on the shifted image as usual. There are no actual changes to the Horne implementation, just a manipulation of the image in the case of a non-flat trace to "make it flat".

The trick within the trick is that we can use fancy indexing to flatten the trace without interpolation or resampling, and do it efficiently. In this PR, we only re-index the underlying image. 

My strategy here is to (1) never make up data (no interp/sampling business), and (2) keep the diff small. 

### Possible Improvements
* We'll need some tests and documentation, of course. (I'm posting this draft PR to get initial feedback.)
* @kecnry pointed out a possible (small?) improvement. This PR casts floats in the trace to integers for rolling the pixels along the spatial dimension (without interpolation). That means we can expect a small spatial difference between the center of the spatial profile and the intended center of the new flat trace. We could pass along that small difference to the initial guess for the mean in the Gaussian 1D spatial profile. This may not affect the results much, because the rolls are accurate to better than a pixel, and the spatial width of the observed trace is usually a few pixels -- so the initial guess is usually good enough.

Closes #102

[🐱](https://jira.stsci.edu/browse/JDAT-2389)