### PR TITLE
Update passenv syntax for tox 4.0.8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ isolated_build = true
 [testenv]
 
 # Pass through the following environment variables which may be needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI
+passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI
 
 setenv =
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple

--- a/tox.ini
+++ b/tox.ini
@@ -36,8 +36,6 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy118: with numpy 1.18.*
-    numpy119: with numpy 1.19.*
     numpy120: with numpy 1.20.*
     numpy121: with numpy 1.21.*
     astropylts: with the latest astropy LTS
@@ -45,13 +43,11 @@ description =
 # The following provides some specific pinnings for key packages
 deps =
 
-    numpy118: numpy==1.18.*
-    numpy119: numpy==1.19.*
     numpy120: numpy==1.20.*
     numpy121: numpy==1.21.*
 
-    astropy50: astropy==5.0.*
-    astropylts: astropy==5.0.*
+    astropy51: astropy==5.1.*
+    astropylts: astropy==5.1.*
 
     devdeps: numpy>=0.0.dev0
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
@@ -59,12 +55,12 @@ deps =
 
     datadeps: git+https://github.com/astropy/specreduce-data.git#egg=specreduce_data
 
-    oldestdeps: numpy==1.18
-    oldestdeps: astropy==5.0
+    oldestdeps: numpy==1.20
+    oldestdeps: astropy==5.1
     oldestdeps: scipy==1.6.0
-    oldestdeps: matplotlib==3.4
+    oldestdeps: matplotlib==3.5
     oldestdeps: photutils==1.0.0
-    oldestdeps: specutils==1.7.0
+    oldestdeps: specutils==1.9.1
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =


### PR DESCRIPTION
Reacting to an upstream update by `tox`, as in spacetelescope/jdaviz#1916.