### PR TITLE
Prevent (most) NaN propagation in `Background` and `BoxcarExtract`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ Bug Fixes
 - Output 1D spectra from Background no longer include NaNs. Output 1D
 spectra from BoxcarExtract no longer include NaNs when none are present
 in the extraction window. NaNs in the window will still propagate to
-Boxcar1D's extracted 1D spectrum. [#159]
+BoxcarExtract's extracted 1D spectrum. [#159]
 
 - Backgrounds using median statistic properly ignore zero-weighted pixels
 [#159]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ API Changes
 Bug Fixes
 ^^^^^^^^^
 
+- Output 1D spectra from Background and BoxcarExtract no longer propagate
+NaNs in source images that contain them as long as none are present in the
+specified background window [#159]
+
 
 1.3.0 (2022-12-05)
 ------------------
@@ -47,6 +51,7 @@ Bug Fixes
 - Moved away from creating image masks with numpy's ``mask_invalid()``
   function after change to upstream API. This will make specreduce
   be compatible with numpy 1.24 or later. [#155]
+
 
 1.2.0 (2022-10-04)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,9 +10,13 @@ API Changes
 Bug Fixes
 ^^^^^^^^^
 
-- Output 1D spectra from Background and BoxcarExtract no longer propagate
-NaNs in source images that contain them as long as none are present in the
-specified background window [#159]
+- Output 1D spectra from Background no longer include NaNs. Output 1D
+spectra from BoxcarExtract no longer include NaNs when none are present
+in the extraction window. NaNs in the window will still propagate to
+Boxcar1D's extracted 1D spectrum. [#159]
+
+- Backgrounds using median statistic properly ignore zero-weighted pixels
+[#159]
 
 
 1.3.0 (2022-12-05)

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -236,8 +236,10 @@ class BoxcarExtract(SpecreduceOperation):
             crossdisp_axis,
             self.image.shape)
 
-        # extract
-        ext1d = np.sum(self.image.data * wimg, axis=crossdisp_axis)
+        # extract, assigning no weight to non-finite pixels outside the window
+        # (non-finite pixels inside the window will still make it into the sum)
+        image_windowed = np.where(wimg, self.image.data*wimg, 0)
+        ext1d = np.sum(image_windowed, axis=crossdisp_axis)
         return Spectrum1D(ext1d * self.image.unit,
                           spectral_axis=self.image.spectral_axis)
 


### PR DESCRIPTION
This pull request should be part 1 of a multi-pronged response to #158. Tests are forthcoming.

### `Background`

Goal: NaNs outside the user-specified window should not propagate into the 1D spectrum of the background or the background-subtracted image. NaNs inside the user-specified window should be ignored.

Approach:
- Adjusted `_bkg_array`:
  - Take the user-provided mask (if it exists) into account by bringing in the `or_mask` approach from `HorneExtract` that also masks non-finite pixels.
  - Fixed a possible mistake in the `statistic='median'` case that may have previously allowed zero-weighted pixels to still make it into the median calculation.
- `bkg_image()` and `sub_image()` don't appear to need changes as long as `_bkg_array` handles NaNs appropriately.
- `bkg_spectrum()` and `sub_spectrum()` just need `np.sum` changed to `np.nansum`.

### `BoxcarExtract`

Goal: As with `Background`, NaNs outside the user-specified window should not propagate into the extracted 1D spectrum. _Unlike with `Background`_, NaNs inside the user-specified window should propagate to the extracted 1D spectrum. Zeroing them out of the sum could lure less careful users into finding spectral features that don't actually exist.

Approach:
- Assign no weight to non-finite pixels with zero weight while summing each column. This case needs to be handled specially because `np.nan * 0 = np.nan`, not 0. `_parse_image()` can't help because, for now, it only either adopts the user's mask or, if none is provided, masks every non-finite pixel. It can't only mask non-finite pixels outside the window.
  - The better approach going forward may be for `_parse_image()` to always defer to the user's mask, even if none is provided. Making our operations more resistant to unmasked NaNs we may see as a result would require major changes in another ticket.