### PR TITLE
Add option to fit and use self profile for HorneExtract

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@
 New Features
 ^^^^^^^^^^^^
 
+- Added 'interpolated_profile' option for HorneExtract. If The ``interpolated_profile`` option
+is used, the image will be sampled in various wavelength bins (set by
+``n_bins_interpolated_profile``), averaged in those bins, and samples are then
+interpolated between (linear by default, interpolation degree can be set with
+the ``interp_degree_interpolated_profile`` parameter) to generate a continuously varying
+spatial profile that can be evaluated at any wavelength.[ #173]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/docs/extraction_quickstart.rst
+++ b/docs/extraction_quickstart.rst
@@ -1,27 +1,30 @@
 .. _extraction_quickstart:
 
+===============================
 Spectral Extraction Quick Start
 ===============================
 
-Specreduce provides flexible functionality for extracting a 1D spectrum from a 2D spectral image,
-including steps for determining the trace of a spectrum, background subtraction, and extraction.
+Specreduce provides flexible functionality for extracting a 1D spectrum from a
+2D spectral image, including steps for determining the trace of a spectrum,
+background subtraction, and extraction.
 
 
 Tracing
--------
+=======
 
-The `specreduce.tracing` module defines the trace of a spectrum on the 2D image.  These
-traces can either be determined semi-automatically or manually, and are provided as the inputs for
-the remaining steps of the extraction process.  Supported trace types include:
+The `specreduce.tracing` module defines the trace of a spectrum on the 2D image.
+These traces can either be determined semi-automatically or manually, and are
+provided as the inputs for the remaining steps of the extraction process.
+Supported trace types include:
 
 * `~specreduce.tracing.ArrayTrace`
 * `~specreduce.tracing.FlatTrace`
 * `~specreduce.tracing.FitTrace`
 
 
-Each of these trace classes takes the 2D spectral image as input, as well as additional information
-needed to define or determine the trace (see the API docs above for required parameters for each
-of the available trace classes)::
+Each of these trace classes takes the 2D spectral image as input, as well as
+additional information needed to define or determine the trace (see the API docs
+above for required parameters for each of the available trace classes)::
 
   trace = specreduce.tracing.FlatTrace(image, 15)
 
@@ -32,11 +35,11 @@ of the available trace classes)::
 
 
 Background
-----------
+==========
 
 The `specreduce.background` module generates and subtracts a background image from
-the input 2D spectral image.  The `~specreduce.background.Background` object is defined by one
-or more windows, and can be generated with:
+the input 2D spectral image.  The `~specreduce.background.Background` object is
+defined by one or more windows, and can be generated with:
 
 * `~specreduce.background.Background`
 * `Background.one_sided <specreduce.background.Background.one_sided>`
@@ -52,24 +55,25 @@ or, equivalently::
   bg = specreduce.tracing.Background.one_sided(image, 15, separation=5, width=2)
 
 
-The background image can be accessed via `~specreduce.background.Background.bkg_image` and the
-background-subtracted image via `~specreduce.background.Background.sub_image` (or ``image - bg``).
+The background image can be accessed via `~specreduce.background.Background.bkg_image`
+and the background-subtracted image via `~specreduce.background.Background.sub_image`
+(or ``image - bg``).
 
-The background and trace steps can be done iteratively, to refine an automated trace using the
-background-subtracted image as input.
+The background and trace steps can be done iteratively, to refine an automated
+trace using the background-subtracted image as input.
 
 Extraction
-----------
+==========
 
-The `specreduce.extract` module extracts a 1D spectrum from an input 2D spectrum (likely a
-background-extracted spectrum from the previous step) and a defined window, using one of the
-implemented methods:
+The `specreduce.extract` module extracts a 1D spectrum from an input 2D spectrum
+(likely a background-extracted spectrum from the previous step) and a defined
+window, using one of the following implemented methods:
 
 * `~specreduce.extract.BoxcarExtract`
 * `~specreduce.extract.HorneExtract`
 
-Each of these takes the input image and trace as inputs (see the API above for other required
-and optional parameters)::
+Each of these takes the input image and trace as inputs (see the API above for
+other required and optional parameters)::
 
   extract = specreduce.extract.BoxcarExtract(image-bg, trace, width=3)
 
@@ -77,28 +81,82 @@ or::
 
   extract = specreduce.extract.HorneExtract(image-bg, trace)
 
-For the Horne algorithm, the input image must include uncertainty and mask.
-These two calls set the options and initialize the object. To extract the spectrum, the
-syntax is::
+For the Horne algorithm, the variance array is required. If the input image is
+an ``astropy.NDData`` object with ``image.uncertainty`` provided,
+then this will be used. Otherwise, the ``variance`` parameter must be set.::
+
+  extract = specreduce.extract.HorneExtract(image-bg, trace, variance=var_array)
+
+An optional mask array for the image may be supplied to HorneExtract as well. 
+This follows the same convention and can either be attacted to ``image`` if it
+is and ``astropy.NDData`` object, or supplied as a keyword argrument. Note that
+any wavelengths columns containing any masked values will be omitted from the
+extraction.
+
+The previous examples in this section show how to initialize the BoxcarExtract
+or HorneExtract objects with their required parameters. To extract the 1D
+spectrum::
 
   spectrum = extract.spectrum
 
-The ``extract`` object contains all the set options.  The extracted 1D spectrum can be
-accessed via the ``spectrum`` property or by calling the ``extract`` object (which also allows
-temporarily overriding any values)::
+The ``extract`` object contains all the set options.  The extracted 1D spectrum
+can be accessed via the ``spectrum`` property or by calling (e.g ``extract()``)
+the ``extract`` object (which also allows temporarily overriding any values)::
 
   spectrum2 = extract(width=6)
 
-The Horne algorithm preforms a Gaussian fit on the source, it is thus best suited for cases
-where the source has a Gaussian profile in the cross-dispersion direction.
+or, for example to override the original ``trace_object``::
+  spectrum2 = extract(trace_object=new_trace)
+
+Spatial profile options
+-----------------------
+The Horne algorithm provides two options for fitting the spatial profile to the
+cross_dispersion direction of the source: a Gaussian fit (default),
+or an empirical 'interpolated_profile' option.
+
+If the default Gaussian option is used, an optional background model may be
+supplied as well (default is a 2D Polynomial) to account
+for residual background in the spatial profile. This option is not supported for
+``interpolated_profile``.
+
+
+If  the ``interpolated_profile`` option is used, the image will be sampled in various
+wavelength bins (set by ``n_bins_interpolated_profile``), averaged in those bins, and
+samples are then interpolated between (linear by default, interpolation degree can
+be set with ``interp_degree_interpolated_profile``, which defaults to linear in
+x and y) to generate an empirical interpolated spatial profile. Since this option
+has two optional parameters to control the fit, the input can either be a string
+to indicate that ``interpolated_profile`` should be used for the spatial profile
+and to use the defaults for bins and interpolation degree, or to override these
+defaults a dictionary can be passed in.
+
+For example, to use the ``interpolated_profile`` option with default bins and
+interpolation degree::
+
+  interp_profile_extraction = extract(spatial_profile='interpolated_profile')
+
+Or, to override the default of 10 samples and use 20 samples::
+
+  interp_profile_extraction = extract(spatial_profile={'name': 'interpolated_profile',
+                                    'n_bins_interpolated_profile': 20)
+
+Or, to do a cubic interpolation instead of the default linear::
+
+    interp_profile_extraction = extract(spatial_profile={'name': 'interpolated_profile',
+                                    'interp_degree_interpolated_profile': 3)
+
+As usual, parameters can either be set when instantiating the HorneExtraxt object,
+or supplied/overridden when calling the extraction method on that object.
 
 Example Workflow
-----------------
+================
 
-This will produce a 1D spectrum, with flux in units of the 2D spectrum. The wavelength units will
-be pixels. Wavelength and flux calibration steps are not included here.
+This will produce a 1D spectrum, with flux in units of the 2D spectrum. The
+wavelength units will be pixels. Wavelength and flux calibration steps are not
+included here.
 
-Putting all these steps together, a simple extraction process might look something like::
+Putting all these steps together, a simple extraction process might look
+something like::
 
     from specreduce.trace import FlatTrace
     from specreduce.background import Background

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -8,6 +8,7 @@ import numpy as np
 from astropy import units as u
 from astropy.modeling import Model, models, fitting
 from astropy.nddata import NDData, VarianceUncertainty
+from scipy.interpolate import RectBivariateSpline
 
 from specreduce.core import SpecreduceOperation
 from specreduce.tracing import Trace, FlatTrace
@@ -250,6 +251,19 @@ class HorneExtract(SpecreduceOperation):
     Perform a Horne (a.k.a. optimal) extraction on a two-dimensional
     spectrum.
 
+    There are two options for fitting the spatial profile used for
+    extraction - by default, a 1D gaussian is fit and as a uniform profile
+    across the spectrum. Alternativley, the ``self profile`` option may be
+    chosen - when this option is chosen, the spatial profile will be sampled
+    at various locations (set by <>) and interpolated between to produce a
+    smoothly varying spatial profile across the spectrum.
+
+    If using the Gaussian option for the spatial profile, a background profile
+    may be fit (but not subtracted) simultaneously to the data. By default,
+    this is done with a 2nd degree polynomial. If using the
+    ``interpolated_profile`` option, the background model must be set to None.
+
+
     Parameters
     ----------
 
@@ -268,8 +282,24 @@ class HorneExtract(SpecreduceOperation):
         The index of the image's cross-dispersion axis. [default: 0]
 
     bkgrd_prof : `~astropy.modeling.Model` or None, optional
-        A model for the image's background flux.
-        [default: models.Polynomial1D(2)]
+        A model for the image's background flux. If ``spatial_profile`` is set
+        to ``interpolated_profile``, then ``bkgrd_prof`` must be set to None.
+        [default: models.Polynomial1D(2)].
+
+    spatial_profile : str or dict, optional
+        The shape of the object profile. The first option is 'gaussian' to fit
+        a uniform 1D gaussian to the average of pixels in the cross-dispersion
+        direction. The other option is 'interpolated_profile'  - when this
+        option is used, the profile is sampled in bins and these samples are
+        interpolated between to construct a continuously varying, empirical
+        spatial profile for extraction. For this option, if passed in as a
+        string (i.e spatial_profile='interpolated_profile') the default values
+        for the number of bins used (10) and degree of interpolation
+        (linear in x and y, by default) will be used. To set these parameters,
+        pass in a dictionary with the keys 'n_bins_interpolated_profile' (which
+        accepts an integer number of bins) and 'interp_degree' (which accepts an
+        int, or tuple of ints for x and y degree, respectively).
+        [default: gaussian]
 
     variance : `~numpy.ndarray`, optional
         (Only used if ``image`` is not an NDData object.)
@@ -294,6 +324,7 @@ class HorneExtract(SpecreduceOperation):
     image: NDData
     trace_object: Trace
     bkgrd_prof: Model = field(default=models.Polynomial1D(2))
+    spatial_profile: str = 'gaussian'  # can actually be str, dict
     variance: np.ndarray = field(default=None)
     mask: np.ndarray = field(default=None)
     unit: np.ndarray = field(default=None)
@@ -420,9 +451,100 @@ class HorneExtract(SpecreduceOperation):
         return Spectrum1D(img * unit, spectral_axis=spectral_axis,
                           uncertainty=variance, mask=mask)
 
+    def _fit_gaussian_spatial_profile(self, img, disp_axis, crossdisp_axis,
+                                      or_mask, bkgrd_prof):
+
+        """
+            Fits an 1D Gaussian profile to spectrum in `img`. Takes the mean
+            of  ``img`` along the cross-dispersion axis (i.e, takes the mean of
+            each row for a horizontal trace). Any columns with non-finite values
+            are omitted from the fit. Background model (optional) is fit
+            simultaneously. Returns an `astropy.model.Gaussian1D` (or compound
+            model, if `bkgrd_prof` is supplied) fit to data.
+        """
+
+        # co-add signal in each image row
+        nrows = img.shape[crossdisp_axis]
+        ncols = img.shape[disp_axis]
+        xd_pixels = np.arange(nrows)
+
+        # for now, mask row with any non-finite value.
+        row_mask = np.logical_or.reduce(or_mask, axis=disp_axis)
+        coadd = np.ma.masked_array(np.sum(img, axis=disp_axis) / ncols,
+                                   mask=row_mask)
+
+        # use the sum of brightest row as an inital guess for Gaussian amplitude,
+        # the the location of the brightest row as an initial guess for the mean
+        gauss_prof = models.Gaussian1D(amplitude=coadd.max(),
+                                       mean=coadd.argmax(), stddev=2)
+
+        # Fit extraction kernel (Gaussian + background model) to coadded rows
+        # with combined model (must exclude masked indices manually;
+        # LevMarLSQFitter does not)
+        if bkgrd_prof is not None:
+            ext_prof = gauss_prof + bkgrd_prof
+        else:
+            # add a trivial constant model so attribute names are the same
+            ext_prof = gauss_prof + models.Const1D(0, fixed={'amplitude': True})
+
+        fitter = fitting.LevMarLSQFitter()
+        fit_ext_kernel = fitter(ext_prof, xd_pixels[~row_mask], coadd[~row_mask])
+
+        return fit_ext_kernel
+
+    def _fit_self_spatial_profile(self, img, disp_axis, crossdisp_axis, or_mask,
+                                  n_bins_interpolated_profile, kx, ky):
+
+        """
+            Fit a spatial profile to spectrum by sampling the median profile in
+            bins (number of which set be `n_bins_interpolated_profile` along the
+            dispersion direction, and interpolating between
+            samples. Columns (assuming horizontal trace) with any non-finite
+            values will be omitted from the fit. Returns an interpolator object
+            (RectBivariateSpline) that can be evaluated at any x,y.
+        """
+
+        # boundaries of bins for sampling profile.
+        sample_locs = np.linspace(0, img.shape[disp_axis]-1,
+                                  n_bins_interpolated_profile+1, dtype=int)
+        # centers of these bins, roughly
+        bin_centers = [(sample_locs[i]+sample_locs[i+1]) // 2 for i in
+                       range(len(sample_locs) - 1)]
+
+        # for now, since fitting isn't enabled for arrays with any nans
+        # mask out the columns with any non-finite values to make sure
+        # these don't contribute to the fit profile
+        col_mask = np.logical_or.reduce(or_mask, axis=crossdisp_axis)
+
+        # make a full mask for the image based on which cols have nans
+        img_col_mask = np.tile(col_mask, (img.shape[0], 1))
+
+        # need to make a new masked array since this mask is different
+        # omit all columns with nans from contributing to the fit
+        new_masked_arr = np.ma.array(img.data.copy(), mask=img_col_mask)
+
+        # sample at these locations, normalize to area so this just reflects the
+        # shape of the spectrum any shifts in center location should be corrected
+        # by _align_along_trace (this should be addressed later with a better way
+        # to flatten the trace, because trace can be wiggly even if 'flat'...)
+        samples = []
+        for i in range(n_bins_interpolated_profile):
+            slicee = new_masked_arr[:, sample_locs[i]:sample_locs[i+1]]
+            bin_median = np.ma.median(slicee, axis=disp_axis)
+            bin_median_sum = np.ma.sum(bin_median)
+            samples.append(bin_median / bin_median_sum)
+
+        interp_2d = RectBivariateSpline(x=bin_centers,
+                                        y=np.arange(img.shape[crossdisp_axis]),
+                                        z=samples, kx=kx, ky=ky)
+
+        return interp_2d
+
     def __call__(self, image=None, trace_object=None,
                  disp_axis=None, crossdisp_axis=None,
-                 bkgrd_prof=None,
+                 bkgrd_prof=None, spatial_profile=None,
+                 n_bins_interpolated_profile=None,
+                 interp_degree_interpolated_profile=None,
                  variance=None, mask=None, unit=None):
         """
         Run the Horne calculation on a region of an image and extract a
@@ -447,6 +569,21 @@ class HorneExtract(SpecreduceOperation):
 
         bkgrd_prof : `~astropy.modeling.Model`, optional
             A model for the image's background flux.
+
+        spatial_profile : str or dict, optional
+            The shape of the object profile. The first option is 'gaussian' to fit
+            a uniform 1D gaussian to the average of pixels in the cross-dispersion
+            direction. The other option is 'interpolated_profile'  - when this
+            option is used, the profile is sampled in bins and these samples are
+            interpolated between to construct a continuously varying, empirical
+            spatial profile for extraction. For this option, if passed in as a
+            string (i.e spatial_profile='interpolated_profile') the default values
+            for the number of bins used (10) and degree of interpolation
+            (linear in x and y, by default) will be used. To set these parameters,
+            pass in a dictionary with the keys 'n_bins_interpolated_profile' (which
+            accepts an integer number of bins) and 'interp_degree' (which accepts an
+            int, or tuple of ints for x and y degree, respectively).
+            [default: gaussian]
 
         variance : `~numpy.ndarray`, optional
             (Only used if ``image`` is not an NDData object.)
@@ -478,9 +615,57 @@ class HorneExtract(SpecreduceOperation):
         disp_axis = disp_axis if disp_axis is not None else self.disp_axis
         crossdisp_axis = crossdisp_axis if crossdisp_axis is not None else self.crossdisp_axis
         bkgrd_prof = bkgrd_prof if bkgrd_prof is not None else self.bkgrd_prof
+        spatial_profile = (spatial_profile if spatial_profile is not None else
+                           self.spatial_profile)
         variance = variance if variance is not None else self.variance
         mask = mask if mask is not None else self.mask
         unit = unit if unit is not None else self.unit
+
+        # figure out what 'spatial_profile' was provided
+        # put this parsing into another method at some point, its a lot..
+        interp_degree_interpolated_profile = None
+        n_bins_interpolated_profile = None
+        spatial_profile_choices = ('gaussian', 'interpolated_profile')
+
+        if isinstance(spatial_profile, str):
+            spatial_profile = spatial_profile.lower()
+            if spatial_profile not in spatial_profile_choices:
+                raise ValueError("spatial_profile must be one of"
+                                 f"{', '.join(spatial_profile_choices)}")
+            if spatial_profile == 'interpolated_profile':  # use defaults
+                bkgrd_prof = None
+                n_bins_interpolated_profile = 10
+                interp_degree_interpolated_profile = 1
+        elif isinstance(spatial_profile, dict):
+            # first, figure out what type of profile is indicated
+            # right now, the only type that should use a dictionary is 'interpolated_profile'
+            # but this may be extended in the future hence the 'name' key. also,
+            # the gaussian option could be supplied as a single-key dict
+
+            # will raise key error if not present, and also fail on .lower if not
+            # a string - think this is informative enough
+            spatial_profile_type = spatial_profile['name'].lower()
+
+            if spatial_profile_type not in spatial_profile_choices:
+                raise ValueError("spatial_profile must be one of"
+                                 f"{', '.join(spatial_profile_choices)}")
+            if spatial_profile_type == 'gaussian':
+                spatial_profile = 'gaussian'
+            else:
+                if 'n_bins_interpolated_profile' in spatial_profile.keys():
+                    n_bins_interpolated_profile = \
+                        spatial_profile['n_bins_interpolated_profile']
+                else:  # use default
+                    n_bins_interpolated_profile = 10
+                if 'interp_degree_interpolated_profile' in spatial_profile.keys():
+                    interp_degree_interpolated_profile = \
+                        spatial_profile['interp_degree_interpolated_profile']
+                else:  # use default
+                    interp_degree_interpolated_profile = 1
+            spatial_profile = spatial_profile_type
+            bkgrd_prof = None
+        else:
+            raise ValueError('``spatial_profile`` must either be string or dictionary.')
 
         # parse image and replace optional arguments with updated values
         self.image = self._parse_image(image, variance, mask, unit, disp_axis)
@@ -497,54 +682,89 @@ class HorneExtract(SpecreduceOperation):
 
         # If the trace is not flat, shift the rows in each column
         # so the image is aligned along the trace:
-        if isinstance(trace_object, FlatTrace):
-            mean_init_guess = trace_object.trace
-        else:
+        if not isinstance(trace_object, FlatTrace):
             img = _align_along_trace(
                 img,
                 trace_object.trace,
                 disp_axis=disp_axis,
-                crossdisp_axis=crossdisp_axis
-            )
-            # Choose the initial guess for the mean of
-            # the Gaussian profile:
-            mean_init_guess = np.broadcast_to(
-                img.shape[crossdisp_axis] // 2, img.shape[disp_axis]
-            )
+                crossdisp_axis=crossdisp_axis)
 
-        # co-add signal in each image column
-        nrows = img.shape[crossdisp_axis]
-        xd_pixels = np.arange(nrows)  # counted in y dir on plot (or x in spec)
+        if self.spatial_profile == 'gaussian':
 
-        row_mask = np.logical_or.reduce(or_mask, axis=disp_axis)
-        coadd = np.ma.masked_array(np.sum(img, axis=disp_axis) / nrows,
-                                   mask=row_mask)
-        # (mask rows with non-finite sums for fit to work later on)
+            # fit profile to average (mean) profile along crossdisp axis
+            fit_ext_kernel = self._fit_gaussian_spatial_profile(img,
+                                                                disp_axis,
+                                                                crossdisp_axis,
+                                                                or_mask,
+                                                                bkgrd_prof)
 
-        # fit source profile to brightest row, using Gaussian model as template
-        # NOTE: could add argument for users to provide their own model
-        gauss_prof = models.Gaussian1D(amplitude=coadd.max(),
-                                       mean=coadd.argmax(), stddev=2)
+            # this is just creating an array of the trace to shift the mean
+            # when iterating over each wavelength. this needs to be fixed in the
+            # future to actually account for the trace shape in a non-flat trace
+            # (or possibly omitted all togehter as it might be redundant if
+            # _align_along_trace is correcting this already)
+            if isinstance(trace_object, FlatTrace):
+                mean_init_guess = trace_object.trace
+            else:
+                mean_init_guess = np.broadcast_to(
+                    img.shape[crossdisp_axis] // 2, img.shape[disp_axis]
+                )
 
-        # Fit extraction kernel to column's finite values with combined model
-        # (must exclude masked indices manually; LevMarLSQFitter does not)
-        if bkgrd_prof is not None:
-            ext_prof = gauss_prof + bkgrd_prof
-        else:
-            # add a trivial constant model so attribute names are the same
-            ext_prof = gauss_prof + models.Const1D(0, fixed={'amplitude': True})
-        fitter = fitting.LevMarLSQFitter()
-        fit_ext_kernel = fitter(ext_prof,
-                                xd_pixels[~row_mask], coadd[~row_mask])
+        else:  # interpolated_profile
+            # for now, bkgrd_prof must be None because a compound model can't
+            # be created with a interpolator + model. i think there is a way
+            # around this, but will follow up later
+            if bkgrd_prof is not None:
+                raise ValueError('When `spatial_profile`is `interpolated_profile`,'
+                                 '`bkgrd_prof` must be None. Background should'
+                                 ' be fit and subtracted from `img` beforehand.')
+            # make sure n_bins doesnt exceed the number of (for now) finite
+            # columns. update this when masking is fixed.
+            n_finite_cols = np.logical_or.reduce(or_mask, axis=crossdisp_axis)
+            n_finite_cols = np.count_nonzero(n_finite_cols.astype(int) == 0)
 
-        # use compound model to fit a kernel to each fully finite image column
-        # NOTE: infers Gaussian1D source profile; needs generalization for others
+            # determine interpolation degree from input and make tuple if int
+            # this can also be moved to another method to parse the input
+            # 'spatial_profile' arg, eventually
+            if isinstance(interp_degree_interpolated_profile, int):
+                kx = ky = interp_degree_interpolated_profile
+            else:  # if input is tuple of ints
+
+                if not isinstance(interp_degree_interpolated_profile, tuple):
+                    raise ValueError("``interp_degree_interpolated_profile`` must be ",
+                                     "an integer or tuple of integers.")
+                if not all(isinstance(x, int) for x in interp_degree_interpolated_profile):
+                    raise ValueError("``interp_degree_interpolated_profile`` must be ",
+                                     "an integer or tuple of integers.")
+
+                kx, ky = interp_degree_interpolated_profile
+
+            if n_bins_interpolated_profile >= n_finite_cols:
+
+                raise ValueError(f'`n_bins_interpolated_profile` ({n_bins_interpolated_profile}) '
+                                 'must be less than the number of fully-finite '
+                                 f'wavelength columns ({n_finite_cols}).')
+
+            interp_spatial_prof = self._fit_self_spatial_profile(img, disp_axis,
+                                                                 crossdisp_axis,
+                                                                 or_mask,
+                                                                 n_bins_interpolated_profile,
+                                                                 kx, ky)
+
+            # add private attribute to save fit profile. should this be public?
+            self._interp_spatial_prof = interp_spatial_prof
+
         col_mask = np.logical_or.reduce(or_mask, axis=crossdisp_axis)
         nonf_col = [np.nan] * img.shape[crossdisp_axis]
+
+        # array of 'x' values for each wavelength for extraction
+        nrows = img.shape[crossdisp_axis]
+        xd_pixels = np.arange(nrows)
 
         kernel_vals = []
         norms = []
         for col_pix in range(img.shape[disp_axis]):
+
             # for now, skip columns with any non-finite values
             # NOTE: fit and other kernel operations should support masking again
             # once a fix is in for renormalizing columns with non-finite values
@@ -553,19 +773,29 @@ class HorneExtract(SpecreduceOperation):
                 norms.append(np.nan)
                 continue
 
-            # else, set compound model's mean to column's matching trace value
-            fit_ext_kernel.mean_0 = mean_init_guess[col_pix]
+            if self.spatial_profile == 'gaussian':
 
-            # NOTE: support for variable FWHMs forthcoming and would be here
+                # set compound model's mean to column's matching trace value
+                # again, this is probably not necessary
+                if bkgrd_prof is not None:  # attr names will be diff. if not compound
+                    fit_ext_kernel.mean_0 = mean_init_guess[col_pix]
+                else:
+                    fit_ext_kernel.mean = mean_init_guess[col_pix]
 
-            # fit compound model to column
-            fitted_col = fit_ext_kernel(xd_pixels)
+                # evaluate fit model (with shifted mean, based on trace)
+                fitted_col = fit_ext_kernel(xd_pixels)
 
-            # save result and normalization
-            kernel_vals.append(fitted_col)
+                # save result and normalization
+                # this doesn't need to be in this loop, address later
+                kernel_vals.append(fitted_col)
 
-            norms.append(fit_ext_kernel.amplitude_0
-                         * fit_ext_kernel.stddev_0 * np.sqrt(2*np.pi))
+                norms.append(fit_ext_kernel.amplitude_0
+                             * fit_ext_kernel.stddev_0 * np.sqrt(2*np.pi))
+
+            else:  # interpolated_profile
+                fitted_col = interp_spatial_prof(col_pix, xd_pixels)
+                kernel_vals.append(fitted_col)
+                norms.append(np.trapz(fitted_col, dx=1)[0])
 
         # transform fit-specific information
         kernel_vals = np.vstack(kernel_vals).T


### PR DESCRIPTION
This PR adds the 'self_profile' option to HorneExtract. Closes JDAT-3222.

A summary of how this works (row/col language assuming a horizontal trace):
- The image is divided along the dispersion axis into equal (plus minus one to make integer sized bins) bins along the x axis.
- Columns with masked or NaN values are omitted (see comments below, proper masking should be addressed eventually)
- The median in each bin along the x axis is computed, producing a median profile in that bin
- These samples are interpolated between (using RectBivariateSpline, by default linearly)
- The Horne normalization process now happens for each column. The interpolator is evaluated at that wavelength column to produce the spatial profile used for weighting. A 1D spectrum object is returned.


I also expanded the docs and fixed a few things in there (i.e a mask is not strictly required for HorneExtract as implied before, but is optional and currently limited in its functionality) 

A few comments, concerns I have for reviewers:
1. This, like the default Gaussian option, does not handle masking properly. This should be addressed in a follow up PR but for now I kept the same limitation that if there are any masked values in a wavelength column, the 1D spectrum will not be returned for that wavelength.
2. Should we return the fit profile (a 2D interpolator object, or the interpolator evaluated on the image grid) as an attribute on the extract object? Right now I have it as a private attribute for testing purposes, but I'm not sure if this is something users would go looking for?
4. The Gaussian option allows you to provide 'bkg_model' to fit simultaneously with the Gaussian extraction kernel, creating a compound model. I did not implement this for the self_profile option because it was not straightforward since I'm no longer using models/fitters and couldn't create a compound model to fit. I also disagree with this option in general, as the documentation and existence of background steps in Specreduce implies that background should be removed beforehand, so I didn't want to spend too much time figuring this out in the event that others agree with my opinion on this. If not, I will figure out how to add this option in a follow up PR.