### PR TITLE
Move some image parsing logic

### DIFF
--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -9,7 +9,7 @@ from astropy.nddata import NDData
 from astropy.utils.decorators import deprecated_attribute
 from specutils import Spectrum1D
 
-from specreduce.core import _ImageParser
+from specreduce.core import _ImageParser, _get_data_from_image
 from specreduce.extract import _ap_weight_image
 from specreduce.tracing import Trace, FlatTrace
 
@@ -183,7 +183,7 @@ class Background(_ImageParser):
         crossdisp_axis : int
             cross-dispersion axis
         """
-        image = cls._parse_image(cls, image)
+        image = _get_data_from_image(image) if image is not None else cls.image
         kwargs['traces'] = [trace_object-separation, trace_object+separation]
         return cls(image=image, **kwargs)
 
@@ -220,7 +220,7 @@ class Background(_ImageParser):
         crossdisp_axis : int
             cross-dispersion axis
         """
-        image = cls._parse_image(cls, image)
+        image = _get_data_from_image(image) if image is not None else cls.image
         kwargs['traces'] = [trace_object+separation]
         return cls(image=image, **kwargs)
 

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -11,6 +11,19 @@ from specutils import Spectrum1D
 __all__ = ['SpecreduceOperation']
 
 
+def _get_data_from_image(image):
+    """Extract data array from various input types for `image`.
+       Retruns `np.ndarray` of image data."""
+
+    if isinstance(image, u.quantity.Quantity):
+        img = image.value
+    if isinstance(image, np.ndarray):
+        img = image
+    else:  # NDData, including CCDData and Spectrum1D
+        img = image.data
+    return img
+
+
 class _ImageParser:
     """
     Coerces images from accepted formats to Spectrum1D objects for
@@ -26,6 +39,7 @@ class _ImageParser:
         - `~astropy.units.quantity.Quantity`
         - `~numpy.ndarray`
     """
+
     def _parse_image(self, image, disp_axis=1):
         """
         Convert all accepted image types to a consistently formatted
@@ -50,12 +64,7 @@ class _ImageParser:
             # useful for Background's instance methods
             return self.image
 
-        if isinstance(image, np.ndarray):
-            img = image
-        elif isinstance(image, u.quantity.Quantity):
-            img = image.value
-        else:  # NDData, including CCDData and Spectrum1D
-            img = image.data
+        img = _get_data_from_image(image)
 
         # mask and uncertainty are set as None when they aren't specified upon
         # creating a Spectrum1D object, so we must check whether these

--- a/specreduce/tests/test_tracing.py
+++ b/specreduce/tests/test_tracing.py
@@ -154,7 +154,7 @@ class TestMasksTracing():
         index_arr = np.tile(np.arange(nrows), (ncols, 1))
         img = col_model(index_arr.T) + noise
 
-        return img
+        return img * u.DN
 
     def test_window_fit_trace(self):
 


### PR DESCRIPTION
Move part of the image parsing logic to its own function to avoid an issue in Background one_sided/two_sided.

Background.one_sided/two_sided were calling an instance method from _Image_Parser. This works as is, but if you were to then try to call another instance method from within that one, it does not understand 'self' and will cause an error. I moved the bit of code that Background needed to its own function to avoid this issue (which doesn't exist in main yet, but does in work on another branch I have).

Also fixed a bug where checking if data was `u.quantity.Quantity` was never triggered because the check for `np.ndarray` happened first.

I don't think this needs a change log.