### PR TITLE
store the fitted_model as its own cached_property

### DIFF
--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -101,16 +101,11 @@ def test_fit_residuals(spec1d):
 
 
 def test_fit_residuals_access(spec1d):
-    # make sure that accessing fit_residuals fails if .wcs hasn't been accessed
-    # yet, which is the property that performs the fit. ``apply_to_spectrum``
-    # also accesses .wcs, so if this is run fit_residuals will be available as well
+    # make sure that accessing fit_residuals can be called before wcs/apply_to_spectrum
 
     centers = np.array([0, 10, 20, 30])
     w = (0.5 * centers + 2) * u.AA
     test = WavelengthCalibration1D(spec1d, line_pixels=centers,
                                    line_wavelengths=w)
-    expected_msg = ('Fit residuals are only available after the new WCS is'
-                    ' fit - this can be done by accessing the ``.wcs`` attribute,'
-                    ' or by calling the ``.apply_to_spectrum`` method.')
-    with pytest.raises(ValueError, match=expected_msg):
-        test.fit_residuals
+    test.fit_residuals
+    test.wcs

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -46,10 +46,10 @@ def test_poly_from_table(spec1d):
     table = QTable([centers, w], names=["pixel_center", "wavelength"])
 
     test = WavelengthCalibration1D(spec1d, matched_line_list=table,
-                                   model=Polynomial1D(2), fitter=LinearLSQFitter())
+                                   input_model=Polynomial1D(2), fitter=LinearLSQFitter())
     test.apply_to_spectrum(spec1d)
 
-    assert_allclose(test.model.parameters, [5.00477143e+03, 1.03457143e+01, 1.28571429e-02])
+    assert_allclose(test.fitted_model.parameters, [5.00477143e+03, 1.03457143e+01, 1.28571429e-02])
 
 
 def test_replace_spectrum(spec1d, spec1d_with_emission_line):
@@ -97,15 +97,15 @@ def test_fit_residuals(spec1d):
 
     test.apply_to_spectrum(spec1d)  # have to apply for residuals to be computed
 
-    assert_quantity_allclose(test.fit_residuals, 0.*u.AA, atol=1e-07*u.AA)
+    assert_quantity_allclose(test.residuals, 0.*u.AA, atol=1e-07*u.AA)
 
 
 def test_fit_residuals_access(spec1d):
-    # make sure that accessing fit_residuals can be called before wcs/apply_to_spectrum
+    # make sure that accessing residuals can be called before wcs/apply_to_spectrum
 
     centers = np.array([0, 10, 20, 30])
     w = (0.5 * centers + 2) * u.AA
     test = WavelengthCalibration1D(spec1d, line_pixels=centers,
                                    line_wavelengths=w)
-    test.fit_residuals
+    test.residuals
     test.wcs

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -213,10 +213,7 @@ class WavelengthCalibration1D():
     def residuals(self):
         """
         calculate fit residuals between matched line list pixel centers and
-        wavelengths and the evaluated fit model. this is only accessible
-        after the ``wcs`` attribute is accessed, where the fit is actually
-        performed. ``apply_to_spectrum`` also calls .wcs and therefore
-        performs the fit, so this is also acessible if that is called.
+        wavelengths and the evaluated fit model.
         """
 
         x = self._matched_line_list["pixel_center"]

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -65,11 +65,10 @@ class WavelengthCalibration1D():
         """
         self._input_spectrum = input_spectrum
         self._model = model
-        self._cached_properties = ['wcs', 'fit_residuals',]
+        self._cached_properties = ['fit_model', 'fit_residuals', 'wcs']
         self.fitter = fitter
         self._potential_wavelengths = None
         self._catalog = catalog
-        self._fit_resids = None
 
         # ToDo: Implement having line catalogs
         self._available_catalogs = get_available_catalogs()
@@ -193,29 +192,7 @@ class WavelengthCalibration1D():
         self._model = new_model
 
     @cached_property
-    def fit_residuals(self):
-        # calculate fit residuals between matched line list pixel centers and
-        # wavelengths and the evaluated fit model. this is only accessible
-        # after the ``wcs`` attribute is accessed, where the fit is actually
-        # performed. ``apply_to_spectrum`` also calls .wcs and therefore
-        # performs the fit, so this is also acessible if that is called.
-
-        x = self._matched_line_list["pixel_center"]
-        y = self._matched_line_list["wavelength"]
-
-        if self._fit_resids is None:
-            raise ValueError('Fit residuals are only available after the new'
-                             ' WCS is fit - this can be done by accessing the'
-                             ' ``.wcs`` attribute, or by calling the'
-                             ' ``.apply_to_spectrum`` method.')
-
-        # Get the fit residuals by evaulating model
-        self._fit_resids = y - self._model(x)
-
-        return self._fit_resids
-
-    @cached_property
-    def wcs(self):
+    def fit_model(self):
         # computes and returns WCS after fitting self.model to self.refined_pixels
         x = self._matched_line_list["pixel_center"]
         y = self._matched_line_list["wavelength"]
@@ -230,20 +207,34 @@ class WavelengthCalibration1D():
             fitter = self.fitter
 
         # Fit the model
-        self._model = fitter(self._model, x, y)
+        return fitter(self.model, x, y)
 
+    @cached_property
+    def fit_residuals(self):
+        """
+        calculate fit residuals between matched line list pixel centers and
+        wavelengths and the evaluated fit model. this is only accessible
+        after the ``wcs`` attribute is accessed, where the fit is actually
+        performed. ``apply_to_spectrum`` also calls .wcs and therefore
+        performs the fit, so this is also acessible if that is called.
+        """
+
+        x = self._matched_line_list["pixel_center"]
+        y = self._matched_line_list["wavelength"]
+
+        # Get the fit residuals by evaulating model
+        return y - self.fit_model(x)
+
+    @cached_property
+    def wcs(self):
         # Build a GWCS pipeline from the fitted model
         pixel_frame = cf.CoordinateFrame(1, "SPECTRAL", [0,], axes_names=["x",], unit=[u.pix,])
         spectral_frame = cf.SpectralFrame(axes_names=["wavelength",],
                                           unit=[self._matched_line_list["wavelength"].unit,])
 
-        pipeline = [(pixel_frame, self.model), (spectral_frame, None)]
+        pipeline = [(pixel_frame, self.fit_model), (spectral_frame, None)]
 
         wcsobj = wcs.WCS(pipeline)
-
-        # set _fit_resids to False instead of None, to indicate that the attribute
-        # is accessible and to calculate it within ``fit_residuals`` when accessed
-        self._fit_resids = False
 
         return wcsobj
 


### PR DESCRIPTION
As a follow-up to #175, this refactors the code slightly so that it is not necessary to call `cal.wcs` or `cal.appy_to_spectrum` before calling `cal.residuals` (and also does some renaming from `fit_residuals` > `residuals` and `model` > `input_model`).  This also separates the _input_ `cal.input_model` from the _output_ `cal.fitted_model` and therefore slightly changes the behavior if calling successive fits on the same calibration object.  If you want to "pick up where you left off", you could now do something like:

```
cal = WavelengthCalibration1D(lamp_spectrum_1, model=Linear1D, ...)
cal.apply_to_spectrum(science_spectrum_1)

cal.input_spectrum = lamp_spectrum_2
cal.input_model = cal.fitted_model
cal.apply_to_spectrum(science_spectrum_2)
```