### PR TITLE
Update and clean up test environments

### DIFF
--- a/.github/workflows/cron-tests.yml
+++ b/.github/workflows/cron-tests.yml
@@ -29,10 +29,10 @@ jobs:
             tox_env: 'linkcheck'
           - os: ubuntu-latest
             python: '3.12'
-            tox_env: 'py311-test-devdeps'
+            tox_env: 'py312-test-devdeps'
           - os: ubuntu-latest
             python: '3.12'
-            tox_env: 'py311-test-predeps'
+            tox_env: 'py312-test-predeps'
 
     steps:
     - name: Check out repository

--- a/.github/workflows/cron-tests.yml
+++ b/.github/workflows/cron-tests.yml
@@ -47,12 +47,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox
-    - name: Print Python, pip, setuptools, and tox versions
-      run: |
-        python -c "import sys; print(f'Python {sys.version}')"
-        python -c "import pip; print(f'pip {pip.__version__}')"
-        python -c "import setuptools; print(f'setuptools {setuptools.__version__}')"
-        python -c "import tox; print(f'tox {tox.__version__}')"
     - name: Test with tox
       run: |
         tox -e ${{ matrix.tox_env }}

--- a/.github/workflows/cron-tests.yml
+++ b/.github/workflows/cron-tests.yml
@@ -25,14 +25,14 @@ jobs:
         # For example -- os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
-            python: '3.10'
+            python: '3.11'
             tox_env: 'linkcheck'
           - os: ubuntu-latest
-            python: '3.10'
-            tox_env: 'py310-test-datadeps-devdeps'
+            python: '3.12'
+            tox_env: 'py311-test-devdeps'
           - os: ubuntu-latest
-            python: '3.10'
-            tox_env: 'py310-test-datadeps-predeps'
+            python: '3.12'
+            tox_env: 'py311-test-predeps'
 
     steps:
     - name: Check out repository

--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -40,14 +40,17 @@ jobs:
           - os: ubuntu-latest
             python: '3.10'
             tox_env: 'py310-test-cov'
-          - os: macos-latest
-            python: '3.10'
-            tox_env: 'py310-test-devdeps'
           - os: ubuntu-latest
             python: '3.11'
             tox_env: 'py311-test'
           - os: ubuntu-latest
-            python: '3.10'
+            python: '3.12'
+            tox_env: 'py312-test'
+          - os: macos-latest
+            python: '3.12'
+            tox_env: 'py312-test-devdeps'
+          - os: ubuntu-latest
+            python: '3.12'
             tox_env: 'codestyle'
           - os: ubuntu-latest
             python: '3.8'

--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -69,12 +69,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox
-    - name: Print Python, pip, setuptools, and tox versions
-      run: |
-        python -c "import sys; print(f'Python {sys.version}')"
-        python -c "import pip; print(f'pip {pip.__version__}')"
-        python -c "import setuptools; print(f'setuptools {setuptools.__version__}')"
-        python -c "import tox; print(f'tox {tox.__version__}')"
     - name: Test with tox
       run: |
         tox -e ${{ matrix.tox_env }}

--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -32,12 +32,6 @@ jobs:
         # For example -- os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
-            python: '3.8'
-            tox_env: 'py38-test'
-          - os: ubuntu-latest
-            python: '3.9'
-            tox_env: 'py39-test'
-          - os: ubuntu-latest
             python: '3.10'
             tox_env: 'py310-test-cov'
           - os: ubuntu-latest

--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -47,8 +47,8 @@ jobs:
             python: '3.12'
             tox_env: 'codestyle'
           - os: ubuntu-latest
-            python: '3.8'
-            tox_env: 'py38-test-oldestdeps'
+            python: '3.10'
+            tox_env: 'py310-test-oldestdeps'
 
     steps:
     - name: Check out repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,7 @@ requires = ["setuptools",
             "cython"]
 
 build-backend = 'setuptools.build_meta'
+
+[tool.pytest.ini_options]
+
+filterwarnings = ["ignore::DeprecationWarning:datetime",]

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,8 @@ isolated_build = true
 passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI
 
 setenv =
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    py312: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple
 
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree

--- a/tox.ini
+++ b/tox.ini
@@ -44,9 +44,9 @@ deps =
     devdeps: git+https://github.com/astropy/specutils.git#egg=specutils
     devdeps: git+https://github.com/astropy/photutils.git#egg=photutils
 
-    oldestdeps: numpy==1.20
+    oldestdeps: numpy==1.22.4
     oldestdeps: astropy==5.1
-    oldestdeps: scipy==1.6.0
+    oldestdeps: scipy==1.8.0
     oldestdeps: matplotlib==3.5
     oldestdeps: photutils==1.0.0
     oldestdeps: specutils==1.9.1

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ deps =
     oldestdeps: specutils==1.9.1
 
     # Currently need dev astropy with python 3.12 as well
-    py312-test: astropy>=0.0.dev0
+    py312: astropy>=0.0.dev0
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ description =
 deps =
 
     devdeps: numpy>=0.0.dev0
-    devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
+    devdeps: astropy>=0.0.dev0
     devdeps: git+https://github.com/astropy/specutils.git#egg=specutils
 
     oldestdeps: numpy==1.20
@@ -48,8 +48,8 @@ deps =
     oldestdeps: photutils==1.0.0
     oldestdeps: specutils==1.9.1
 
-    # Currently need dev astropy with python 3.12
-    py312: git+https://github.com/astropy/astropy.git#egg=astropy
+    # Currently need dev astropy with python 3.12 as well
+    py312: astropy>=0.0.dev0
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311}-test{,-devdeps}{,-cov}
-    py{38,39,310,311}-test-numpy{120,121,122,123}
-    py{38,39,310,311}-test-astropy{lts,rc}
+    py{38,39,310,311,312}-test{,-devdeps,-predeps}{,-cov}
     build_docs
     codestyle
 requires =
@@ -35,22 +33,9 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: enable remote data and measure test coverage
-    numpy120: with numpy 1.20.*
-    numpy121: with numpy 1.21.*
-    numpy122: with numpy 1.22.*
-    numpy123: with numpy 1.23.*
-    astropylts: with the latest astropy LTS
 
 # The following provides some specific pinnings for key packages
 deps =
-
-    numpy120: numpy==1.20.*
-    numpy121: numpy==1.21.*
-    numpy122: numpy==1.22.*
-    numpy123: numpy==1.23.*
-
-    astropy51: astropy==5.1.*
-    astropylts: astropy==5.1.*
 
     devdeps: numpy>=0.0.dev0
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
@@ -63,12 +48,17 @@ deps =
     oldestdeps: photutils==1.0.0
     oldestdeps: specutils==1.9.1
 
+    # Currently need dev astropy with python 3.12
+    py312: git+https://github.com/astropy/astropy.git#egg=astropy
+
 # The following indicates which extras_require from setup.cfg will be installed
 extras =
     test: test
     build_docs: docs
 
 commands =
+    # Force numpy-dev after matplotlib downgrades it (https://github.com/matplotlib/matplotlib/issues/26847)
+    devdeps: python -m pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
     pip freeze
     !cov: pytest --pyargs specreduce {toxinidir}/docs {posargs}
     cov: pytest --pyargs specreduce {toxinidir}/docs --cov specreduce --cov-config={toxinidir}/setup.cfg --remote-data {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ description =
 deps =
 
     devdeps: numpy>=0.0.dev0
+    devdeps: scipy>=0.0.dev0
     devdeps: astropy>=0.0.dev0
     devdeps: git+https://github.com/astropy/specutils.git#egg=specutils
 

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ deps =
     oldestdeps: specutils==1.9.1
 
     # Currently need dev astropy with python 3.12 as well
-    py312: astropy>=0.0.dev0
+    py312-test: astropy>=0.0.dev0
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,8 @@ extras =
 commands =
     # Force numpy-dev after matplotlib downgrades it (https://github.com/matplotlib/matplotlib/issues/26847)
     devdeps: python -m pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+    # Maybe we also have to do this for scipy?
+    devdeps: python -m pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
     pip freeze
     !cov: pytest --pyargs specreduce {toxinidir}/docs {posargs}
     cov: pytest --pyargs specreduce {toxinidir}/docs --cov specreduce --cov-config={toxinidir}/setup.cfg --remote-data {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     build_docs
     codestyle
 requires =
-    setuptools >= 30.3.0
+    setuptools
     pip >= 19.3.1
 isolated_build = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ deps =
     devdeps: scipy>=0.0.dev0
     devdeps: astropy>=0.0.dev0
     devdeps: git+https://github.com/astropy/specutils.git#egg=specutils
+    devdeps: git+https://github.com/astropy/photutils.git#egg=photutils
 
     oldestdeps: numpy==1.20
     oldestdeps: astropy==5.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312}-test{,-devdeps,-predeps}{,-cov}
+    py{310,311,312}-test{,-devdeps,-predeps}{,-cov}
     build_docs
     codestyle
 requires =


### PR DESCRIPTION
This does a few things:

- Cleans up lines related to numpy and astropy test envs that aren't actually used in any tests.
- Adds/updates tests to use python 3.12, installs dev astropy for those to get around deprecation warning.
- Fixes (I hope) the weekly cron test, which was failing because there was no `predeps` test environment defined.
- Forces dev numpy to install in `devdeps` after it would be downgraded by matplotlib.

Closes #185, #186, #187, #188.