### PR TITLE
Add a note about FitTrace with low S/N

### DIFF
--- a/docs/extraction_quickstart.rst
+++ b/docs/extraction_quickstart.rst
@@ -27,7 +27,8 @@ of the available trace classes)::
 
 .. note::
   The fit for `~specreduce.tracing.FitTrace` may be adversely affected by noise where the spectrum
-  is faint. In these areas we recommend using a narrow cross-dispersion window to improve the fit.
+  is faint. Narrowing the window parameter or lowering the order of the fitting function may
+  improve the result for noisy data.
 
 
 Background

--- a/docs/extraction_quickstart.rst
+++ b/docs/extraction_quickstart.rst
@@ -25,6 +25,10 @@ of the available trace classes)::
 
   trace = specreduce.tracing.FlatTrace(image, 15)
 
+.. note::
+  The fit for `~specreduce.tracing.FitTrace` may be adversely affected by noise where the spectrum
+  is faint. In these areas we recommend using a narrow cross-dispersion window to improve the fit.
+
 
 Background
 ----------


### PR DESCRIPTION
User comment: "FitTrace doesn't seem to produce an optimal fit". The recommendation from POs was to add a note recommending a smaller cross-dispersion window in this case. 