### PR TITLE
Use simpler checks for invalid values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ Bug Fixes
 
 - Fixed passing a single ``Trace`` object to ``Background`` [#146]
 
+- Moved away from creating image masks with numpy's ``mask_inavlid()``
+function after change to upstream API [#155]
+
 
 1.2.0 (2022-10-04)
 ------------------

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -63,7 +63,7 @@ class _ImageParser:
         if getattr(image, 'mask', None) is not None:
             mask = image.mask
         else:
-            mask = np.ma.masked_invalid(img).mask
+            mask = ~np.isfinite(img)
 
         if getattr(image, 'uncertainty', None) is not None:
             uncertainty = image.uncertainty

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -357,7 +357,7 @@ class HorneExtract(SpecreduceOperation):
         elif mask is not None:
             pass
         else:
-            mask = np.ma.masked_invalid(img).mask
+            mask = ~np.isfinite(img)
 
         if img.shape != mask.shape:
             raise ValueError('image and mask shapes must match.')
@@ -486,7 +486,7 @@ class HorneExtract(SpecreduceOperation):
 
         # mask any previously uncaught invalid values
         or_mask = np.logical_or(mask,
-                                np.ma.masked_invalid(self.image.data).mask)
+                                ~np.isfinite(self.image.data))
         img = np.ma.masked_array(self.image.data, or_mask)
         mask = img.mask
 

--- a/specreduce/tests/test_image_parsing.py
+++ b/specreduce/tests/test_image_parsing.py
@@ -9,6 +9,7 @@ from specreduce.extract import HorneExtract
 from specreduce.tracing import FlatTrace
 from specutils import Spectrum1D, SpectralAxis
 
+
 # fetch test image
 fn = download_file('https://stsci.box.com/shared/static/exnkul627fcuhy5akf2gswytud5tazmw.fits',
                    cache=True)
@@ -96,7 +97,7 @@ def test_parse_horne():
             # requires a variance, so it's chosen here to be on equal footing
             # with the general case
             defaults = {'variance': unc_def,
-                        'mask': np.ma.masked_invalid(img).mask,
+                        'mask': ~np.isfinite(img),
                         'unit': getattr(img, 'unit', u.DN)}
 
         col[key] = HorneExtract._parse_image(object, img, **defaults)

--- a/specreduce/tests/test_tracing.py
+++ b/specreduce/tests/test_tracing.py
@@ -125,7 +125,7 @@ def test_fit_trace():
         FitTrace(img, bins=20., trace_model=models.Polynomial1D(2))
 
     # ensure non-equipped models are rejected
-    with pytest.raises(ValueError, match=r'trace_model must be one of*'):
+    with pytest.raises(ValueError, match=r'trace_model must be one of'):
         FitTrace(img, trace_model=models.Hermite1D(3))
 
     # ensure a bin number below 4 is rejected
@@ -137,23 +137,15 @@ def test_fit_trace():
         FitTrace(img, bins=4, trace_model=models.Chebyshev1D(5))
 
     # ensure number of bins greater than number of dispersion pixels is rejected
-    with pytest.raises(ValueError, match=r'bins must be <*'):
+    with pytest.raises(ValueError, match=r'bins must be <'):
         FitTrace(img, bins=ncols + 1)
 
     # error on trace of otherwise valid image with all-nan window around guess
-    try:
+    with pytest.raises(ValueError, match='pixels in window region are masked'):
         FitTrace(img_win_nans, guess=guess, window=window)
-    except ValueError as e:
-        print(f"(expected) All-NaN window error message: {e}")
-    else:
-        raise RuntimeError('Trace was erroneously calculated on all-NaN window')
 
     # error on trace of all-nan image
-    try:
+    with pytest.raises(ValueError, match=r'image is fully masked'):
         FitTrace(img_all_nans)
-    except ValueError as e:
-        print(f"(expected) All-NaN image error message: {e}")
-    else:
-        raise RuntimeError('Trace was erroneously calculated on all-NaN image')
 
     # could try to catch warning thrown for all-nan bins

--- a/specreduce/tests/test_tracing.py
+++ b/specreduce/tests/test_tracing.py
@@ -144,7 +144,7 @@ def test_fit_trace():
     try:
         FitTrace(img_win_nans, guess=guess, window=window)
     except ValueError as e:
-        print(f"All-NaN window error message: {e}")
+        print(f"(expected) All-NaN window error message: {e}")
     else:
         raise RuntimeError('Trace was erroneously calculated on all-NaN window')
 
@@ -152,7 +152,7 @@ def test_fit_trace():
     try:
         FitTrace(img_all_nans)
     except ValueError as e:
-        print(f"All-NaN image error message: {e}")
+        print(f"(expected) All-NaN image error message: {e}")
     else:
         raise RuntimeError('Trace was erroneously calculated on all-NaN image')
 

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -212,8 +212,7 @@ class FitTrace(Trace, _ImageParser):
         self.image = self._parse_image(self.image)
 
         # mask any previously uncaught invalid values
-        or_mask = np.logical_or(self.image.mask,
-                                np.ma.masked_invalid(self.image.data).mask)
+        or_mask = np.logical_or(self.image.mask, ~np.isfinite(self.image.data))
         img = np.ma.masked_array(self.image.data, or_mask)
 
         # validate arguments

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,9 @@ isolated_build = true
 # Pass through the following environment variables which may be needed for the CI
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI
 
+setenv =
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree
 changedir = .tmp/{envname}
@@ -50,6 +53,7 @@ deps =
     astropy50: astropy==5.0.*
     astropylts: astropy==5.0.*
 
+    devdeps: numpy>=0.0.dev0
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
     devdeps: git+https://github.com/astropy/specutils.git#egg=specutils
 


### PR DESCRIPTION
In response to findings from #153, I've changed most uses of `np.ma.mask_invalid()` to `~np.isfinite()` since we only sought a mask instead of an entire masked array object most times it was used. We do still want a masked array as the final result of `FitTrace`, so it remains in use there.

These changes should help tests pass with numpy v1.24.0rc1. Would close #153.