### PR TITLE
update namespace of Background in the documentation (docs/extraction_quickstart.rst)

### DIFF
--- a/docs/extraction_quickstart.rst
+++ b/docs/extraction_quickstart.rst
@@ -47,12 +47,12 @@ defined by one or more windows, and can be generated with:
 
 The center of the window can either be passed as a float/integer or as a trace::
 
-  bg = specreduce.tracing.Background.one_sided(image, trace, separation=5, width=2)
+  bg = specreduce.background.Background.one_sided(image, trace, separation=5, width=2)
 
 
 or, equivalently::
 
-  bg = specreduce.tracing.Background.one_sided(image, 15, separation=5, width=2)
+  bg = specreduce.background.Background.one_sided(image, 15, separation=5, width=2)
 
 
 The background image can be accessed via `~specreduce.background.Background.bkg_image`


### PR DESCRIPTION
Replace `specreduce.tracing.Background` with `specreduce.background.Background` for correct calling of the `Background` submodule.