### PR TITLE
TST: Add dev numpy to devdeps, fix compat with numpy 1.24

### DIFF
--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -75,6 +75,9 @@ class _ImageParser:
         spectral_axis = getattr(image, 'spectral_axis',
                                 np.arange(img.shape[disp_axis]) * u.pix)
 
+        if mask.ndim == np.ma.nomask:
+            mask = np.zeros(img.shape, dtype=bool)  # 0 = good
+
         return Spectrum1D(img * unit, spectral_axis=spectral_axis,
                           uncertainty=uncertainty, mask=mask)
 

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -359,6 +359,9 @@ class HorneExtract(SpecreduceOperation):
         else:
             mask = np.ma.masked_invalid(img).mask
 
+        if mask.ndim == np.ma.nomask:
+            mask = np.zeros(img.shape, dtype=bool)  # 0 = good
+
         if img.shape != mask.shape:
             raise ValueError('image and mask shapes must match.')
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,9 @@ isolated_build = true
 # Pass through the following environment variables which may be needed for the CI
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI
 
+setenv =
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree
 changedir = .tmp/{envname}
@@ -50,6 +53,7 @@ deps =
     astropy50: astropy==5.0.*
     astropylts: astropy==5.0.*
 
+    devdeps: numpy>=0.0.dev0
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
     devdeps: git+https://github.com/astropy/specutils.git#egg=specutils
 


### PR DESCRIPTION
This might smoke out the error that #151 is trying to fix.

I also see this error in https://github.com/astropy/astropy-integration-testing/actions/runs/3604333353/jobs/6073585087

Possible suspects:

* https://github.com/numpy/numpy/pull/22046
* https://github.com/numpy/numpy/pull/22406