### PR TITLE
Issue 170 align spectrum along trace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,15 +18,12 @@ Other changes
 
 New Features
 ^^^^^^^^^^^^
+
 - Added the ``mask_treatment`` parameter to Background, Trace, and Boxcar Extract
   operations to handle non-finite data and boolean masks. Choice of ``filter``,
   ``omit``, or ``zero-fill``. [#216]
 
-API Changes
-^^^^^^^^^^^
 
-New Features
-^^^^^^^^^^^^
 - Added a ``specreduce.utils.align_2d_spectrum_along_trace`` utility function that aligns a
   rectilinear 2D spectrum image along a spectrum trace. The rectification can be done using
   either linear interpolation, giving a sub-pixel shift resolution, or using integer shifts.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,13 @@ New Features
 API Changes
 ^^^^^^^^^^^
 
+New Features
+^^^^^^^^^^^^
+- Added a ``specreduce.utils.align_2d_spectrum_along_trace`` utility function that aligns a
+  rectilinear 2D spectrum image along a spectrum trace. The rectification can be done using
+  either linear interpolation, giving a sub-pixel shift resolution, or using integer shifts.
+  The function also updates the image mask and propagates the uncertainties.
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/specreduce/tests/test_align_along_trace.py
+++ b/specreduce/tests/test_align_along_trace.py
@@ -1,0 +1,59 @@
+import pytest
+import numpy as np
+import astropy.units as u
+
+from specreduce.tracing import ArrayTrace
+from specreduce.utils import align_spectrum_along_trace
+
+
+def mk_test_image():
+    height, width = 9, 2
+    centers = np.array([5.5, 3.0])
+    image = np.zeros((height, width))
+    image[5, 0] = 1
+    image[2:4, 1] = 0.5
+    return image, ArrayTrace(image, centers)
+
+
+def test_align_spectrum_along_trace_bad_input():
+    image, trace = mk_test_image()
+    with pytest.raises(ValueError, match='Unre'):
+        im = align_spectrum_along_trace(image, None)
+
+    with pytest.raises(ValueError, match='method must be'):
+        im = align_spectrum_along_trace(image, trace, method='int')
+
+    with pytest.raises(ValueError, match='Spectral axis length'):
+        im = align_spectrum_along_trace(image.T, trace, method='interpolate', disp_axis=0)
+
+    with pytest.raises(ValueError, match='Displacement axis must be'):
+        im = align_spectrum_along_trace(image, trace, disp_axis=2)
+
+    with pytest.raises(ValueError, match='The number of image dimensions must be'):
+        im = align_spectrum_along_trace(np.zeros((3,6,9)), trace)
+
+
+@pytest.mark.parametrize("method, truth_data, truth_mask, truth_ucty",
+                         [('interpolate',
+                           np.array([[0, 0, 0, 0.00, 1.0, 0.00, 0, 0, 0],
+                                     [0, 0, 0, 0.25, 0.5, 0.25, 0, 0, 0]]).T,
+                           np.array([[0, 0, 0, 0, 0, 0, 0, 1, 1],
+                                     [1, 1, 0, 0, 0, 0, 0, 0, 0]]).astype(bool).T,
+                           np.array([[1. , 1. , 1. , 1. , 1. , 1. , 1. , 1. , 1. ],
+                                     [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]]).T),
+                          ('shift',
+                           np.array([[0. , 0. , 0. , 0. , 1. , 0. , 0. , 0. , 0. ],
+                                     [0. , 0. , 0. , 0.5, 0.5, 0. , 0. , 0. , 0. ]]).T,
+                           np.array([[0, 0, 0, 0, 0, 0, 0, 0, 1],
+                                     [1, 0, 0, 0, 0, 0, 0, 0, 0]]).astype(bool).T,
+                           np.ones((9,2)))],
+                         ids=('method=interpolate', 'method=shift'))
+def test_align_spectrum_along_trace(method, truth_data, truth_mask, truth_ucty):
+    image, trace = mk_test_image()
+    im =  align_spectrum_along_trace(image, trace, method=method)
+    assert im.shape == image.shape
+    assert im.unit == u.DN
+    assert im.uncertainty.uncertainty_type == 'var'
+    np.testing.assert_allclose(im.data, truth_data)
+    np.testing.assert_allclose(im.uncertainty.array, truth_ucty)
+    np.testing.assert_array_equal(im.mask, truth_mask)

--- a/specreduce/tests/test_align_along_trace.py
+++ b/specreduce/tests/test_align_along_trace.py
@@ -18,19 +18,19 @@ def mk_test_image():
 def test_align_spectrum_along_trace_bad_input():
     image, trace = mk_test_image()
     with pytest.raises(ValueError, match='Unre'):
-        im = align_spectrum_along_trace(image, None)
+        im = align_spectrum_along_trace(image, None)   # noqa
 
     with pytest.raises(ValueError, match='method must be'):
-        im = align_spectrum_along_trace(image, trace, method='int')
+        im = align_spectrum_along_trace(image, trace, method='int')   # noqa
 
     with pytest.raises(ValueError, match='Spectral axis length'):
-        im = align_spectrum_along_trace(image.T, trace, method='interpolate', disp_axis=0)
+        im = align_spectrum_along_trace(image.T, trace, method='interpolate', disp_axis=0)   # noqa
 
     with pytest.raises(ValueError, match='Displacement axis must be'):
-        im = align_spectrum_along_trace(image, trace, disp_axis=2)
+        im = align_spectrum_along_trace(image, trace, disp_axis=2)  # noqa
 
     with pytest.raises(ValueError, match='The number of image dimensions must be'):
-        im = align_spectrum_along_trace(np.zeros((3,6,9)), trace)
+        im = align_spectrum_along_trace(np.zeros((3, 6, 9)), trace)  # noqa
 
 
 @pytest.mark.parametrize("method, truth_data, truth_mask, truth_ucty",
@@ -39,18 +39,18 @@ def test_align_spectrum_along_trace_bad_input():
                                      [0, 0, 0, 0.25, 0.5, 0.25, 0, 0, 0]]).T,
                            np.array([[0, 0, 0, 0, 0, 0, 0, 1, 1],
                                      [1, 1, 0, 0, 0, 0, 0, 0, 0]]).astype(bool).T,
-                           np.array([[1. , 1. , 1. , 1. , 1. , 1. , 1. , 1. , 1. ],
+                           np.array([[1., 1., 1., 1., 1., 1., 1., 1., 1.],
                                      [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]]).T),
                           ('shift',
-                           np.array([[0. , 0. , 0. , 0. , 1. , 0. , 0. , 0. , 0. ],
-                                     [0. , 0. , 0. , 0.5, 0.5, 0. , 0. , 0. , 0. ]]).T,
+                           np.array([[0., 0., 0., 0., 1., 0., 0., 0., 0.],
+                                     [0., 0., 0., 0.5, 0.5, 0., 0., 0., 0.]]).T,
                            np.array([[0, 0, 0, 0, 0, 0, 0, 0, 1],
                                      [1, 0, 0, 0, 0, 0, 0, 0, 0]]).astype(bool).T,
-                           np.ones((9,2)))],
+                           np.ones((9, 2)))],
                          ids=('method=interpolate', 'method=shift'))
 def test_align_spectrum_along_trace(method, truth_data, truth_mask, truth_ucty):
     image, trace = mk_test_image()
-    im =  align_spectrum_along_trace(image, trace, method=method)
+    im = align_spectrum_along_trace(image, trace, method=method)
     assert im.shape == image.shape
     assert im.unit == u.DN
     assert im.uncertainty.uncertainty_type == 'var'

--- a/specreduce/tests/test_align_along_trace.py
+++ b/specreduce/tests/test_align_along_trace.py
@@ -3,7 +3,7 @@ import numpy as np
 import astropy.units as u
 
 from specreduce.tracing import ArrayTrace
-from specreduce.utils import align_spectrum_along_trace
+from specreduce.utils import align_2d_spectrum_along_trace
 
 
 def mk_test_image():
@@ -18,19 +18,19 @@ def mk_test_image():
 def test_align_spectrum_along_trace_bad_input():
     image, trace = mk_test_image()
     with pytest.raises(ValueError, match='Unre'):
-        im = align_spectrum_along_trace(image, None)   # noqa
+        im = align_2d_spectrum_along_trace(image, None)   # noqa
 
     with pytest.raises(ValueError, match='method must be'):
-        im = align_spectrum_along_trace(image, trace, method='int')   # noqa
+        im = align_2d_spectrum_along_trace(image, trace, method='int')   # noqa
 
     with pytest.raises(ValueError, match='Spectral axis length'):
-        im = align_spectrum_along_trace(image.T, trace, method='interpolate', disp_axis=0)   # noqa
+        im = align_2d_spectrum_along_trace(image.T, trace, method='interpolate', disp_axis=0)   # noqa
 
     with pytest.raises(ValueError, match='Displacement axis must be'):
-        im = align_spectrum_along_trace(image, trace, disp_axis=2)  # noqa
+        im = align_2d_spectrum_along_trace(image, trace, disp_axis=2)  # noqa
 
     with pytest.raises(ValueError, match='The number of image dimensions must be'):
-        im = align_spectrum_along_trace(np.zeros((3, 6, 9)), trace)  # noqa
+        im = align_2d_spectrum_along_trace(np.zeros((3, 6, 9)), trace)  # noqa
 
 
 @pytest.mark.parametrize("method, truth_data, truth_mask, truth_ucty",
@@ -50,7 +50,7 @@ def test_align_spectrum_along_trace_bad_input():
                          ids=('method=interpolate', 'method=shift'))
 def test_align_spectrum_along_trace(method, truth_data, truth_mask, truth_ucty):
     image, trace = mk_test_image()
-    im = align_spectrum_along_trace(image, trace, method=method)
+    im = align_2d_spectrum_along_trace(image, trace, method=method)
     assert im.shape == image.shape
     assert im.unit == u.DN
     assert im.uncertainty.uncertainty_type == 'var'

--- a/specreduce/utils/utils.py
+++ b/specreduce/utils/utils.py
@@ -9,7 +9,8 @@ from specreduce.core import _ImageParser
 from specreduce.tracing import Trace, FlatTrace
 from specreduce.extract import _ap_weight_image, _align_along_trace
 
-__all__ = ['measure_cross_dispersion_profile', '_align_along_trace', 'align_2d_spectrum_along_trace']
+__all__ = ['measure_cross_dispersion_profile', '_align_along_trace',
+           'align_2d_spectrum_along_trace']
 
 
 def _get_image_ndim(image):


### PR DESCRIPTION
This PR addresses Issue #170  by introducing a utility function `specreduce.utils.align_2d_spectrum_along_trace` to align a rectilinear 2D spectrum image along a trace. The function is based on the `specreduce.extract._align_along_trace` function and adds (optional) sub-pixel precision shifting using linear interpolation, mask handling, and uncertainty propagation (when using the 'interpolate' method). I can change the `specreduce.extract` code to use the new function after @cshanahan1's masking code (PR #216) has been merged.