### PR TITLE
allow HorneExtract to accept None as a valid input for background model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ BoxcarExtract's extracted 1D spectrum. [#159]
 - Backgrounds using median statistic properly ignore zero-weighted pixels
 [#159]
 
+- HorneExtract now accepts 'None' as a vaild option for bkgrd_prof [#171]
+
 
 1.3.0 (2022-12-05)
 ------------------

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -197,3 +197,13 @@ def test_horne_non_flat_trace():
 
     # ensure both extractions are equivalent:
     assert_quantity_allclose(extract_non_flat.flux, extract_flat.flux)
+
+
+def test_horne_no_bkgrnd():
+    # Test HorneExtract when using bkgrd_prof=None
+
+    trace = FlatTrace(image, 3.0)
+    extract = HorneExtract(image.data, trace, bkgrd_prof=None,
+                           variance=np.ones(image.data.shape))
+    # This is just testing that it runs with no errors and returns something
+    assert len(extract.spectrum.flux) == 10


### PR DESCRIPTION
This PR allows HorneExtract to accept 'None' as a valid input for bkgrd_prof.