### PR TITLE
implement average and median support for bkg_spectrum

### DIFF
--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -365,7 +365,8 @@ class Background(_ImageParser):
         elif bkg_statistic == 'average':
             statistic_function = np.nanmean
         else:
-            raise ValueError(f"Background statistics not supported for {bkg_statistic}")
+            raise ValueError(f"Background statistic {bkg_statistic} is not supported. "
+                             "Please choose from: average, median, or sum.")
 
         try:
             return bkg_image.collapse(statistic_function, axis=self.crossdisp_axis)

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -342,11 +342,12 @@ class Background(_ImageParser):
             direction is axis 1. If None, will extract the background
             from ``image`` used to initialize the class. [default: None]
         bkg_statistic : str, optional
-            Statistical method used to collapse the background image.
+            Statistical method used to collapse the background image. [default: ``sum``]
             Supported values are:
-            - `'median'` : Uses the median (`np.nanmedian`).
-            - `'average'` : Uses the mean (`np.nanmean`).
-            - Any other value (including `None`): Defaults to summation (`np.nansum`).
+
+            - `'median'` : Uses the median (`numpy.nanmedian`).
+            - `'average'` : Uses the mean (`numpy.nanmean`).
+            - `'sum'` : Uses the sum (`numpy.nansum`).
 
         Returns
         -------
@@ -360,7 +361,6 @@ class Background(_ImageParser):
         statistic_function = np.nansum
 
         if bkg_statistic:
-            bkg_statistic = bkg_statistic.lower()
             if bkg_statistic == 'median':
                 statistic_function = np.nanmedian
             elif bkg_statistic == 'average':

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -345,9 +345,9 @@ class Background(_ImageParser):
             Statistical method used to collapse the background image. [default: ``sum``]
             Supported values are:
 
-            - `'median'` : Uses the median (`numpy.nanmedian`).
-            - `'average'` : Uses the mean (`numpy.nanmean`).
-            - `'sum'` : Uses the sum (`numpy.nansum`).
+            - ``median`` : Uses the median (`numpy.nanmedian`).
+            - ``average`` : Uses the mean (`numpy.nanmean`).
+            - ``sum`` : Uses the sum (`numpy.nansum`).
 
         Returns
         -------

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -330,7 +330,7 @@ class Background(_ImageParser):
                                   (image.shape[0], 1)) * image.unit,
                           spectral_axis=image.spectral_axis)
 
-    def bkg_spectrum(self, image=None, bkg_statistic=None):
+    def bkg_spectrum(self, image=None, bkg_statistic="sum"):
         """
         Expose the 1D spectrum of the background.
 
@@ -341,13 +341,13 @@ class Background(_ImageParser):
             (spatial) direction is axis 0 and dispersion (wavelength)
             direction is axis 1. If None, will extract the background
             from ``image`` used to initialize the class. [default: None]
-        bkg_statistic : str, optional
-            Statistical method used to collapse the background image. [default: ``sum``]
+        bkg_statistic : {'average', 'median', 'sum'}, optional
+            Statistical method used to collapse the background image. [default: ``'sum'``]
             Supported values are:
 
-            - ``median`` : Uses the median (`numpy.nanmedian`).
-            - ``average`` : Uses the mean (`numpy.nanmean`).
-            - ``sum`` : Uses the sum (`numpy.nansum`).
+            - ``'average'`` : Uses the mean (`numpy.nanmean`).
+            - ``'median'`` : Uses the median (`numpy.nanmedian`).
+            - ``'sum'`` : Uses the sum (`numpy.nansum`).
 
         Returns
         -------
@@ -358,13 +358,14 @@ class Background(_ImageParser):
         """
         bkg_image = self.bkg_image(image)
 
-        statistic_function = np.nansum
-
-        if bkg_statistic:
-            if bkg_statistic == 'median':
-                statistic_function = np.nanmedian
-            elif bkg_statistic == 'average':
-                statistic_function = np.nanmean
+        if bkg_statistic == 'sum':
+            statistic_function = np.nansum
+        elif bkg_statistic == 'median':
+            statistic_function = np.nanmedian
+        elif bkg_statistic == 'average':
+            statistic_function = np.nanmean
+        else:
+            raise ValueError(f"Background statistics not supported for {bkg_statistic}")
 
         try:
             return bkg_image.collapse(statistic_function, axis=self.crossdisp_axis)

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -341,6 +341,12 @@ class Background(_ImageParser):
             (spatial) direction is axis 0 and dispersion (wavelength)
             direction is axis 1. If None, will extract the background
             from ``image`` used to initialize the class. [default: None]
+        bkg_statistic : str, optional
+            Statistical method used to collapse the background image.
+            Supported values are:
+            - `'median'` : Uses the median (`np.nanmedian`).
+            - `'average'` : Uses the mean (`np.nanmean`).
+            - Any other value (including `None`): Defaults to summation (`np.nansum`).
 
         Returns
         -------

--- a/specreduce/tests/test_background.py
+++ b/specreduce/tests/test_background.py
@@ -1,6 +1,7 @@
 from astropy.nddata import NDData
 import astropy.units as u
 import numpy as np
+from numpy.testing import assert_allclose
 import pytest
 from specutils import Spectrum1D
 
@@ -79,6 +80,12 @@ def test_background(mk_test_img_raw, mk_test_spec_no_spectral_axis,
         assert np.isnan(bg._bkg_array).sum() == 0
         assert np.isnan(bg.bkg_spectrum().flux).sum() == 0
         assert np.isnan(bg.sub_spectrum().flux).sum() == 0
+
+    bkg_spec_avg = bg1.bkg_spectrum(bkg_statistic='Average')
+    assert_allclose(bkg_spec_avg.mean().value, 14.5, rtol=0.5)
+
+    bkg_spec_median = bg1.bkg_spectrum(bkg_statistic='Median')
+    assert_allclose(bkg_spec_median.mean().value, 14.5, rtol=0.5)
 
 
 def test_warnings_errors(mk_test_spec_no_spectral_axis):

--- a/specreduce/tests/test_background.py
+++ b/specreduce/tests/test_background.py
@@ -87,7 +87,8 @@ def test_background(mk_test_img_raw, mk_test_spec_no_spectral_axis,
     bkg_spec_median = bg1.bkg_spectrum(bkg_statistic='median')
     assert_allclose(bkg_spec_median.mean().value, 14.5, rtol=0.5)
 
-    with pytest.raises(ValueError, match="Background statistics not supported for max"):
+    with pytest.raises(ValueError, match="Background statistic max is not supported. "
+                                         "Please choose from: average, median, or sum."):
         bg1.bkg_spectrum(bkg_statistic='max')
 
 

--- a/specreduce/tests/test_background.py
+++ b/specreduce/tests/test_background.py
@@ -81,11 +81,14 @@ def test_background(mk_test_img_raw, mk_test_spec_no_spectral_axis,
         assert np.isnan(bg.bkg_spectrum().flux).sum() == 0
         assert np.isnan(bg.sub_spectrum().flux).sum() == 0
 
-    bkg_spec_avg = bg1.bkg_spectrum(bkg_statistic='Average')
+    bkg_spec_avg = bg1.bkg_spectrum(bkg_statistic='average')
     assert_allclose(bkg_spec_avg.mean().value, 14.5, rtol=0.5)
 
-    bkg_spec_median = bg1.bkg_spectrum(bkg_statistic='Median')
+    bkg_spec_median = bg1.bkg_spectrum(bkg_statistic='median')
     assert_allclose(bkg_spec_median.mean().value, 14.5, rtol=0.5)
+
+    with pytest.raises(ValueError, match="Background statistics not supported for max"):
+        bg1.bkg_spectrum(bkg_statistic='max')
 
 
 def test_warnings_errors(mk_test_spec_no_spectral_axis):


### PR DESCRIPTION
This pull request is created to add functionality to the bkg_spectrum function. Currently, this function utilizes np.nansum for all computations of the background spectrum. This pull request defaults this function with np.nansum, while also adding support for 'Average' and 'Median' by utilizing np.nanmean and np.nanmedian.