### PR TITLE
BUG: Handle invalid masked_invalid mask

### DIFF
--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -64,7 +64,7 @@ class _ImageParser:
             mask = image.mask
         else:
             mask = np.ma.masked_invalid(img).mask
-            if not mask:  # Could be False
+            if mask is False:  # Could be False
                 mask = None
 
         if getattr(image, 'uncertainty', None) is not None:

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -64,6 +64,8 @@ class _ImageParser:
             mask = image.mask
         else:
             mask = np.ma.masked_invalid(img).mask
+            if not mask:  # Could be False
+                mask = None
 
         if getattr(image, 'uncertainty', None) is not None:
             uncertainty = image.uncertainty


### PR DESCRIPTION
I came across this while investigating https://github.com/spacetelescope/jdaviz/issues/1877 . `np.ma.masked_invalid(img).mask` could return `False`. This is not being recognized by `specutils`, which will then emit a confusing message about the mask having mismatch shape `()`.

Possible suspects:

* https://github.com/numpy/numpy/pull/22046
* https://github.com/numpy/numpy/pull/22406

Also see:

* #153