### PR TITLE
TST: Update URL for Scientific Python nightlies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ isolated_build = true
 passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI
 
 setenv =
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree


### PR DESCRIPTION
Scientific Python packages have moved their nightly wheels to a new location. xref astropy/astropy#14869

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.