### PR TITLE
Implement 1D wavelength calibration classes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,7 +174,8 @@ intersphinx_mapping.update(
     {
         'astropy': ('https://docs.astropy.org/en/stable/', None),
         'ccdproc': ('https://ccdproc.readthedocs.io/en/stable/', None),
-        'specutils': ('https://specutils.readthedocs.io/en/stable/', None)
+        'specutils': ('https://specutils.readthedocs.io/en/stable/', None),
+        'gwcs': ('https://gwcs.readthedocs.io/en/stable/', None)
     }
 )
 #

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,7 @@ Calibration
 .. toctree::
     :maxdepth: 1
 
+    wavelength_calibration.rst
     extinction.rst
     specphot_standards.rst
 

--- a/docs/wavelength_calibration.rst
+++ b/docs/wavelength_calibration.rst
@@ -17,20 +17,20 @@ spectrum, you can currently use ``specreduce`` to:
 The `~specreduce.wavelength_calibration.WavelengthCalibration1D` class can be used
 to fit a dispersion model to a list of line positions and wavelengths. Future development
 will implement catalogs of known lamp spectra for use in matching observed lines. In the
-example below, the line positions (``line_list``) have already been extracted from
+example below, the line positions (``pixel_centers``) have already been extracted from
 ``lamp_spectrum``::
 
     import astropy.units as u
 	 from specreduce import WavelengthCalibration1D
-	 line_list = [10, 22, 31, 43]
+	 pixel_centers = [10, 22, 31, 43]
 	 wavelengths = [5340, 5410, 5476, 5543]*u.AA
-	 test_cal = WavelengthCalibration1D(lamp_spectrum, line_list,
-												  line_wavelengths=wavelengths)
+	 test_cal = WavelengthCalibration1D(lamp_spectrum, line_pixels=pixel_centers,
+										line_wavelengths=wavelengths)
     calibrated_spectrum = test_cal.apply_to_spectrum(science_spectrum)
 
 The example above uses the default model (`~astropy.modeling.functional_models.Linear1D`)
 to fit the input spectral lines, and then applies the calculated WCS solution to a second
-spectrum (``science_spectrum``). Any other ``astropy`` model can be provided as the
+spectrum (``science_spectrum``). Any other 1D ``astropy`` model can be provided as the
 input ``model`` parameter to the `~specreduce.wavelength_calibration.WavelengthCalibration1D`.
 In the above example, the model fit and WCS construction is all done as part of the
 ``apply_to_spectrum()`` call, but you could also access the `~gwcs.wcs.WCS` object itself
@@ -43,10 +43,11 @@ or ``input_spectrum`` properties are updated, since these will alter the calcula
 fit.
 
 You can also provide the input pixel locations and wavelengths of the lines as an
-`~astropy.table.QTable`, with columns ``pixel_center`` and ``wavelength``::
+`~astropy.table.QTable` with (at minimum) columns ``pixel_center`` and ``wavelength``,
+using the ``matched_line_list`` input argument::
 
     from astropy.table import QTable
     pixels = [10, 20, 30, 40]*u.pix
     wavelength = [5340, 5410, 5476, 5543]*u.AA
     line_list = QTable([pixels, wavelength], names=["pixel_center", "wavelength"])
-    test_cal = WavelengthCalibration1D(lamp_spectrum, line_list)
+    test_cal = WavelengthCalibration1D(lamp_spectrum, matched_line_list=line_list)

--- a/docs/wavelength_calibration.rst
+++ b/docs/wavelength_calibration.rst
@@ -1,0 +1,71 @@
+.. _wavelength_calibration:
+
+Wavelength Calibration
+======================
+
+Wavelength calibration is currently supported for 1D spectra. Given a list of spectral
+lines with known wavelengths and estimated pixel positions on an input calibration
+spectrum, you can currently use ``specreduce`` to:
+
+#. Refine the pixel position estimates of the lines based on features in the input
+   calibration spectrum.
+#. Fit an ``astropy`` model to the wavelength/pixel pairs to generate a spectral WCS
+   solution for the dispersion.
+#. Apply the generated spectral WCS to other `~specutils.Spectrum1D` objects.
+
+Calibration Lines
+-----------------
+
+``specreduce`` provides a `~specreduce.wavelength_calibration.CalibrationLine` class for
+encoding the information about each spectral line to be used in the dispersion model
+solution fitting. The minimum information required is the wavelength and estimated pixel
+location on the calibration spectrum of each line. By default, no refinement of the pixel
+position is done; to enable this feature you must provide a refinement method and any
+associated keywords (currently ``range`` defines the number of pixels on either side
+of the estimated location to use for all available refinement options). For example,
+to define a line and use ``specreduce`` to update the pixel location the the centroid
+of a gaussian fit to the line, you would do the following::
+
+	import astropy.units as u
+	from specreduce import CalibrationLine
+	test_line = CalibrationLine(calibration_spectrum, 6562.81*u.AA, 500,
+							   refinement_method="gaussian",
+							   refinement_kwargs={"range": 10})
+	refined_line = test_line.with_refined_pixel()
+
+Note that in this example and in the example below, ``calibration_spectrum`` is a
+`~specutils.Spectrum1D` spectrum to be used to refine the line locations (for example
+a lamp spectrum).
+
+1D Wavelength Calibration
+-------------------------
+
+Of course, refining the location of a line is only really useful when done for multiple
+lines to be fit as part of the dispersion model. This can be accomplished with the
+`~specreduce.wavelength_calibration.WavelengthCalibration1D` class as follows below.
+Note that the lines can be input as simple (wavelength, pixel) pairs rather than as
+`~specreduce.wavelength_calibration.CalibrationLine` objects - in this case the
+``default_refinement_method`` and ``default_refinement_kwargs`` will be applied to
+each input line::
+
+	import astropy.units as u
+	from specreduce import WavelengthCalibration1D
+	test_cal = WavelengthCalibration1D(calibration_spectrum,
+									   [(5000*u.AA, 0), (5100*u.AA, 10),
+									    (5198*u.AA, 20), (5305*u.AA, 30)],
+                                       default_refinement_method="gaussian")
+    calibrated_spectrum = test_cal.apply_to_spectrum(science_spectrum)
+
+The example above uses the default model (`~astropy.modeling.functional_models.Linear1D`)
+to fit the input spectral lines, and then applies the calculated WCS solution to a second
+spectrum (``science_spectrum``). Any other ``astropy`` model can be provided as the
+input ``model`` parameter to the `~specreduce.wavelength_calibration.WavelengthCalibration1D`.
+In the above example, the model fit and WCS construction is all done as part of the
+``apply_to_spectrum()`` call, but you could also access the `~gwcs.wcs.WCS` object itself
+by calling::
+
+	test_cal.wcs
+
+The calculated WCS is a cached property that will be cleared if the ``lines``, ``model``,
+or ``input_spectrum`` properties are updated, since these will alter the calculated dispersion
+fit.

--- a/docs/wavelength_calibration.rst
+++ b/docs/wavelength_calibration.rst
@@ -7,53 +7,25 @@ Wavelength calibration is currently supported for 1D spectra. Given a list of sp
 lines with known wavelengths and estimated pixel positions on an input calibration
 spectrum, you can currently use ``specreduce`` to:
 
-#. Refine the pixel position estimates of the lines based on features in the input
-   calibration spectrum.
 #. Fit an ``astropy`` model to the wavelength/pixel pairs to generate a spectral WCS
    solution for the dispersion.
 #. Apply the generated spectral WCS to other `~specutils.Spectrum1D` objects.
 
-Calibration Lines
------------------
-
-``specreduce`` provides a `~specreduce.wavelength_calibration.CalibrationLine` class for
-encoding the information about each spectral line to be used in the dispersion model
-solution fitting. The minimum information required is the wavelength and estimated pixel
-location on the calibration spectrum of each line. By default, no refinement of the pixel
-position is done; to enable this feature you must provide a refinement method and any
-associated keywords (currently ``range`` defines the number of pixels on either side
-of the estimated location to use for all available refinement options). For example,
-to define a line and use ``specreduce`` to update the pixel location the the centroid
-of a gaussian fit to the line, you would do the following::
-
-	import astropy.units as u
-	from specreduce import CalibrationLine
-	test_line = CalibrationLine(calibration_spectrum, 6562.81*u.AA, 500,
-							   refinement_method="gaussian",
-							   refinement_kwargs={"range": 10})
-	refined_line = test_line.with_refined_pixel()
-
-Note that in this example and in the example below, ``calibration_spectrum`` is a
-`~specutils.Spectrum1D` spectrum to be used to refine the line locations (for example
-a lamp spectrum).
-
 1D Wavelength Calibration
 -------------------------
 
-Of course, refining the location of a line is only really useful when done for multiple
-lines to be fit as part of the dispersion model. This can be accomplished with the
-`~specreduce.wavelength_calibration.WavelengthCalibration1D` class as follows below.
-Note that the lines can be input as simple (wavelength, pixel) pairs rather than as
-`~specreduce.wavelength_calibration.CalibrationLine` objects - in this case the
-``default_refinement_method`` and ``default_refinement_kwargs`` will be applied to
-each input line::
+The `~specreduce.wavelength_calibration.WavelengthCalibration1D` class can be used
+to fit a dispersion model to a list of line positions and wavelengths. Future development
+will implement catalogs of known lamp spectra for use in matching observed lines. In the
+example below, the line positions (``line_list``) have already been extracted from
+``lamp_spectrum``::
 
-	import astropy.units as u
-	from specreduce import WavelengthCalibration1D
-	test_cal = WavelengthCalibration1D(calibration_spectrum,
-									   [(5000*u.AA, 0), (5100*u.AA, 10),
-									    (5198*u.AA, 20), (5305*u.AA, 30)],
-                                       default_refinement_method="gaussian")
+    import astropy.units as u
+	 from specreduce import WavelengthCalibration1D
+	 line_list = [10, 22, 31, 43]
+	 wavelengths = [5340, 5410, 5476, 5543]*u.AA
+	 test_cal = WavelengthCalibration1D(lamp_spectrum, line_list,
+												  line_wavelengths=wavelengths)
     calibrated_spectrum = test_cal.apply_to_spectrum(science_spectrum)
 
 The example above uses the default model (`~astropy.modeling.functional_models.Linear1D`)
@@ -64,8 +36,17 @@ In the above example, the model fit and WCS construction is all done as part of 
 ``apply_to_spectrum()`` call, but you could also access the `~gwcs.wcs.WCS` object itself
 by calling::
 
-	test_cal.wcs
+    test_cal.wcs
 
-The calculated WCS is a cached property that will be cleared if the ``lines``, ``model``,
+The calculated WCS is a cached property that will be cleared if the ``line_list``, ``model``,
 or ``input_spectrum`` properties are updated, since these will alter the calculated dispersion
 fit.
+
+You can also provide the input pixel locations and wavelengths of the lines as an
+`~astropy.table.QTable`, with columns ``pixel_center`` and ``wavelength``::
+
+    from astropy.table import QTable
+    pixels = [10, 20, 30, 40]*u.pix
+    wavelength = [5340, 5410, 5476, 5543]*u.AA
+    line_list = QTable([pixels, wavelength], names=["pixel_center", "wavelength"])
+    test_cal = WavelengthCalibration1D(lamp_spectrum, line_list)

--- a/specreduce/__init__.py
+++ b/specreduce/__init__.py
@@ -7,3 +7,4 @@ from ._astropy_init import *   # noqa
 # ----------------------------------------------------------------------------
 
 from specreduce.core import *  # noqa
+from specreduce.wavelength_calibration import * # noqa

--- a/specreduce/conftest.py
+++ b/specreduce/conftest.py
@@ -6,6 +6,10 @@
 import os
 
 from astropy.version import version as astropy_version
+import astropy.units as u
+import numpy as np
+import pytest
+from specutils import Spectrum1D
 
 # For Astropy 3.0 and later, we can use the standalone pytest plugin
 if astropy_version < '3.0':
@@ -19,6 +23,33 @@ else:
     except ImportError:
         ASTROPY_HEADER = False
 
+@pytest.fixture
+def spec1d():
+    np.random.seed(7)
+    flux = np.random.random(50)*u.Jy
+    sa = np.arange(0, 50)*u.pix
+    spec = Spectrum1D(flux, spectral_axis=sa)
+    return spec
+
+@pytest.fixture
+def spec1d_with_emission_line():
+    np.random.seed(7)
+    sa = np.arange(0, 200)*u.pix
+    flux = (np.random.randn(200) +
+             10*np.exp(-0.01*((sa.value-130)**2)) +
+             sa.value/100) * u.Jy
+    spec = Spectrum1D(flux, spectral_axis=sa)
+    return spec
+
+@pytest.fixture
+def spec1d_with_absorption_line():
+    np.random.seed(7)
+    sa = np.arange(0, 200)*u.pix
+    flux = (np.random.randn(200) -
+             10*np.exp(-0.01*((sa.value-130)**2)) +
+             sa.value/100) * u.Jy
+    spec = Spectrum1D(flux, spectral_axis=sa)
+    return spec
 
 def pytest_configure(config):
 

--- a/specreduce/conftest.py
+++ b/specreduce/conftest.py
@@ -23,6 +23,7 @@ else:
     except ImportError:
         ASTROPY_HEADER = False
 
+
 @pytest.fixture
 def spec1d():
     np.random.seed(7)
@@ -31,25 +32,28 @@ def spec1d():
     spec = Spectrum1D(flux, spectral_axis=sa)
     return spec
 
+
 @pytest.fixture
 def spec1d_with_emission_line():
     np.random.seed(7)
     sa = np.arange(0, 200)*u.pix
     flux = (np.random.randn(200) +
-             10*np.exp(-0.01*((sa.value-130)**2)) +
-             sa.value/100) * u.Jy
+            10*np.exp(-0.01*((sa.value-130)**2)) +
+            sa.value/100) * u.Jy
     spec = Spectrum1D(flux, spectral_axis=sa)
     return spec
+
 
 @pytest.fixture
 def spec1d_with_absorption_line():
     np.random.seed(7)
     sa = np.arange(0, 200)*u.pix
     flux = (np.random.randn(200) -
-             10*np.exp(-0.01*((sa.value-130)**2)) +
-             sa.value/100) * u.Jy
+            10*np.exp(-0.01*((sa.value-130)**2)) +
+            sa.value/100) * u.Jy
     spec = Spectrum1D(flux, spectral_axis=sa)
     return spec
+
 
 def pytest_configure(config):
 

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -1,69 +1,52 @@
 from numpy.testing import assert_allclose
 
+from astropy.table import QTable
 import astropy.units as u
 from astropy.modeling.models import Polynomial1D
 from astropy.tests.helper import assert_quantity_allclose
 
-from specreduce import CalibrationLine, WavelengthCalibration1D
+from specreduce import WavelengthCalibration1D
 
 
 def test_linear_from_list(spec1d):
-    test = WavelengthCalibration1D(spec1d, [(5000*u.AA, 0), (5100*u.AA, 10),
-                                            (5198*u.AA, 20), (5305*u.AA, 30)])
+    centers = [0, 10, 20, 30]
+    w = [5000, 5100, 5198, 5305]*u.AA
+    test = WavelengthCalibration1D(spec1d, centers, line_wavelengths=w)
     spec2 = test.apply_to_spectrum(spec1d)
 
     assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
     assert_quantity_allclose(spec2.spectral_axis[-1], 5495.169999*u.AA)
 
-
-def test_linear_from_calibrationline(spec1d):
-    lines = [CalibrationLine(spec1d, 5000*u.AA, 0), CalibrationLine(spec1d, 5100*u.AA, 10),
-             CalibrationLine(spec1d, 5198*u.AA, 20), CalibrationLine(spec1d, 5305*u.AA, 30)]
-    test = WavelengthCalibration1D(spec1d, lines)
+def test_linear_from_table(spec1d):
+    centers = [0, 10, 20, 30]
+    w = [5000, 5100, 5198, 5305]*u.AA
+    table = QTable([centers, w], names=["pixel_center", "wavelength"])
+    test = WavelengthCalibration1D(spec1d, table)
     spec2 = test.apply_to_spectrum(spec1d)
 
     assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
     assert_quantity_allclose(spec2.spectral_axis[-1], 5495.169999*u.AA)
 
-
-def test_poly_from_calibrationline(spec1d):
+def test_poly_from_table(spec1d):
     # This test is mostly to prove that you can use other models
-    lines = [CalibrationLine(spec1d, 5005*u.AA, 0), CalibrationLine(spec1d, 5110*u.AA, 10),
-             CalibrationLine(spec1d, 5214*u.AA, 20), CalibrationLine(spec1d, 5330*u.AA, 30),
-             CalibrationLine(spec1d, 5438*u.AA, 40)]
-    test = WavelengthCalibration1D(spec1d, lines, model=Polynomial1D(2))
+    centers = [0, 10, 20, 30, 40]
+    w = [5005, 5110, 5214, 5330, 5438]*u.AA
+    table = QTable([centers, w], names=["pixel_center", "wavelength"])
+
+    test = WavelengthCalibration1D(spec1d, table, model=Polynomial1D(2))
     test.apply_to_spectrum(spec1d)
 
     assert_allclose(test.model.parameters, [5.00477143e+03, 1.03457143e+01, 1.28571429e-02])
 
 
-def test_calibrationline(spec1d_with_emission_line, spec1d_with_absorption_line):
-
-    line = CalibrationLine(spec1d_with_emission_line, 5000*u.AA, 128, refinement_method='gaussian',
-                           refinement_kwargs={'range': 25})
-    assert_allclose(line.refine(), 129.44371, atol=0.01)
-
-    line2 = CalibrationLine(spec1d_with_emission_line, 5000*u.AA, 130, refinement_method='max',
-                            refinement_kwargs={'range': 10})
-    assert line2.refine() == 128
-
-    line3 = CalibrationLine(spec1d_with_absorption_line, 5000*u.AA, 128, refinement_method='min',
-                            refinement_kwargs={'range': 10})
-    assert line3.refine() == 130
-
-
 def test_replace_spectrum(spec1d, spec1d_with_emission_line):
-    lines = [CalibrationLine(spec1d, 5000*u.AA, 0), CalibrationLine(spec1d, 5100*u.AA, 10),
-             CalibrationLine(spec1d, 5198*u.AA, 20), CalibrationLine(spec1d, 5305*u.AA, 30)]
-    test = WavelengthCalibration1D(spec1d, lines)
+    centers = [0, 10, 20, 30]*u.pix
+    w = [5000, 5100, 5198, 5305]*u.AA
+    test = WavelengthCalibration1D(spec1d, centers, line_wavelengths=w)
     # Accessing this property causes fits the model and caches the resulting WCS
     test.wcs
     assert "wcs" in test.__dict__
-    for line in test.lines:
-        assert "refined_pixel" in line.__dict__
 
     # Replace the input spectrum, which should clear the cached properties
     test.input_spectrum = spec1d_with_emission_line
     assert "wcs" not in test.__dict__
-    for line in test.lines:
-        assert "refined_pixel" not in line.__dict__

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -1,8 +1,10 @@
 from numpy.testing import assert_allclose
+import pytest
 
 from astropy.table import QTable
 import astropy.units as u
 from astropy.modeling.models import Polynomial1D
+from astropy.modeling.fitting import LinearLSQFitter
 from astropy.tests.helper import assert_quantity_allclose
 
 from specreduce import WavelengthCalibration1D
@@ -16,6 +18,13 @@ def test_linear_from_list(spec1d):
 
     assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
     assert_quantity_allclose(spec2.spectral_axis[-1], 5495.169999*u.AA)
+
+
+def test_wavelength_from_table(spec1d):
+    centers = [0, 10, 20, 30]
+    w = [5000, 5100, 5198, 5305]*u.AA
+    table = QTable([w], names=["wavelength"])
+    WavelengthCalibration1D(spec1d, centers, line_wavelengths=table)
 
 
 def test_linear_from_table(spec1d):
@@ -35,7 +44,7 @@ def test_poly_from_table(spec1d):
     w = [5005, 5110, 5214, 5330, 5438]*u.AA
     table = QTable([centers, w], names=["pixel_center", "wavelength"])
 
-    test = WavelengthCalibration1D(spec1d, table, model=Polynomial1D(2))
+    test = WavelengthCalibration1D(spec1d, table, model=Polynomial1D(2), fitter=LinearLSQFitter())
     test.apply_to_spectrum(spec1d)
 
     assert_allclose(test.model.parameters, [5.00477143e+03, 1.03457143e+01, 1.28571429e-02])
@@ -52,3 +61,23 @@ def test_replace_spectrum(spec1d, spec1d_with_emission_line):
     # Replace the input spectrum, which should clear the cached properties
     test.input_spectrum = spec1d_with_emission_line
     assert "wcs" not in test.__dict__
+
+
+def test_expected_errors(spec1d):
+    centers = [0, 10, 20, 30, 40]
+    w = [5005, 5110, 5214, 5330, 5438]*u.AA
+    table = QTable([centers, w], names=["pixel_center", "wavelength"])
+
+    with pytest.raises(ValueError, match="Cannot specify line_wavelengths separately"):
+        WavelengthCalibration1D(spec1d, table, line_wavelengths=w)
+
+    with pytest.raises(ValueError, match="must have the same length"):
+        w2 = [5005, 5110, 5214, 5330, 5438, 5500]*u.AA
+        WavelengthCalibration1D(spec1d, table, line_wavelengths=w2)
+
+    with pytest.raises(ValueError, match="must have the same length"):
+        w2 = [5005, 5110, 5214, 5330, 5438, 5500]*u.AA
+        WavelengthCalibration1D(spec1d, table, line_wavelengths=w2)
+
+    with pytest.raises(ValueError, match="specify at least one"):
+        WavelengthCalibration1D(spec1d, centers)

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+
+import astropy.units as u
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils.exceptions import AstropyUserWarning
+from specutils import Spectrum1D
+
+from specreduce.wavelength_calibration import CalibrationLine, WavelengthCalibration1D
+
+def test_linear_from_list():
+    np.random.seed(7)
+    flux = np.random.random(50)*u.Jy
+    sa = np.arange(0,50)*u.pix
+    spec = Spectrum1D(flux, spectral_axis = sa)
+    test = WavelengthCalibration1D(spec, [(5000*u.AA, 0),(5100*u.AA, 10),(5198*u.AA, 20),(5305*u.AA, 30)])
+    with pytest.warns(AstropyUserWarning, match="Model is linear in parameters"):
+        spec2 = test.apply_to_spectrum(spec)
+    
+    assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
+    assert_quantity_allclose(spec2.spectral_axis[-1], 5495.169999*u.AA)
+
+
+def test_linear_from_calibrationline():
+    np.random.seed(7)
+    flux = np.random.random(50)*u.Jy
+    sa = np.arange(0,50)*u.pix
+    spec = Spectrum1D(flux, spectral_axis = sa)
+    lines = [CalibrationLine(spec, 5000*u.AA, 0), CalibrationLine(spec, 5100*u.AA, 10),
+             CalibrationLine(spec, 5198*u.AA, 20), CalibrationLine(spec, 5305*u.AA, 30)]
+    test = WavelengthCalibration1D(spec, lines)
+    with pytest.warns(AstropyUserWarning, match="Model is linear in parameters"):
+        spec2 = test.apply_to_spectrum(spec)
+    
+    assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
+    assert_quantity_allclose(spec2.spectral_axis[-1], 5495.169999*u.AA)

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -17,6 +17,7 @@ def test_linear_from_list(spec1d):
     assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
     assert_quantity_allclose(spec2.spectral_axis[-1], 5495.169999*u.AA)
 
+
 def test_linear_from_table(spec1d):
     centers = [0, 10, 20, 30]
     w = [5000, 5100, 5198, 5305]*u.AA
@@ -26,6 +27,7 @@ def test_linear_from_table(spec1d):
 
     assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
     assert_quantity_allclose(spec2.spectral_axis[-1], 5495.169999*u.AA)
+
 
 def test_poly_from_table(spec1d):
     # This test is mostly to prove that you can use other models

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -8,15 +8,17 @@ from specutils import Spectrum1D
 
 from specreduce.wavelength_calibration import CalibrationLine, WavelengthCalibration1D
 
+
 def test_linear_from_list():
     np.random.seed(7)
     flux = np.random.random(50)*u.Jy
-    sa = np.arange(0,50)*u.pix
-    spec = Spectrum1D(flux, spectral_axis = sa)
-    test = WavelengthCalibration1D(spec, [(5000*u.AA, 0),(5100*u.AA, 10),(5198*u.AA, 20),(5305*u.AA, 30)])
+    sa = np.arange(0, 50)*u.pix
+    spec = Spectrum1D(flux, spectral_axis=sa)
+    test = WavelengthCalibration1D(spec, [(5000*u.AA, 0), (5100*u.AA, 10),
+                                          (5198*u.AA, 20), (5305*u.AA, 30)])
     with pytest.warns(AstropyUserWarning, match="Model is linear in parameters"):
         spec2 = test.apply_to_spectrum(spec)
-    
+
     assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
     assert_quantity_allclose(spec2.spectral_axis[-1], 5495.169999*u.AA)
 
@@ -24,13 +26,13 @@ def test_linear_from_list():
 def test_linear_from_calibrationline():
     np.random.seed(7)
     flux = np.random.random(50)*u.Jy
-    sa = np.arange(0,50)*u.pix
-    spec = Spectrum1D(flux, spectral_axis = sa)
+    sa = np.arange(0, 50)*u.pix
+    spec = Spectrum1D(flux, spectral_axis=sa)
     lines = [CalibrationLine(spec, 5000*u.AA, 0), CalibrationLine(spec, 5100*u.AA, 10),
              CalibrationLine(spec, 5198*u.AA, 20), CalibrationLine(spec, 5305*u.AA, 30)]
     test = WavelengthCalibration1D(spec, lines)
     with pytest.warns(AstropyUserWarning, match="Model is linear in parameters"):
         spec2 = test.apply_to_spectrum(spec)
-    
+
     assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
     assert_quantity_allclose(spec2.spectral_axis[-1], 5495.169999*u.AA)

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_allclose
 import pytest
 
 import astropy.units as u
@@ -8,31 +9,43 @@ from specutils import Spectrum1D
 
 from specreduce.wavelength_calibration import CalibrationLine, WavelengthCalibration1D
 
-
-def test_linear_from_list():
-    np.random.seed(7)
-    flux = np.random.random(50)*u.Jy
-    sa = np.arange(0, 50)*u.pix
-    spec = Spectrum1D(flux, spectral_axis=sa)
-    test = WavelengthCalibration1D(spec, [(5000*u.AA, 0), (5100*u.AA, 10),
+def test_linear_from_list(spec1d):
+    test = WavelengthCalibration1D(spec1d, [(5000*u.AA, 0), (5100*u.AA, 10),
                                           (5198*u.AA, 20), (5305*u.AA, 30)])
     with pytest.warns(AstropyUserWarning, match="Model is linear in parameters"):
-        spec2 = test.apply_to_spectrum(spec)
+        spec2 = test.apply_to_spectrum(spec1d)
 
     assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
     assert_quantity_allclose(spec2.spectral_axis[-1], 5495.169999*u.AA)
 
 
-def test_linear_from_calibrationline():
-    np.random.seed(7)
-    flux = np.random.random(50)*u.Jy
-    sa = np.arange(0, 50)*u.pix
-    spec = Spectrum1D(flux, spectral_axis=sa)
-    lines = [CalibrationLine(spec, 5000*u.AA, 0), CalibrationLine(spec, 5100*u.AA, 10),
-             CalibrationLine(spec, 5198*u.AA, 20), CalibrationLine(spec, 5305*u.AA, 30)]
-    test = WavelengthCalibration1D(spec, lines)
+def test_linear_from_calibrationline(spec1d):
+    lines = [CalibrationLine(spec1d, 5000*u.AA, 0), CalibrationLine(spec1d, 5100*u.AA, 10),
+             CalibrationLine(spec1d, 5198*u.AA, 20), CalibrationLine(spec1d, 5305*u.AA, 30)]
+    test = WavelengthCalibration1D(spec1d, lines)
     with pytest.warns(AstropyUserWarning, match="Model is linear in parameters"):
-        spec2 = test.apply_to_spectrum(spec)
+        spec2 = test.apply_to_spectrum(spec1d)
 
     assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
     assert_quantity_allclose(spec2.spectral_axis[-1], 5495.169999*u.AA)
+
+def test_calibrationline(spec1d_with_emission_line, spec1d_with_absorption_line):
+    with pytest.raises(ValueError, match="You must define 'range' in refinement_kwargs"):
+        line = CalibrationLine(spec1d_with_emission_line, 5000*u.AA, 128,
+                               refinement_method='gaussian')
+
+    with pytest.raises(ValueError, match="You must define 'direction' in refinement_kwargs"):
+        line = CalibrationLine(spec1d_with_emission_line, 5000*u.AA, 128,
+                               refinement_method='gradient')
+
+    line = CalibrationLine(spec1d_with_emission_line, 5000*u.AA, 128, refinement_method='gaussian',
+                           refinement_kwargs={'range': 25})
+    assert_allclose(line.refine(), 129.44371)
+
+    line2 = CalibrationLine(spec1d_with_emission_line, 5000*u.AA, 130, refinement_method='max',
+                            refinement_kwargs={'range': 10})
+    assert line2.refine() == 128
+
+    line3 = CalibrationLine(spec1d_with_absorption_line, 5000*u.AA, 128, refinement_method='min',
+                            refinement_kwargs={'range': 10})
+    assert line3.refine() == 130

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -1,17 +1,16 @@
-import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.exceptions import AstropyUserWarning
-from specutils import Spectrum1D
 
 from specreduce.wavelength_calibration import CalibrationLine, WavelengthCalibration1D
 
+
 def test_linear_from_list(spec1d):
     test = WavelengthCalibration1D(spec1d, [(5000*u.AA, 0), (5100*u.AA, 10),
-                                          (5198*u.AA, 20), (5305*u.AA, 30)])
+                                            (5198*u.AA, 20), (5305*u.AA, 30)])
     with pytest.warns(AstropyUserWarning, match="Model is linear in parameters"):
         spec2 = test.apply_to_spectrum(spec1d)
 
@@ -28,6 +27,7 @@ def test_linear_from_calibrationline(spec1d):
 
     assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
     assert_quantity_allclose(spec2.spectral_axis[-1], 5495.169999*u.AA)
+
 
 def test_calibrationline(spec1d_with_emission_line, spec1d_with_absorption_line):
     with pytest.raises(ValueError, match="You must define 'range' in refinement_kwargs"):

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -2,6 +2,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 import astropy.units as u
+from astropy.modeling.models import Polynomial1D
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -27,6 +28,17 @@ def test_linear_from_calibrationline(spec1d):
 
     assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
     assert_quantity_allclose(spec2.spectral_axis[-1], 5495.169999*u.AA)
+
+def test_poly_from_calibrationline(spec1d):
+    # This test is mostly to prove that you can use other models
+    lines = [CalibrationLine(spec1d, 5005*u.AA, 0), CalibrationLine(spec1d, 5110*u.AA, 10),
+             CalibrationLine(spec1d, 5214*u.AA, 20), CalibrationLine(spec1d, 5330*u.AA, 30),
+             CalibrationLine(spec1d, 5438*u.AA, 40)]
+    test = WavelengthCalibration1D(spec1d, lines, model=Polynomial1D(2))
+    with pytest.warns(AstropyUserWarning, match="Model is linear in parameters"):
+        spec2 = test.apply_to_spectrum(spec1d)
+        
+    assert_allclose(test.model.parameters, [5.00477143e+03, 1.03457143e+01, 1.28571429e-02])
 
 
 def test_calibrationline(spec1d_with_emission_line, spec1d_with_absorption_line):

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -39,13 +39,6 @@ def test_poly_from_calibrationline(spec1d):
 
 
 def test_calibrationline(spec1d_with_emission_line, spec1d_with_absorption_line):
-    with pytest.raises(ValueError, match="You must define 'range' in refinement_kwargs"):
-        line = CalibrationLine(spec1d_with_emission_line, 5000*u.AA, 128,
-                               refinement_method='gaussian')
-
-    with pytest.raises(ValueError, match="You must define 'direction' in refinement_kwargs"):
-        line = CalibrationLine(spec1d_with_emission_line, 5000*u.AA, 128,
-                               refinement_method='gradient')
 
     line = CalibrationLine(spec1d_with_emission_line, 5000*u.AA, 128, refinement_method='gaussian',
                            refinement_kwargs={'range': 25})

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -4,7 +4,7 @@ import astropy.units as u
 from astropy.modeling.models import Polynomial1D
 from astropy.tests.helper import assert_quantity_allclose
 
-from specreduce.wavelength_calibration import CalibrationLine, WavelengthCalibration1D
+from specreduce import CalibrationLine, WavelengthCalibration1D
 
 
 def test_linear_from_list(spec1d):

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -40,7 +40,7 @@ def test_calibrationline(spec1d_with_emission_line, spec1d_with_absorption_line)
 
     line = CalibrationLine(spec1d_with_emission_line, 5000*u.AA, 128, refinement_method='gaussian',
                            refinement_kwargs={'range': 25})
-    assert_allclose(line.refine(), 129.44371)
+    assert_allclose(line.refine(), 129.44371, atol=0.01)
 
     line2 = CalibrationLine(spec1d_with_emission_line, 5000*u.AA, 130, refinement_method='max',
                             refinement_kwargs={'range': 10})

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -58,3 +58,20 @@ def test_calibrationline(spec1d_with_emission_line, spec1d_with_absorption_line)
     line3 = CalibrationLine(spec1d_with_absorption_line, 5000*u.AA, 128, refinement_method='min',
                             refinement_kwargs={'range': 10})
     assert line3.refine() == 130
+
+
+def test_replace_spectrum(spec1d, spec1d_with_emission_line):
+    lines = [CalibrationLine(spec1d, 5000*u.AA, 0), CalibrationLine(spec1d, 5100*u.AA, 10),
+             CalibrationLine(spec1d, 5198*u.AA, 20), CalibrationLine(spec1d, 5305*u.AA, 30)]
+    test = WavelengthCalibration1D(spec1d, lines)
+    # Accessing this property causes fits the model and caches the resulting WCS
+    test.wcs
+    assert "wcs" in test.__dict__
+    for line in test.lines:
+        assert "refined_pixel" in line.__dict__
+
+    # Replace the input spectrum, which should clear the cached properties
+    test.input_spectrum = spec1d_with_emission_line
+    assert "wcs" not in test.__dict__
+    for line in test.lines:
+        assert "refined_pixel" not in line.__dict__

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -1,5 +1,4 @@
 from numpy.testing import assert_allclose
-import pytest
 
 import astropy.units as u
 from astropy.modeling.models import Polynomial1D

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -4,7 +4,6 @@ import pytest
 import astropy.units as u
 from astropy.modeling.models import Polynomial1D
 from astropy.tests.helper import assert_quantity_allclose
-from astropy.utils.exceptions import AstropyUserWarning
 
 from specreduce.wavelength_calibration import CalibrationLine, WavelengthCalibration1D
 
@@ -12,8 +11,7 @@ from specreduce.wavelength_calibration import CalibrationLine, WavelengthCalibra
 def test_linear_from_list(spec1d):
     test = WavelengthCalibration1D(spec1d, [(5000*u.AA, 0), (5100*u.AA, 10),
                                             (5198*u.AA, 20), (5305*u.AA, 30)])
-    with pytest.warns(AstropyUserWarning, match="Model is linear in parameters"):
-        spec2 = test.apply_to_spectrum(spec1d)
+    spec2 = test.apply_to_spectrum(spec1d)
 
     assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
     assert_quantity_allclose(spec2.spectral_axis[-1], 5495.169999*u.AA)
@@ -23,11 +21,11 @@ def test_linear_from_calibrationline(spec1d):
     lines = [CalibrationLine(spec1d, 5000*u.AA, 0), CalibrationLine(spec1d, 5100*u.AA, 10),
              CalibrationLine(spec1d, 5198*u.AA, 20), CalibrationLine(spec1d, 5305*u.AA, 30)]
     test = WavelengthCalibration1D(spec1d, lines)
-    with pytest.warns(AstropyUserWarning, match="Model is linear in parameters"):
-        spec2 = test.apply_to_spectrum(spec1d)
+    spec2 = test.apply_to_spectrum(spec1d)
 
     assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
     assert_quantity_allclose(spec2.spectral_axis[-1], 5495.169999*u.AA)
+
 
 def test_poly_from_calibrationline(spec1d):
     # This test is mostly to prove that you can use other models
@@ -35,9 +33,8 @@ def test_poly_from_calibrationline(spec1d):
              CalibrationLine(spec1d, 5214*u.AA, 20), CalibrationLine(spec1d, 5330*u.AA, 30),
              CalibrationLine(spec1d, 5438*u.AA, 40)]
     test = WavelengthCalibration1D(spec1d, lines, model=Polynomial1D(2))
-    with pytest.warns(AstropyUserWarning, match="Model is linear in parameters"):
-        spec2 = test.apply_to_spectrum(spec1d)
-        
+    test.apply_to_spectrum(spec1d)
+
     assert_allclose(test.model.parameters, [5.00477143e+03, 1.03457143e+01, 1.28571429e-02])
 
 

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -73,11 +73,12 @@ def test_expected_errors(spec1d):
 
     with pytest.raises(ValueError, match="must have the same length"):
         w2 = [5005, 5110, 5214, 5330, 5438, 5500]*u.AA
-        WavelengthCalibration1D(spec1d, table, line_wavelengths=w2)
+        WavelengthCalibration1D(spec1d, centers, line_wavelengths=w2)
 
-    with pytest.raises(ValueError, match="must have the same length"):
-        w2 = [5005, 5110, 5214, 5330, 5438, 5500]*u.AA
-        WavelengthCalibration1D(spec1d, table, line_wavelengths=w2)
+    with pytest.raises(ValueError, match="astropy.units.Quantity array or"
+                                         " as an astropy.table.QTable"):
+        w2 = [5005, 5110, 5214, 5330, 5438]
+        WavelengthCalibration1D(spec1d, centers, line_wavelengths=w2)
 
     with pytest.raises(ValueError, match="specify at least one"):
         WavelengthCalibration1D(spec1d, centers)

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -13,7 +13,7 @@ from specreduce import WavelengthCalibration1D
 def test_linear_from_list(spec1d):
     centers = [0, 10, 20, 30]
     w = [5000, 5100, 5198, 5305]*u.AA
-    test = WavelengthCalibration1D(spec1d, centers, line_wavelengths=w)
+    test = WavelengthCalibration1D(spec1d, line_pixels=centers, line_wavelengths=w)
     spec2 = test.apply_to_spectrum(spec1d)
 
     assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
@@ -24,14 +24,14 @@ def test_wavelength_from_table(spec1d):
     centers = [0, 10, 20, 30]
     w = [5000, 5100, 5198, 5305]*u.AA
     table = QTable([w], names=["wavelength"])
-    WavelengthCalibration1D(spec1d, centers, line_wavelengths=table)
+    WavelengthCalibration1D(spec1d, line_pixels=centers, line_wavelengths=table)
 
 
 def test_linear_from_table(spec1d):
     centers = [0, 10, 20, 30]
     w = [5000, 5100, 5198, 5305]*u.AA
     table = QTable([centers, w], names=["pixel_center", "wavelength"])
-    test = WavelengthCalibration1D(spec1d, table)
+    test = WavelengthCalibration1D(spec1d, matched_line_list=table)
     spec2 = test.apply_to_spectrum(spec1d)
 
     assert_quantity_allclose(spec2.spectral_axis[0], 4998.8*u.AA)
@@ -44,7 +44,8 @@ def test_poly_from_table(spec1d):
     w = [5005, 5110, 5214, 5330, 5438]*u.AA
     table = QTable([centers, w], names=["pixel_center", "wavelength"])
 
-    test = WavelengthCalibration1D(spec1d, table, model=Polynomial1D(2), fitter=LinearLSQFitter())
+    test = WavelengthCalibration1D(spec1d, matched_line_list=table,
+                                   model=Polynomial1D(2), fitter=LinearLSQFitter())
     test.apply_to_spectrum(spec1d)
 
     assert_allclose(test.model.parameters, [5.00477143e+03, 1.03457143e+01, 1.28571429e-02])
@@ -53,7 +54,7 @@ def test_poly_from_table(spec1d):
 def test_replace_spectrum(spec1d, spec1d_with_emission_line):
     centers = [0, 10, 20, 30]*u.pix
     w = [5000, 5100, 5198, 5305]*u.AA
-    test = WavelengthCalibration1D(spec1d, centers, line_wavelengths=w)
+    test = WavelengthCalibration1D(spec1d, line_pixels=centers, line_wavelengths=w)
     # Accessing this property causes fits the model and caches the resulting WCS
     test.wcs
     assert "wcs" in test.__dict__
@@ -69,16 +70,16 @@ def test_expected_errors(spec1d):
     table = QTable([centers, w], names=["pixel_center", "wavelength"])
 
     with pytest.raises(ValueError, match="Cannot specify line_wavelengths separately"):
-        WavelengthCalibration1D(spec1d, table, line_wavelengths=w)
+        WavelengthCalibration1D(spec1d, matched_line_list=table, line_wavelengths=w)
 
     with pytest.raises(ValueError, match="must have the same length"):
         w2 = [5005, 5110, 5214, 5330, 5438, 5500]*u.AA
-        WavelengthCalibration1D(spec1d, centers, line_wavelengths=w2)
+        WavelengthCalibration1D(spec1d, line_pixels=centers, line_wavelengths=w2)
 
     with pytest.raises(ValueError, match="astropy.units.Quantity array or"
                                          " as an astropy.table.QTable"):
         w2 = [5005, 5110, 5214, 5330, 5438]
-        WavelengthCalibration1D(spec1d, centers, line_wavelengths=w2)
+        WavelengthCalibration1D(spec1d, line_pixels=centers, line_wavelengths=w2)
 
     with pytest.raises(ValueError, match="specify at least one"):
-        WavelengthCalibration1D(spec1d, centers)
+        WavelengthCalibration1D(spec1d, line_pixels=centers)

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -9,6 +9,9 @@ from specutils import SpectralRegion, Spectrum1D
 from specutils.fitting import fit_lines
 
 
+__all__ = ['CalibrationLine', 'WavelengthCalibration1D']
+
+
 class CalibrationLine():
 
     def __init__(self, input_spectrum, wavelength, pixel, refinement_method=None,

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -42,9 +42,10 @@ class WavelengthCalibration1D():
             wavelengths populated.
         line_wavelengths: `~astropy.units.Quantity`, `~astropy.table.QTable`, optional
             `astropy.units.Quantity` array of line wavelength values corresponding to the
-            line pixels defined in ``line_list``. Does not have to be in the same order (the lists will be sorted)
-            but does currently need to be the same length as line_list. Can also be input
-            as an `~astropy.table.QTable` with (minimally) a "wavelength" column.
+            line pixels defined in ``line_list``. Does not have to be in the same order]
+            (the lists will be sorted) but does currently need to be the same length as
+            line_list. Can also be input as an `~astropy.table.QTable` with (minimally)
+            a "wavelength" column.
         catalog: list, str, optional
             The name of a catalog of line wavelengths to load and use in automated and
             template-matching line matching.
@@ -197,5 +198,3 @@ class WavelengthCalibration1D():
         updated_spectrum = Spectrum1D(spectrum.flux, wcs=self.wcs, mask=spectrum.mask,
                                       uncertainty=spectrum.uncertainty)
         return updated_spectrum
-
-

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -32,7 +32,7 @@ class CalibrationLine():
             of line center to include on either side of gaussian fit is set by int ``range``.
             Gradient descent/ascent is determined by setting ``direction`` to 'min' or 'max'.
         """
-        self.input_spectrum = input_spectrum
+        self._input_spectrum = input_spectrum
         self.wavelength = wavelength
         self.pixel = pixel
         self.refinement_method = refinement_method
@@ -118,6 +118,16 @@ class CalibrationLine():
         # returns a copy of this object, but with the pixel updated to the refined value
         return self.refine(return_object=True)
 
+    @property
+    def input_spectrum(self):
+        return self._input_spectrum
+
+    @input_spectrum.setter
+    def input_spectrum(self, new_spectrum):
+        # We want to clear the refined locations if a new calibration spectrum is provided
+        self._clear_cache()
+        self._input_spectrum = new_spectrum
+
     def __str__(self):
         return f"CalibrationLine: ({self.wavelength}, {self.pixel})"
 
@@ -143,7 +153,7 @@ class WavelengthCalibration1D():
         default_refinement_kwargs: dict, optional
             words
         """
-        self.input_spectrum = input_spectrum
+        self._input_spectrum = input_spectrum
         self.model = model
         self.spectral_unit = spectral_unit
         self.default_refinement_method = default_refinement_method
@@ -151,7 +161,6 @@ class WavelengthCalibration1D():
         self._cached_properties = ['wcs',]
 
         if fitter is None:
-            print("Got here")
             if self.model.linear:
                 self.fitter = LinearLSQFitter(calc_uncertainties=True)
             else:
@@ -190,6 +199,18 @@ class WavelengthCalibration1D():
         for attr in attrs:
             if attr in self.__dict__:
                 del self.__dict__[attr]
+
+    @property
+    def input_spectrum(self):
+        return self._input_spectrum
+
+    @input_spectrum.setter
+    def input_spectrum(self, new_spectrum):
+        # We want to clear the refined locations if a new calibration spectrum is provided
+        self._clear_cache()
+        for line in self.lines:
+            line.input_spectrum = new_spectrum
+        self._input_spectrum = new_spectrum
 
     @property
     def refined_lines(self):

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -1,0 +1,198 @@
+from astropy.modeling.models import Linear1D, Gaussian1D
+import astropy.units as u
+from specutils import SpectralRegion
+from specutils.fitting import fit_lines
+
+
+"""
+Starting from Kyle's proposed pseudocode from https://github.com/astropy/specreduce/pull/152
+"""
+
+class CalibrationLine():
+
+    def __init__(input_spectrum, wavelength, pixel, refinement_method=None,
+                 refinement_kwargs={}):
+        """
+        input_spectrum: `~specutils.Spectrum1D`
+            A one-dimensional Spectrum1D calibration spectrum from an arc lamp or similar.
+        wavelength: `astropy.units.Quantity`
+            The rest wavelength of the line.
+        pixel: int
+            Initial guess of the integer pixel location of the line center in the spectrum.
+        refinement_method: str, optional
+            None: use the actual provided pixel values as anchors for the fit without refining
+            their location.
+            'gradient': Simple gradient descent/ascent to nearest min/max value. Direction
+            defined by ``direction`` in refinement_kwargs.
+            'min'/'max': find min/max within pixel range provided by ``range`` kwarg.
+            'gaussian': fit gaussian to spectrum within pixel range provided by ``range`` kwarg.
+        refinement_kwargs: dict, optional
+            Keywords to set the parameters for line location refinement. Distance on either side
+            of line center to include on either side of gaussian fit is set by int ``range``.
+            Gradient descent/ascent is determined by setting ``direction`` to 'min' or 'max'.
+        """
+        self.input_spectrum = input_spectrum
+        self.wavelength = wavelength
+        self.pixel = pixel
+        self.refinement_method = refinement_method
+        self.refinement_kwargs = refinement_kwargs
+
+        if self.refinement_method in ("gaussian", "min", "max"):
+            if 'range' not in self.refinement_kwargs:
+                raise ValueError(f"You must define 'range' in refinement_kwargs to use "
+                                  "{self.refinement_method} refinement.")
+        elif self.refinement_method == "gradient" and 'direction' not in self.refinement_kwargs:
+            raise ValueError("You must define 'direction' in refinement_kwargs to use "
+                             "gradient refinement")
+
+    @classmethod
+    def by_name(cls, input_spectrum, line_name, pixel,
+                refinement_method=None, refinement_kwargs={}):
+	   # this does wavelength lookup and passes that wavelength to __init__ allowing the user
+       # to call CalibrationLine.by_name(spectrum, 'H_alpha', pixel=40)
+       # We could also have a type-check for ``wavelength`` above, this just feels more verbose
+       return cls(...)
+
+    def _do_refinement(input_spectrum):
+            if self.refinement_method == 'gaussian':
+                window_width = self.refinement_kwargs.get('range')
+                window = SpectralRegion((self.pixel-window_width)*u.pix,
+                                        (self.pixel+window_width)*u.pix)
+
+                # Use specutils.fit_lines to do model fitting. Define window in u.pix based on kwargs
+                input_model = Gaussian1D(mean=self.pixel, amplitude = self.input_spectrum[pixel],
+                                         stddev=3)
+
+                fitted_model = fit_lines(self.input_spectrum, input_model, window=window)
+                new_pixel = fitted_model.mean
+
+            elif self.refinement_method == 'min':
+                window_width = self.refinement_kwargs.get('range')
+                new_pixel = np.argmin(self.input_spectrum[self.pixel-window_width:self.pixel+window_width+1])
+
+            elif self.refinement_method = 'max':
+                window_width = self.refinement_kwargs.get('range')
+                new_pixel = np.argmax(self.input_spectrum[self.pixel-window_width:self.pixel+window_width+1])
+
+            return new_pixel
+
+    def refine(self, input_spectrum=None, return_object=False):
+        # finds the center of the line according to refinement_method/kwargs and returns
+        # either the pixel value or a CalibrationLine object with pixel changed to the refined value
+        input_spectrum = self.input_spectrum if input_spectrum is None else input_spectrum
+        refined_pixel = _do_refinement(input_spectrum, self.refinement_method, **self.refinement_kwargs)
+        if return_object:
+            return CalibrationLine(input_spectrum, self.wavelength, refined_pixel, ...)
+
+        return refined_pixel
+
+    @cached_property
+    def refined_pixel(self):
+        # returns the refined pixel for self.input_spectrum
+        return self.refine()
+
+    @property
+    def with_refined_pixel(self):
+        # returns a copy of this object, but with the pixel updated to the refined value
+        return self.refine(return_object=True)
+
+
+class WavelengthCalibration1D():
+
+    def __init__(input_spectrum, lines, model=Linear1D,
+                              default_refinement_method=None, default_refinement_kwargs={}):
+        """
+        input_spectrum: `~specutils.Spectrum1D`
+            A one-dimensional Spectrum1D calibration spectrum from an arc lamp or similar.
+        lines:
+            List of lines to anchor the wavelength solution fit. coerced to CalibrationLine
+            objects if passed as tuples with default_refinement_method and default_refinement_kwargs as defaults
+        model: `~astropy.modeling.Model`
+            The model to fit for the wavelength solution. Defaults to a linear model.
+        default_refinement_method: str, optional
+            words
+        default_refinement_kwargs: dict, optional
+            words
+        """
+        self.model = model
+
+
+    @classmethod
+    def autoidentify(cls, input_spectrum, line_list, model=Linear1D, ...):
+        # line_list could be a string ("common stellar") or an object
+        # this builds a list of CalibrationLine objects and passes to __init__
+        return cls(...)
+
+    @property 
+    def refined_lines(self):
+        return [l.with_refined_pixel for l in self.lines]
+
+    @property
+    def refined_pixels(self):
+        # useful for plotting over spectrum to change input lines/refinement options
+        return [(l.wavelength, l.refined_pixel) for l in self.lines]
+
+    @cached_property
+    def wcs(self):
+        # computes and returns WCS after fitting self.model to self.refined_pixels
+        return WCS(...)
+
+    def __call__(self, apply_to_spectrum=None):
+       # returns spectrum1d with wavelength calibration applied
+       # actual line refinement and WCS solution should already be done so that this can be called on multiple science sources
+       apply_to_spectrum = self.input_spectrum if apply_to_spectrum is None else apply_to_spectrum
+       apply_to_spectrum.wcs = apply_to_spectrum  # might need a deepcopy!
+       return apply_to_spectrum 
+
+
+class WavelengthCalibration2D(input_spectrum, trace, lines, model=Linear1D,
+                              default_refinement_method=None, default_refinement_kwargs={}):
+    # input_spectrum must be 2-dimensional
+    # lines are coerced to CalibrationLine objects if passed as tuples with default_refinement_method and default_refinement_kwargs as defaults
+    @classmethod
+    def autoidentify(cls, input_spectrum, trace, line_list, model=Linear1D, ...):
+        # does this do 2D identification, or just search a 1d spectrum exactly at the trace?
+        # or should we require using WavelengthCalibration1D.autoidentify?
+        return cls(...)
+
+    @property
+    def refined_lines(self):
+        return [[(l.wavelength, l.refine(input_spectrum.get_row(row), return_object=False)) for l in self.lines] for row in rows]
+
+    @property
+    def refined_pixels(self):
+        return [[(l.wavelength, l.refine(input_spectrum.get_row(row), return_object=True)) for l in self.lines] for row in rows]
+
+    @cached_property
+    def wcs(self):
+        # computes and returns WCS after fitting self.model to self.refined_pixels
+        return WCS(...)
+
+    def __call__(self, apply_to_spectrum=None):
+       # returns spectrum1d with wavelength calibration applied
+       # actual line refinement and WCS solution should already be done so that this can be called on multiple science sources
+       apply_to_spectrum = self.input_spectrum if apply_to_spectrum is None else apply_to_spectrum
+       apply_to_spectrum.wcs = apply_to_spectrum  # might need a deepcopy!
+       return apply_to_spectrum 
+
+
+
+# various supported syntaxes for creating a calibration object (do we want this much flexibility?):
+cal1d = WavelengthCalibration1D(spec1d_lamp, (CalibrationLine(5500, 20), CalibrationLine(6200, 32)))
+cal1d = WavelengthCalibration1D(spec1d_lamp, (CalibrationLine.by_name('H_alpha', 20, 'uphill'), CalibrationLine.by_name('Lyman_alpha', 32, 'max', {'range': 10})))
+cal1d = WavelengthCalibration1D(spec1d_lamp, ((5500, 20), ('Lyman_alpha', 32)))
+cal1d = WavelengthCalibration1D(spec1d_lamp, ((5500, 20), (6000, 30)), default_refinement_method='gaussian')
+cal1d = WavelengthCalibration1D.autoidentify(spec1d_lamp, common_stellar_line_list)
+
+# once we have that object, we can access the fitted wavelength solution via the WCS and apply it to 
+# a spectrum (either the same or separate from the spectrum used for fitting)
+targ_wcs = cal1d.wcs
+spec1d_targ1_cal = cal1d(spec1d_targ1)
+spec1d_targ2_cal = cal1d(spec1d_targ2)
+
+
+# we sould either start a 2D calibration the same way (except also passing the trace) or by passing
+# the refined lines from the 1D calibration as the starting point
+cal2d = WavelengthCalibration2D(spec2d_lamp, trace_lamp, ((5500, 20), (6000, 30)))
+cal2d = WavelengthCalibration2D(spec2d_lamp, trace_lamp, cal1d.refined_lines)
+spec2d_targ_cal = cal2d(spec2d_targ, trace_targ?)

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -156,14 +156,7 @@ class WavelengthCalibration1D():
         self.default_refinement_method = default_refinement_method
         self.default_refinement_kwargs = default_refinement_kwargs
         self._cached_properties = ['wcs',]
-
-        if fitter is None:
-            if self.model.linear:
-                self.fitter = LinearLSQFitter(calc_uncertainties=True)
-            else:
-                self.fitter = LMLSQFitter(calc_uncertainties=True)
-        else:
-            self.fitter = fitter
+        self.fitter = fitter
 
         if self.default_refinement_method in ("gaussian", "min", "max"):
             if 'range' not in self.default_refinement_kwargs:
@@ -237,6 +230,12 @@ class WavelengthCalibration1D():
         # computes and returns WCS after fitting self.model to self.refined_pixels
         x = [line[1] for line in self.refined_pixels] * u.pix
         y = [line[0].value for line in self.refined_pixels] * self.spectral_unit
+
+        if self.fitter is None:
+            if self.model.linear:
+                self.fitter = LinearLSQFitter(calc_uncertainties=True)
+            else:
+                self.fitter = LMLSQFitter(calc_uncertainties=True)
 
         # Fit the model
         self._model = self.fitter(self._model, x, y)

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -98,7 +98,12 @@ class WavelengthCalibration1D():
                 line_wavelengths.sort("wavelength")
                 self._line_list = hstack(self._line_list, line_wavelengths)
 
+        # Parse desired catalogs of lines for matching.
         if catalog is not None:
+            # For now we avoid going into the later logic and just throw an error
+            raise NotImplementedError("No catalogs are available yet, please input "
+                                      "wavelengths with line_wavelengths or as a "
+                                      "column in line_list")
             if isinstance(catalog, list):
                 self._catalog = catalog
             else:

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -41,11 +41,8 @@ class CalibrationLine():
 
         if self.refinement_method in ("gaussian", "min", "max"):
             if 'range' not in self.refinement_kwargs:
-                raise ValueError(f"You must define 'range' in refinement_kwargs to use "
-                                 f"{self.refinement_method} refinement.")
-        elif self.refinement_method == "gradient" and 'direction' not in self.refinement_kwargs:
-            raise ValueError("You must define 'direction' in refinement_kwargs to use "
-                             "gradient refinement")
+                # We may want to adjust this default based on real calibration spectra
+                self.refinement_kwargs['range'] = 10
 
     def _clear_cache(self, *attrs):
         """
@@ -170,12 +167,8 @@ class WavelengthCalibration1D():
 
         if self.default_refinement_method in ("gaussian", "min", "max"):
             if 'range' not in self.default_refinement_kwargs:
-                raise ValueError("You must define 'range' in default_refinement_kwargs to use "
-                                 f"{self.refinement_method} refinement.")
-        elif (self.default_refinement_method == "gradient" and 'direction' not in
-                self.default_refinement_kwargs):
-            raise ValueError("You must define 'direction' in default_refinement_kwargs to use "
-                             "gradient refinement")
+                # We may want to adjust this default based on real calibration spectra
+                self.default_refinement_method['range'] = 10
 
         self.lines = []
         if isinstance(lines, str):

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -151,7 +151,7 @@ class WavelengthCalibration1D():
             words
         """
         self._input_spectrum = input_spectrum
-        self.model = model
+        self._model = model
         self.spectral_unit = spectral_unit
         self.default_refinement_method = default_refinement_method
         self.default_refinement_kwargs = default_refinement_kwargs
@@ -170,18 +170,18 @@ class WavelengthCalibration1D():
                 # We may want to adjust this default based on real calibration spectra
                 self.default_refinement_method['range'] = 10
 
-        self.lines = []
+        self._lines = []
         if isinstance(lines, str):
             if lines in self.available_line_lists:
                 raise ValueError(f"Line list '{lines}' is not an available line list.")
         else:
             for line in lines:
                 if isinstance(line, CalibrationLine):
-                    self.lines.append(line)
+                    self._lines.append(line)
                 else:
-                    self.lines.append(CalibrationLine(self.input_spectrum, line[0], line[1],
-                                      self.default_refinement_method,
-                                      self.default_refinement_kwargs))
+                    self._lines.append(CalibrationLine(self.input_spectrum, line[0], line[1],
+                                       self.default_refinement_method,
+                                       self.default_refinement_kwargs))
 
     def _clear_cache(self, *attrs):
         """
@@ -206,6 +206,24 @@ class WavelengthCalibration1D():
         self._input_spectrum = new_spectrum
 
     @property
+    def lines(self):
+        return self._lines
+
+    @lines.setter
+    def lines(self, new_lines):
+        self._clear_cache()
+        self._lines = new_lines
+
+    @property
+    def model(self):
+        return self._model
+
+    @model.setter
+    def model(self, new_model):
+        self._clear_cache()
+        self._model = new_model
+
+    @property
     def refined_lines(self):
         return [line.with_refined_pixel for line in self.lines]
 
@@ -221,7 +239,7 @@ class WavelengthCalibration1D():
         y = [line[0].value for line in self.refined_pixels] * self.spectral_unit
 
         # Fit the model
-        self.model = self.fitter(self.model, x, y)
+        self._model = self.fitter(self._model, x, y)
 
         # Build a GWCS pipeline from the fitted model
         pixel_frame = cf.CoordinateFrame(1, "SPECTRAL", [0,], axes_names=["x",], unit=[u.pix,])

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -102,7 +102,7 @@ class CalibrationLine():
         # returns the refined pixel for self.input_spectrum
         return self.refine()
 
-    @property
+    @cached_property
     def with_refined_pixel(self):
         # returns a copy of this object, but with the pixel updated to the refined value
         return self.refine(return_object=True)
@@ -161,12 +161,6 @@ class WavelengthCalibration1D():
                     self.lines.append(CalibrationLine(self.input_spectrum, line[0], line[1],
                                       self.default_refinement_method,
                                       self.default_refinement_kwargs))
-
-    @classmethod
-    def autoidentify(cls, input_spectrum, line_list, model=Linear1D):
-        # line_list could be a string ("common stellar") or an object
-        # this builds a list of CalibrationLine objects and passes to __init__
-        return cls(...)
 
     @property
     def refined_lines(self):

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -85,7 +85,7 @@ class WavelengthCalibration1D():
         if line_wavelengths is not None:
             if isinstance(line_list, QTable) and "wavelength" in line_list.columns:
                 raise ValueError("Cannot specify line_wavelengths separately if there is"
-                                " a 'wavelength' column in line_list.")
+                                 " a 'wavelength' column in line_list.")
             if len(line_wavelengths) != len(line_list):
                 raise ValueError("If line_wavelengths is specified, it must have the same "
                                  "length as line_pixels")

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -109,14 +109,21 @@ class WavelengthCalibration1D():
             raise NotImplementedError("No catalogs are available yet, please input "
                                       "wavelengths with line_wavelengths or as a "
                                       "column in line_list")
-            if isinstance(catalog, list):
+
+            if isinstance(catalog, QTable):
+                if "wavelength" not in catalog.columns:
+                    raise ValueError("Catalog table must have a 'wavelength' column.")
                 self._catalog = catalog
             else:
-                self._catalog = [catalog]
-            for cat in self._catalog:
-                if isinstance(cat, str):
-                    if cat not in self._available_catalogs:
-                        raise ValueError(f"Line list '{cat}' is not an available catalog.")
+                # This will need to be updated to match up with Tim's catalog code
+                if isinstance(catalog, list):
+                    self._catalog = catalog
+                else:
+                    self._catalog = [catalog]
+                for cat in self._catalog:
+                    if isinstance(cat, str):
+                        if cat not in self._available_catalogs:
+                            raise ValueError(f"Line list '{cat}' is not an available catalog.")
 
             # Get the potential lines from any specified catalogs to use in matching
             self._potential_wavelengths = concatenate_catalogs(self._catalog)

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -30,7 +30,7 @@ def concatenate_catalogs():
 class WavelengthCalibration1D():
 
     def __init__(self, input_spectrum, line_list, line_wavelengths=None, catalog=None,
-                 model=Linear1D(), spectral_unit=u.Angstrom, fitter=None):
+                 model=Linear1D(), fitter=None):
         """
         input_spectrum: `~specutils.Spectrum1D`
             A one-dimensional Spectrum1D calibration spectrum from an arc lamp or similar.
@@ -50,11 +50,14 @@ class WavelengthCalibration1D():
             template-matching line matching.
         model: `~astropy.modeling.Model`
             The model to fit for the wavelength solution. Defaults to a linear model.
+        fitter: `~astropy.modeling.fitting.Fitter`, optional
+            The fitter to use in optimizing the model fit. Defaults to
+            `~astropy.modeling.fitting.LinearLSQFitter` if the model to fit is linear
+            or `~astropy.modeling.fitting.LMLSQFitter` if the model to fit is non-linear.
         """
         self._input_spectrum = input_spectrum
         self._model = model
         self._line_list = line_list
-        self.spectral_unit = spectral_unit
         self._cached_properties = ['wcs',]
         self.fitter = fitter
         self._potential_wavelengths = None
@@ -168,7 +171,8 @@ class WavelengthCalibration1D():
 
         # Build a GWCS pipeline from the fitted model
         pixel_frame = cf.CoordinateFrame(1, "SPECTRAL", [0,], axes_names=["x",], unit=[u.pix,])
-        spectral_frame = cf.SpectralFrame(axes_names=["wavelength",], unit=[self.spectral_unit,])
+        spectral_frame = cf.SpectralFrame(axes_names=["wavelength",],
+                                          unit=[self._line_list["wavelength"].unit,])
 
         pipeline = [(pixel_frame, self.model), (spectral_frame, None)]
 

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -232,13 +232,16 @@ class WavelengthCalibration1D():
         y = [line[0].value for line in self.refined_pixels] * self.spectral_unit
 
         if self.fitter is None:
+            # Flexible defaulting if self.fitter is None
             if self.model.linear:
-                self.fitter = LinearLSQFitter(calc_uncertainties=True)
+                fitter = LinearLSQFitter(calc_uncertainties=True)
             else:
-                self.fitter = LMLSQFitter(calc_uncertainties=True)
+                fitter = LMLSQFitter(calc_uncertainties=True)
+        else:
+            fitter = self.fitter
 
         # Fit the model
-        self._model = self.fitter(self._model, x, y)
+        self._model = fitter(self._model, x, y)
 
         # Build a GWCS pipeline from the fitted model
         pixel_frame = cf.CoordinateFrame(1, "SPECTRAL", [0,], axes_names=["x",], unit=[u.pix,])

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -46,7 +46,7 @@ class WavelengthCalibration1D():
             (the lists will be sorted) but does currently need to be the same length as
             line_list. Can also be input as an `~astropy.table.QTable` with (minimally)
             a "wavelength" column.
-        catalog: list, str, optional
+        catalog: list, str, `~astropy.table.QTable`, optional
             The name of a catalog of line wavelengths to load and use in automated and
             template-matching line matching.
         model: `~astropy.modeling.Model`
@@ -83,15 +83,15 @@ class WavelengthCalibration1D():
 
         # Sanity checks on line_wavelengths value
         if line_wavelengths is not None:
-            if "wavelength" in line_list:
+            if isinstance(line_list, QTable) and "wavelength" in line_list.columns:
                 raise ValueError("Cannot specify line_wavelengths separately if there is"
-                                 "a 'wavelength' column in line_list.")
+                                " a 'wavelength' column in line_list.")
             if len(line_wavelengths) != len(line_list):
                 raise ValueError("If line_wavelengths is specified, it must have the same "
                                  "length as line_pixels")
             if not isinstance(line_wavelengths, (u.Quantity, QTable)):
                 raise ValueError("line_wavelengths must be specified as an astropy.units.Quantity"
-                                 "array or as an astropy.table.QTable")
+                                 " array or as an astropy.table.QTable")
             if isinstance(line_wavelengths, u.Quantity):
                 # Ensure frequency is descending or wavelength is ascending
                 if str(line_wavelengths.unit.physical_type) == "frequency":
@@ -101,7 +101,7 @@ class WavelengthCalibration1D():
                 self._line_list["wavelength"] = line_wavelengths
             elif isinstance(line_wavelengths, QTable):
                 line_wavelengths.sort("wavelength")
-                self._line_list = hstack(self._line_list, line_wavelengths)
+                self._line_list = hstack([self._line_list, line_wavelengths])
 
         # Parse desired catalogs of lines for matching.
         if catalog is not None:

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -42,7 +42,7 @@ class WavelengthCalibration1D():
             wavelengths populated.
         line_wavelengths: `~astropy.units.Quantity`, `~astropy.table.QTable`, optional
             `astropy.units.Quantity` array of line wavelength values corresponding to the
-            line_pixels. Does not have to be in the same order (the lists will be sorted)
+            line pixels defined in ``line_list``. Does not have to be in the same order (the lists will be sorted)
             but does currently need to be the same length as line_list. Can also be input
             as an `~astropy.table.QTable` with (minimally) a "wavelength" column.
         catalog: list, str, optional
@@ -100,7 +100,7 @@ class WavelengthCalibration1D():
                 self._catalog = catalog
             else:
                 self._catalog = [catalog]
-            for cat in catalog:
+            for cat in self._catalog:
                 if isinstance(cat, str):
                     if cat not in self._available_catalogs:
                         raise ValueError(f"Line list '{cat}' is not an available catalog.")
@@ -186,43 +186,3 @@ class WavelengthCalibration1D():
         return updated_spectrum
 
 
-'''
-# WavelengthCalibration2D is a planned future feature
-class WavelengthCalibration2D():
-    # input_spectrum must be 2-dimensional
-
-    # lines are coerced to CalibrationLine objects if passed as tuples with
-    # default_refinement_method and default_refinement_kwargs as defaults
-    def __init__(input_spectrum, trace, lines, model=Linear1D,
-                 default_refinement_method=None, default_refinement_kwargs={}):
-        return NotImplementedError("2D wavelength calibration is not yet implemented")
-
-    @classmethod
-    def autoidentify(cls, input_spectrum, trace, line_list, model=Linear1D):
-        # does this do 2D identification, or just search a 1d spectrum exactly at the trace?
-        # or should we require using WavelengthCalibration1D.autoidentify?
-        return cls(...)
-
-    @property
-    def refined_lines(self):
-        return [[(l.wavelength, l.refine(input_spectrum.get_row(row), return_object=False))
-                 for l in self.lines] for row in rows]
-
-    @property
-    def refined_pixels(self):
-        return [[(l.wavelength, l.refine(input_spectrum.get_row(row), return_object=True))
-                 for l in self.lines] for row in rows]
-
-    @cached_property
-    def wcs(self):
-        # computes and returns WCS after fitting self.model to self.refined_pixels
-        pass
-
-    def __call__(self, apply_to_spectrum=None):
-        # returns spectrum1d with wavelength calibration applied
-        # actual line refinement and WCS solution should already be done so that this
-        # can be called on multiple science sources
-        apply_to_spectrum = self.input_spectrum if apply_to_spectrum is None else apply_to_spectrum
-        apply_to_spectrum.wcs = apply_to_spectrum  # might need a deepcopy!
-        return apply_to_spectrum
-'''

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -78,6 +78,9 @@ class CalibrationLine():
                                                            self.pixel+window_width+1])
             new_pixel += self.pixel - window_width
 
+        else:
+            raise ValueError(f"Refinement method {self.refinement_method} is not implemented")
+
         return new_pixel
 
     def refine(self, input_spectrum=None, return_object=False):

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -92,7 +92,11 @@ class WavelengthCalibration1D():
                 raise ValueError("line_wavelengths must be specified as an astropy.units.Quantity"
                                  "array or as an astropy.table.QTable")
             if isinstance(line_wavelengths, u.Quantity):
-                line_wavelengths.value.sort()
+                # Ensure frequency is descending or wavelength is ascending
+                if str(line_wavelengths.unit.physical_type) == "frequency":
+                    line_wavelengths[::-1].sort()
+                else:
+                    line_wavelengths.sort()
                 self._line_list["wavelength"] = line_wavelengths
             elif isinstance(line_wavelengths, QTable):
                 line_wavelengths.sort("wavelength")

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -121,7 +121,7 @@ class WavelengthCalibration1D():
             A one-dimensional Spectrum1D calibration spectrum from an arc lamp or similar.
         lines: str, list
             List of lines to anchor the wavelength solution fit. List items are coerced to
-            CalibrationLine objects if passed as tuples of (pixel, wavelength) with
+            CalibrationLine objects if passed as tuples of (wavelength, pixel) with
             default_refinement_method and default_refinement_kwargs as defaults.
         model: `~astropy.modeling.Model`
             The model to fit for the wavelength solution. Defaults to a linear model.
@@ -155,7 +155,7 @@ class WavelengthCalibration1D():
                 if isinstance(line, CalibrationLine):
                     self.lines.append(line)
                 else:
-                    self.lines.append(CalibrationLine(self.input_spectrum, line[1], line[0],
+                    self.lines.append(CalibrationLine(self.input_spectrum, line[0], line[1],
                                       self.default_refinement_method,
                                       self.default_refinement_kwargs))
 


### PR DESCRIPTION
This implements the initial work needed for 1D wavelength calibration, defaulting to a basic linear fit to the input wavelength/pixel pairs. Does not implement autoidentification of lines or input of a preset named line list. I have a little bit of refinement left to do (e.g., making sure the internals are consistent on whether pixel values are stored as `Quantities` with `u.pix`) and need to add tests, but I figured it's to a point where I should get other eyes on it to make sure I'm fulfilling the consensus reached in the discussion on #152.

The following code snippet is what I was using to test this:

```
import astropy.units as u
import numpy as np
from specutils import Spectrum1D
from wavelength_calibration import WavelengthCalibration1D

flux = np.random.random(50)*u.Jy
sa = np.arange(0,50)*u.pix
spec = Spectrum1D(flux, spectral_axis = sa)
test = WavelengthCalibration1D(spec, [(0,5000*u.AA),(10,5100*u.AA),(20,5198*u.AA),(30,5305*u.AA)])
spec2 = test.apply_to_spectrum(spec)
spec2
```