### PR TITLE
fix input for background.traces, raise error in FlatTrace for negative trace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,9 @@ Bug Fixes
   were set to the number of rows in the image, biasing the final fit to all bin
   peaks. Previously for Gaussian, the entire fit failed. [#205, #206]
 
+- Fixed input of `traces` in `Background`. Added a condition to 'FlatTrace' that
+  trace position must be a positive number. [#211]
+
 Other changes
 ^^^^^^^^^^^^^
 

--- a/specreduce/tests/test_background.py
+++ b/specreduce/tests/test_background.py
@@ -109,3 +109,29 @@ def test_warnings_errors(mk_test_spec_no_spectral_axis):
 
     with pytest.raises(ValueError, match="width must be positive"):
         Background.two_sided(image, 25, 2, width=-1)
+
+
+def test_trace_inputs(mk_test_img_raw):
+
+    image = mk_test_img_raw
+
+    # When `Background` object is created with no Trace object passed in it should
+    # create a FlatTrace in the middle of the image (according to disp. axis)
+    background = Background(image, width=5)
+    assert np.all(background.traces[0].trace.data == image.shape[1] / 2.)
+
+    # FlatTrace(s) should be created if number or list of numbers is passed in for `traces`
+    background = Background(image, 10., width=5)
+    assert isinstance(background.traces[0], FlatTrace)
+    assert background.traces[0].trace_pos == 10.
+
+    traces = [10., 15]
+    background = Background(image, traces, width=5)
+    for i, trace_pos in enumerate(traces):
+        assert background.traces[i].trace_pos == trace_pos
+
+    # make sure error is raised if input for `traces` is invalid
+    match_str = 'objects, a number or list of numbers to define FlatTraces, ' +\
+                'or None to use a FlatTrace in the middle of the image.'
+    with pytest.raises(ValueError, match=match_str):
+        Background(image, 'non_valid_trace_pos')

--- a/specreduce/tests/test_tracing.py
+++ b/specreduce/tests/test_tracing.py
@@ -36,8 +36,12 @@ def test_flat_trace():
     t.set_position(400.)
     assert t[0] == 400.
 
-    t.set_position(-100)
-    assert np.ma.is_masked(t[0])
+
+def test_negative_flat_trace_err():
+    # make sure correct error is raised when trying to create FlatTrace with
+    # negative trace_pos
+    with pytest.raises(ValueError, match='must be positive.'):
+        FlatTrace(IM, trace_pos=-1)
 
 
 # test array traces

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -110,6 +110,8 @@ class FlatTrace(Trace, _ImageParser):
         trace_pos : float
             Position of the trace
         """
+        if trace_pos < 1:
+            raise ValueError('`trace_pos` must be positive.')
         self.trace_pos = trace_pos
         self.trace = np.ones_like(self.image.data[0]) * self.trace_pos
         self._bound_trace()


### PR DESCRIPTION
This PR cleans up a few things in Background.

1. Added a condition to FlatTrace that trace position must be negative. This check was originally done in Background when a FlatTrace was being used, but should generally be done. Before, if trace_pos was negative, a fully masked trace was being returned.

2. Previously, Background produced an unrelated error if 'traces' was None. Now, if no trace/number is passed in, a FlatTrace in the middle of the image will be used. 

3. There was some other inconsistencies with inputs - the docstring said 'traces' must be a list, but the logic in the code implied that it could be a Trace object not in a list. Also, a FlatTrace object can be defined with either a float or an int, where previously 'Background' allowed only integer inputs. I fixed this to allow either single trace/int/float or list trace/int/float inputs. The only condition is that lists must all be of the same type (either numeric or `Trace`). I also added some checks for input to make sure something valid is passed in for `traces` (either None, int/float or list of int/float to define FlatTraces, or a Trace object, or a list of Trace objects). I also added tests for all of these allowed inputs.

