### PR TITLE
Fix for PypeIt calibration line loading

### DIFF
--- a/specreduce/calibration_data.py
+++ b/specreduce/calibration_data.py
@@ -280,14 +280,12 @@ def load_pypeit_calibration_lines(
         warnings.warn(f"No calibration lines loaded from {lamps}.")
         linelist = None
     else:
-        linelist = vstack(linelists)
+        linelist = QTable(vstack(linelists))
         linelist.rename_column('wave', 'wavelength')
         # pypeit linelists use vacuum wavelengths in angstroms
         linelist['wavelength'] *= u.Angstrom
         if wave_air:
             linelist['wavelength'] = vac_to_air(linelist['wavelength'])
-        linelist = QTable(linelist)
-
     return linelist
 
 


### PR DESCRIPTION
This PR fixes Issue #227 by converting the `linelist` table in `specreduce.calibration_data.load_pypeit_calibration_lines` from a Table to a QTable before calling `specutils.utils.wcs_utils.vac_to_air`. The `vac_to_air` function requires wavelengths to be given as `Quantity` objects, but the line list was a Table instead of a QTable. 