### PR TITLE
Fix changelog formatting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,19 +4,25 @@
 New Features
 ^^^^^^^^^^^^
 
-- The new FitTrace class (see "API Changes" below) introduces the ability to
-take a polynomial trace of an image [#128]
+- The new FitTrace class (see "API Changes" below) introduces the
+  ability to take a polynomial trace of an image [#128]
 
 API Changes
 ^^^^^^^^^^^
 
-- Renamed KosmosTrace as FitTrace, a conglomerate class for traces that are fit
-to images instead of predetermined [#128]
-- The default number of bins for FitTrace is now its associated image's number
-of dispersion pixels instead of 20. Its default peak_method is now 'max' [#128]
-- All operations now accept Spectrum1D and Quantity-type images. All accepted
-image types are now processed internally as Spectrum1D objects [#144]
-- All operations' ``image`` attributes are now coerced Spectrum1D objects [#144]
+- Renamed KosmosTrace as FitTrace, a conglomerate class for traces that
+  are fit to images instead of predetermined [#128]
+
+- The default number of bins for FitTrace is now its associated image's
+  number of dispersion pixels instead of 20. Its default peak_method is
+  now 'max' [#128]
+
+- All operations now accept Spectrum1D and Quantity-type images. All
+  accepted image types are now processed internally as Spectrum1D objects
+  [#144]
+
+- All operations' ``image`` attributes are now coerced Spectrum1D
+  objects [#144]
 
 Bug Fixes
 ^^^^^^^^^
@@ -24,25 +30,31 @@ Bug Fixes
 - Fixed passing a single ``Trace`` object to ``Background`` [#146]
 
 
-1.2.0
------
+1.2.0 (2022-10-04)
+------------------
 
 New Features
 ^^^^^^^^^^^^
-- ``Background`` has new methods for exposing the 1D spectrum of the background or
-  background-subtracted regions [#143]
+
+- ``Background`` has new methods for exposing the 1D spectrum of the
+  background or background-subtracted regions [#143]
 
 Bug Fixes
 ^^^^^^^^^
 
-- Improved errors/warnings when background region extends beyond bounds of image [#127]
-- Fixed boxcar weighting bug that often resulted in peak pixels having weight
-  above 1 and erroneously triggered overlapping background errors [#125]
-- Fixed boxcar weighting to handle zero width and edge of image cases [#141]
+- Improved errors/warnings when background region extends beyond bounds
+  of image [#127]
+
+- Fixed boxcar weighting bug that often resulted in peak pixels having
+  weight above 1 and erroneously triggered overlapping background errors
+  [#125]
+
+- Fixed boxcar weighting to handle zero width and edge of image cases
+  [#141]
 
 
-1.1.0
------
+1.1.0 (2022-08-18)
+------------------
 
 New Features
 ^^^^^^^^^^^^
@@ -53,30 +65,41 @@ API Changes
 ^^^^^^^^^^^
 
 - ``HorneExtract`` no longer requires ``mask`` and ``unit`` arguments [#105]
-- ``BoxcarExtract`` and ``HorneExtract`` now accept parameters (and require the image and trace)
-  at initialization, and allow overriding any input parameters when calling [#117]
+
+- ``BoxcarExtract`` and ``HorneExtract`` now accept parameters (and
+  require the image and trace) at initialization, and allow overriding any
+  input parameters when calling [#117]
 
 Bug Fixes
 ^^^^^^^^^
 
-- Corrected the default mask created in ``HorneExtract``/``OptimalExtract``
-  when a user doesn't specify one and gives their image as a numpy array [#118]
+- Corrected the default mask created in
+  ``HorneExtract``/``OptimalExtract`` when a user doesn't specify one and
+  gives their image as a numpy array [#118]
 
-1.0.0
------
+
+1.0.0 (2022-03-29)
+------------------
 
 New Features
 ^^^^^^^^^^^^
 
 - Added ``Trace`` classes
+
 - Added basic synthetic data routines
+
 - Added ``BoxcarExtract``
+
 - Added ``HorneExtract``, a.k.a. ``OptimalExtract``
+
 - Added basic ``Background`` subtraction
 
 Bug Fixes
 ^^^^^^^^^
 
 - Update ``codecov-action`` to ``v2``
+
 - Change default branch from ``master`` to ``main``
-- Test fixes; bump CI to python 3.8 and 3.9 and deprecate support for 3.7
+
+- Test fixes; bump CI to python 3.8 and 3.9 and deprecate support for
+  3.7


### PR DESCRIPTION
This PR fixes some formatting issues I noticed in the changelog.  It also adds dates for the releases.  Here's how it looks in GitHub:  https://github.com/larrybradley/specreduce/blob/fix-changelog/CHANGES.rst
