### PR TITLE
Expose residuals in WavelengthCalibration1D

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ spatial profile that can be evaluated at any wavelength.[ #173]
 API Changes
 ^^^^^^^^^^^
 
+- Fit residuals exposed for wavelength calibration in WavelengthCalibration1D.fit_residuals. [#446]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -1,4 +1,5 @@
 from numpy.testing import assert_allclose
+import numpy as np
 import pytest
 
 from astropy.table import QTable
@@ -83,3 +84,30 @@ def test_expected_errors(spec1d):
 
     with pytest.raises(ValueError, match="specify at least one"):
         WavelengthCalibration1D(spec1d, line_pixels=centers)
+
+
+def test_fit_residuals(spec1d):
+    # test that fit residuals are all 0 when input is perfectly linear and model
+    # is a linear model
+
+    centers = np.array([0, 10, 20, 30])
+    w = (0.5 * centers + 2) * u.AA
+    test = WavelengthCalibration1D(spec1d, line_pixels=centers,
+                                   line_wavelengths=w)
+
+    test.apply_to_spectrum(spec1d)  # have to apply for residuals to be computed
+
+    assert_quantity_allclose(test.fit_residuals, 0.*u.AA, atol=1e-07*u.AA)
+
+
+def test_fit_residuals_access(spec1d):
+    # make sure that accessing fit_residuals fails if .wcs hasn't been accessed
+    # yet, which is the property that performs the fit. ``apply_to_spectrum``
+    # also accesses .wcs, so if this is run fit_residuals will be available as well
+
+    centers = np.array([0, 10, 20, 30])
+    w = (0.5 * centers + 2) * u.AA
+    test = WavelengthCalibration1D(spec1d, line_pixels=centers,
+                                   line_wavelengths=w)
+    with pytest.raises(ValueError):
+        test.fit_residuals

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -109,5 +109,8 @@ def test_fit_residuals_access(spec1d):
     w = (0.5 * centers + 2) * u.AA
     test = WavelengthCalibration1D(spec1d, line_pixels=centers,
                                    line_wavelengths=w)
-    with pytest.raises(ValueError):
+    expected_msg = ('Fit residuals are only available after the new WCS is'
+                    ' fit - this can be done by accessing the ``.wcs`` attribute,'
+                    ' or by calling the ``.apply_to_spectrum`` method.')
+    with pytest.raises(ValueError, match=expected_msg):
         test.fit_residuals

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -205,8 +205,8 @@ class WavelengthCalibration1D():
 
         if self._fit_resids is None:
             raise ValueError('Fit residuals are only available after the new'
-                             'WCS is fit - this can be done by accessing the'
-                             '``.wcs`` attribute, or by calling the'
+                             ' WCS is fit - this can be done by accessing the'
+                             ' ``.wcs`` attribute, or by calling the'
                              ' ``.apply_to_spectrum`` method.')
 
         # Get the fit residuals by evaulating model


### PR DESCRIPTION
Add ``fit_residuals`` attribute to ``WavelengthCalibration1D``. These are computed by evaluating the model after the fit is performed, which is done when ``apply_to_spectrum`` is called.

(Closes JDAT-3405)