### PR TITLE
fix for masked values in FitTrace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,11 @@ Bug Fixes
 
 - HorneExtract now accepts 'None' as a vaild option for ``bkgrd_prof``. [#171]
 
+- Fix for fully masked bins in FitTrace when using ``gaussian`` for ``peak_method``.
+  Fully masked columns now have a peak of nan, which is used for the all-bin fit
+  for the Trace. Warning messages for ``peak_method`` == ``max`` and ``centroid``
+  are also now reflective of what the bin peak is being set to. [#205]
+
 Other changes
 ^^^^^^^^^^^^^
 


### PR DESCRIPTION
This PR fixes some issues with FitTrace when bins are fully masked:

1. If `peak_method=gaussian`, the fit will fail if even one column/bin is fully masked, with the error being raised by the fitter. This PR fixes that issue by setting the fit trace value to nan for that column, so it can proceed and fit the next bin. For the final fit to all bin peaks for the trace, these nans bins/columns will then be filtered. 

2. If peak_method=max or centroid, a warning when a fully masked bin is encountered claiming that it is 'Falling back on trace value from all-bin fit.'. This is not accurate to what is happening
      2a. for `max`, the argmax of that bin will be returned which is always 0 for a fully masked bin. To avoid skewing the final fit to all bins when 0, i think a more appropriate value for this is 'nan' which can then be filtered from the final fit. theres nothing to really 'fall back' to in this case. This will require fixing almost all of the tests, so for now in this PR i just modify the warning message and retain the current behavior. See ISSUE.
       2b.  for `centroid`, when there is a fully masked bin it is also not 'falling back to the all bin fit'. to find the centroid of a fully masked bin, it attempts to interpolate between nans and will always return the maximum index in the bin. Like `max`, i am not changing the current behavior in this PR, that can be done as a follow up to resolve the corresponding ISSUE, but I change the warning message to reflect what is actually happening at the moment.

I also reorganized some stuff out of post_init into its own method, but this change is inconsequential. 