### PR TITLE
Mask and non-finite option refactor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,11 +21,14 @@ New Features
 
 - Added the ``mask_treatment`` parameter to Background, Trace, and Boxcar Extract
   operations to handle non-finite data and boolean masks. Available options are
-  ``filter``, ``omit``, or ``zero-fill``, with ``exclude`` additionally available
-  for BoxcarExtract. [#216]
+  ``apply``, ``ignore``, ``propagate``, ``zero-fill``, ``nan-fill``, ``apply_mask_only``,
+  or ``apply_nan_only``. [#216, #254]
 
-- Modified BoxcarExtract to ignore non-finite pixels when ``mask_treatment`` is set
-  to ``exclude``; otherwise, non-finite values are propagated. Boxcar extraction is
+- Modified ``background.Background.bgk_spectrum`` to allow the user to select the statistic
+  used for background estimation between ``median`` or ``average``. [#253]
+
+- Modified ``extract.BoxcarExtract`` to ignore non-finite pixels when ``mask_treatment`` is set
+  to ``apply``; otherwise, non-finite values are propagated. Boxcar extraction is
   now carried out as a weighed sum over the window. When no non-finite values are
   present, the extracted spectra remain unchanged from the previous behaviour.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ New Features
 
 - Added the ``mask_treatment`` parameter to Background, Trace, and Boxcar Extract
   operations to handle non-finite data and boolean masks. Available options are
-  ``apply``, ``ignore``, ``propagate``, ``zero-fill``, ``nan-fill``, ``apply_mask_only``,
+  ``apply``, ``ignore``, ``propagate``, ``zero_fill``, ``nan_fill``, ``apply_mask_only``,
   or ``apply_nan_only``. [#216, #254]
 
 - Modified ``background.Background.bgk_spectrum`` to allow the user to select the statistic

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ Calibration
     wavelength_calibration.rst
     extinction.rst
     specphot_standards.rst
+    mask_treatment/mask_treatment.rst
 
 
 *****

--- a/docs/mask_treatment/fig_masking_apply.svg
+++ b/docs/mask_treatment/fig_masking_apply.svg
@@ -1,0 +1,1086 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="180pt" viewBox="0 0 720 180" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-02-27T11:02:27.464870</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 180 
+L 720 180 
+L 720 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 16.678365 145.740616 
+L 165.320008 145.740616 
+L 165.320008 34.259384 
+L 16.678365 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#pa6484e7e51)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB5UlEQVR4nO3c0QmEMAAFQe+4vhMr92pwwYgy00ACYcnf+8w5jw047Xv3BeCpxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCD63X2BpxpjXH7Gvu+Xn0Hn54FIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oHIYmhkzfO8FSur27bubfw8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigWjZ6OHbBu84721v4+eBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBaNli6NvWIsHPA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EfuboRRmbCNVMAAAAASUVORK5CYII=" id="imageb15f81f5f4" transform="scale(1 -1) translate(0 -111.6)" x="16.678365" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m8e6533588c" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m8e6533588c" x="25.968468" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(22.787218 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m8e6533588c" x="63.128878" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2 -->
+      <g transform="translate(59.947628 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m8e6533588c" x="100.289289" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 4 -->
+      <g transform="translate(97.108039 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m8e6533588c" x="137.4497" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 6 -->
+      <g transform="translate(134.26845 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_5">
+     <!-- Dispersion axis -->
+     <g transform="translate(53.021061 174.017179) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="text_6">
+     <!-- Cross-dispersion axis -->
+     <g transform="translate(10.598678 142.809375) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-72" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-6f" x="108.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="169.869141"/>
+      <use xlink:href="#DejaVuSans-73" x="221.96875"/>
+      <use xlink:href="#DejaVuSans-2d" x="274.068359"/>
+      <use xlink:href="#DejaVuSans-64" x="310.152344"/>
+      <use xlink:href="#DejaVuSans-69" x="373.628906"/>
+      <use xlink:href="#DejaVuSans-73" x="401.412109"/>
+      <use xlink:href="#DejaVuSans-70" x="453.511719"/>
+      <use xlink:href="#DejaVuSans-65" x="516.988281"/>
+      <use xlink:href="#DejaVuSans-72" x="578.511719"/>
+      <use xlink:href="#DejaVuSans-73" x="619.625"/>
+      <use xlink:href="#DejaVuSans-69" x="671.724609"/>
+      <use xlink:href="#DejaVuSans-6f" x="699.507812"/>
+      <use xlink:href="#DejaVuSans-6e" x="760.689453"/>
+      <use xlink:href="#DejaVuSans-20" x="824.068359"/>
+      <use xlink:href="#DejaVuSans-61" x="855.855469"/>
+      <use xlink:href="#DejaVuSans-78" x="917.134766"/>
+      <use xlink:href="#DejaVuSans-69" x="976.314453"/>
+      <use xlink:href="#DejaVuSans-73" x="1004.097656"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 16.678365 145.740616 
+L 16.678365 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 165.320008 145.740616 
+L 165.320008 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 16.678365 145.740616 
+L 165.320008 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 16.678365 34.259384 
+L 165.320008 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_7">
+    <!-- Image -->
+    <g transform="translate(72.206999 28.259384) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-49"/>
+     <use xlink:href="#DejaVuSans-6d" x="29.492188"/>
+     <use xlink:href="#DejaVuSans-61" x="126.904297"/>
+     <use xlink:href="#DejaVuSans-67" x="188.183594"/>
+     <use xlink:href="#DejaVuSans-65" x="251.660156"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 171.320488 145.740616 
+L 319.962131 145.740616 
+L 319.962131 34.259384 
+L 171.320488 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#pef9bf43b3c)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB30lEQVR4nO3csRECMQwAQcR8/y2bCgi4wH5gtwEpuVGmWWutB/Cx5+kF4FuJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBBdpxfgf8zMljm7nuC6PBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBD5GMo2uz557uLyQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiK7TC/DezGyZs9baMufXuDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQ+Rh6Yz553pvLA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EL0T0RNCcVrOQAAAAASUVORK5CYII=" id="image1f56993597" transform="scale(1 -1) translate(0 -111.6)" x="171.320488" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m8e6533588c" x="180.610591" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0 -->
+      <g transform="translate(177.429341 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m8e6533588c" x="217.771001" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 2 -->
+      <g transform="translate(214.589751 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m8e6533588c" x="254.931412" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 4 -->
+      <g transform="translate(251.750162 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m8e6533588c" x="292.091823" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 6 -->
+      <g transform="translate(288.910573 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- Dispersion axis -->
+     <g transform="translate(207.663184 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4"/>
+   <g id="patch_8">
+    <path d="M 171.320488 145.740616 
+L 171.320488 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 319.962131 145.740616 
+L 319.962131 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 171.320488 145.740616 
+L 319.962131 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 171.320488 34.259384 
+L 319.962131 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- Mask -->
+    <g transform="translate(230.187559 28.259384) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-61" x="86.279297"/>
+     <use xlink:href="#DejaVuSans-73" x="147.558594"/>
+     <use xlink:href="#DejaVuSans-6b" x="199.658203"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_12">
+    <path d="M 334.137901 93.47999 
+Q 366.839063 93.47999 397.304156 93.47999 
+" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 393.304156 91.47999 
+L 397.304156 93.47999 
+L 393.304156 95.47999 
+" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linecap: round"/>
+   </g>
+   <g id="matplotlib.axis_5"/>
+   <g id="matplotlib.axis_6"/>
+  </g>
+  <g id="axes_4">
+   <g id="patch_13">
+    <path d="M 413.715994 145.740616 
+L 562.357637 145.740616 
+L 562.357637 34.259384 
+L 413.715994 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p0c972dee7a)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB5UlEQVR4nO3c0QmEMAAFQe+4vhMr92pwwYgy00ACYcnf+8w5jw047Xv3BeCpxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCD63X2BpxpjXH7Gvu+Xn0Hn54FIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oHIYmhkzfO8FSur27bubfw8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigWjZ6OHbBu84721v4+eBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBaNli6NvWIsHPA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EfuboRRmbCNVMAAAAASUVORK5CYII=" id="imagea3038561d6" transform="scale(1 -1) translate(0 -111.6)" x="413.715994" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_7">
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m8e6533588c" x="423.006097" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 0 -->
+      <g transform="translate(419.824847 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m8e6533588c" x="460.166508" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 2 -->
+      <g transform="translate(456.985258 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m8e6533588c" x="497.326918" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 4 -->
+      <g transform="translate(494.145668 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m8e6533588c" x="534.487329" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 6 -->
+      <g transform="translate(531.306079 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- Dispersion axis -->
+     <g transform="translate(450.058691 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_8"/>
+   <g id="patch_14">
+    <path d="M 413.715994 145.740616 
+L 413.715994 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 562.357637 145.740616 
+L 562.357637 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 413.715994 145.740616 
+L 562.357637 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 413.715994 34.259384 
+L 562.357637 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_19">
+    <!-- Image -->
+    <g transform="translate(469.244628 28.259384) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-49"/>
+     <use xlink:href="#DejaVuSans-6d" x="29.492188"/>
+     <use xlink:href="#DejaVuSans-61" x="126.904297"/>
+     <use xlink:href="#DejaVuSans-67" x="188.183594"/>
+     <use xlink:href="#DejaVuSans-65" x="251.660156"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_5">
+   <g id="patch_18">
+    <path d="M 568.358117 145.740616 
+L 716.99976 145.740616 
+L 716.99976 34.259384 
+L 568.358117 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p7af292dd86)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB8ElEQVR4nO3cwQ3CMBBFQRvRf8umBt5hI8xMAyRET3v7+5xzFvC119MPAL9KPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oHo/fQD8D/23iO/MzWC6/JAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAZDE0mli/nFq+nHLb+7g8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EFkMjW5bv5wwsbK61ty3cXkgEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQD0djo4W2DdxNu+89u+jZruTyQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQ7XPbjCMMcXkgEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXgg+gCvpiEsntn32AAAAABJRU5ErkJggg==" id="image6ceffdec91" transform="scale(1 -1) translate(0 -111.6)" x="568.358117" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_9">
+    <g id="xtick_13">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m8e6533588c" x="577.64822" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 0 -->
+      <g transform="translate(574.46697 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m8e6533588c" x="614.808631" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 2 -->
+      <g transform="translate(611.627381 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m8e6533588c" x="651.969041" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 4 -->
+      <g transform="translate(648.787791 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m8e6533588c" x="689.129452" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 6 -->
+      <g transform="translate(685.948202 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_24">
+     <!-- Dispersion axis -->
+     <g transform="translate(604.700814 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_10"/>
+   <g id="patch_19">
+    <path d="M 568.358117 145.740616 
+L 568.358117 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 716.99976 145.740616 
+L 716.99976 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 568.358117 145.740616 
+L 716.99976 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 568.358117 34.259384 
+L 716.99976 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_25">
+    <!-- Mask -->
+    <g transform="translate(627.225189 28.259384) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-61" x="86.279297"/>
+     <use xlink:href="#DejaVuSans-73" x="147.558594"/>
+     <use xlink:href="#DejaVuSans-6b" x="199.658203"/>
+    </g>
+   </g>
+  </g>
+  <g id="text_26">
+   <!-- apply -->
+   <g transform="translate(353.078125 86.52001) scale(0.1 -0.1)">
+    <defs>
+     <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-61"/>
+    <use xlink:href="#DejaVuSans-70" x="61.279297"/>
+    <use xlink:href="#DejaVuSans-70" x="124.755859"/>
+    <use xlink:href="#DejaVuSans-6c" x="188.232422"/>
+    <use xlink:href="#DejaVuSans-79" x="216.015625"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pa6484e7e51">
+   <rect x="16.678365" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="pef9bf43b3c">
+   <rect x="171.320488" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="p0c972dee7a">
+   <rect x="413.715994" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="p7af292dd86">
+   <rect x="568.358117" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/mask_treatment/fig_masking_apply_mask_only.svg
+++ b/docs/mask_treatment/fig_masking_apply_mask_only.svg
@@ -1,0 +1,1103 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="180pt" viewBox="0 0 720 180" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-02-27T11:02:30.168638</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 180 
+L 720 180 
+L 720 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 16.678365 145.740616 
+L 165.320008 145.740616 
+L 165.320008 34.259384 
+L 16.678365 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#pc74b6ababd)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB5UlEQVR4nO3c0QmEMAAFQe+4vhMr92pwwYgy00ACYcnf+8w5jw047Xv3BeCpxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCD63X2BpxpjXH7Gvu+Xn0Hn54FIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oHIYmhkzfO8FSur27bubfw8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigWjZ6OHbBu84721v4+eBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBaNli6NvWIsHPA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EfuboRRmbCNVMAAAAASUVORK5CYII=" id="imagea401258103" transform="scale(1 -1) translate(0 -111.6)" x="16.678365" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m4c3591d490" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m4c3591d490" x="25.968468" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(22.787218 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m4c3591d490" x="63.128878" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2 -->
+      <g transform="translate(59.947628 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m4c3591d490" x="100.289289" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 4 -->
+      <g transform="translate(97.108039 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m4c3591d490" x="137.4497" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 6 -->
+      <g transform="translate(134.26845 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_5">
+     <!-- Dispersion axis -->
+     <g transform="translate(53.021061 174.017179) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="text_6">
+     <!-- Cross-dispersion axis -->
+     <g transform="translate(10.598678 142.809375) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-72" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-6f" x="108.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="169.869141"/>
+      <use xlink:href="#DejaVuSans-73" x="221.96875"/>
+      <use xlink:href="#DejaVuSans-2d" x="274.068359"/>
+      <use xlink:href="#DejaVuSans-64" x="310.152344"/>
+      <use xlink:href="#DejaVuSans-69" x="373.628906"/>
+      <use xlink:href="#DejaVuSans-73" x="401.412109"/>
+      <use xlink:href="#DejaVuSans-70" x="453.511719"/>
+      <use xlink:href="#DejaVuSans-65" x="516.988281"/>
+      <use xlink:href="#DejaVuSans-72" x="578.511719"/>
+      <use xlink:href="#DejaVuSans-73" x="619.625"/>
+      <use xlink:href="#DejaVuSans-69" x="671.724609"/>
+      <use xlink:href="#DejaVuSans-6f" x="699.507812"/>
+      <use xlink:href="#DejaVuSans-6e" x="760.689453"/>
+      <use xlink:href="#DejaVuSans-20" x="824.068359"/>
+      <use xlink:href="#DejaVuSans-61" x="855.855469"/>
+      <use xlink:href="#DejaVuSans-78" x="917.134766"/>
+      <use xlink:href="#DejaVuSans-69" x="976.314453"/>
+      <use xlink:href="#DejaVuSans-73" x="1004.097656"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 16.678365 145.740616 
+L 16.678365 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 165.320008 145.740616 
+L 165.320008 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 16.678365 145.740616 
+L 165.320008 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 16.678365 34.259384 
+L 165.320008 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_7">
+    <!-- Image -->
+    <g transform="translate(72.206999 28.259384) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-49"/>
+     <use xlink:href="#DejaVuSans-6d" x="29.492188"/>
+     <use xlink:href="#DejaVuSans-61" x="126.904297"/>
+     <use xlink:href="#DejaVuSans-67" x="188.183594"/>
+     <use xlink:href="#DejaVuSans-65" x="251.660156"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 171.320488 145.740616 
+L 319.962131 145.740616 
+L 319.962131 34.259384 
+L 171.320488 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p0c509362d6)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB30lEQVR4nO3csRECMQwAQcR8/y2bCgi4wH5gtwEpuVGmWWutB/Cx5+kF4FuJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBBdpxfgf8zMljm7nuC6PBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBD5GMo2uz557uLyQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiK7TC/DezGyZs9baMufXuDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQ+Rh6Yz553pvLA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EL0T0RNCcVrOQAAAAASUVORK5CYII=" id="image575ed6e3d3" transform="scale(1 -1) translate(0 -111.6)" x="171.320488" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m4c3591d490" x="180.610591" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0 -->
+      <g transform="translate(177.429341 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m4c3591d490" x="217.771001" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 2 -->
+      <g transform="translate(214.589751 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m4c3591d490" x="254.931412" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 4 -->
+      <g transform="translate(251.750162 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m4c3591d490" x="292.091823" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 6 -->
+      <g transform="translate(288.910573 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- Dispersion axis -->
+     <g transform="translate(207.663184 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4"/>
+   <g id="patch_8">
+    <path d="M 171.320488 145.740616 
+L 171.320488 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 319.962131 145.740616 
+L 319.962131 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 171.320488 145.740616 
+L 319.962131 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 171.320488 34.259384 
+L 319.962131 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- Mask -->
+    <g transform="translate(230.187559 28.259384) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-61" x="86.279297"/>
+     <use xlink:href="#DejaVuSans-73" x="147.558594"/>
+     <use xlink:href="#DejaVuSans-6b" x="199.658203"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_12">
+    <path d="M 334.137901 93.47999 
+Q 366.839063 93.47999 397.304156 93.47999 
+" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 393.304156 91.47999 
+L 397.304156 93.47999 
+L 393.304156 95.47999 
+" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linecap: round"/>
+   </g>
+   <g id="matplotlib.axis_5"/>
+   <g id="matplotlib.axis_6"/>
+  </g>
+  <g id="axes_4">
+   <g id="patch_13">
+    <path d="M 413.715994 145.740616 
+L 562.357637 145.740616 
+L 562.357637 34.259384 
+L 413.715994 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#pa560371a2f)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB5UlEQVR4nO3c0QmEMAAFQe+4vhMr92pwwYgy00ACYcnf+8w5jw047Xv3BeCpxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCD63X2BpxpjXH7Gvu+Xn0Hn54FIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oHIYmhkzfO8FSur27bubfw8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigWjZ6OHbBu84721v4+eBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBaNli6NvWIsHPA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EfuboRRmbCNVMAAAAASUVORK5CYII=" id="imageb67f8f9a6f" transform="scale(1 -1) translate(0 -111.6)" x="413.715994" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_7">
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m4c3591d490" x="423.006097" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 0 -->
+      <g transform="translate(419.824847 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m4c3591d490" x="460.166508" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 2 -->
+      <g transform="translate(456.985258 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m4c3591d490" x="497.326918" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 4 -->
+      <g transform="translate(494.145668 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m4c3591d490" x="534.487329" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 6 -->
+      <g transform="translate(531.306079 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- Dispersion axis -->
+     <g transform="translate(450.058691 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_8"/>
+   <g id="patch_14">
+    <path d="M 413.715994 145.740616 
+L 413.715994 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 562.357637 145.740616 
+L 562.357637 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 413.715994 145.740616 
+L 562.357637 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 413.715994 34.259384 
+L 562.357637 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_19">
+    <!-- Image -->
+    <g transform="translate(469.244628 28.259384) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-49"/>
+     <use xlink:href="#DejaVuSans-6d" x="29.492188"/>
+     <use xlink:href="#DejaVuSans-61" x="126.904297"/>
+     <use xlink:href="#DejaVuSans-67" x="188.183594"/>
+     <use xlink:href="#DejaVuSans-65" x="251.660156"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_5">
+   <g id="patch_18">
+    <path d="M 568.358117 145.740616 
+L 716.99976 145.740616 
+L 716.99976 34.259384 
+L 568.358117 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p6d1468af1a)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB30lEQVR4nO3csRECMQwAQcR8/y2bCgi4wH5gtwEpuVGmWWutB/Cx5+kF4FuJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBBdpxfgf8zMljm7nuC6PBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBD5GMo2uz557uLyQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiK7TC/DezGyZs9baMufXuDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQ+Rh6Yz553pvLA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EL0T0RNCcVrOQAAAAASUVORK5CYII=" id="image1a00f4d330" transform="scale(1 -1) translate(0 -111.6)" x="568.358117" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_9">
+    <g id="xtick_13">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m4c3591d490" x="577.64822" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 0 -->
+      <g transform="translate(574.46697 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m4c3591d490" x="614.808631" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 2 -->
+      <g transform="translate(611.627381 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m4c3591d490" x="651.969041" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 4 -->
+      <g transform="translate(648.787791 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m4c3591d490" x="689.129452" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 6 -->
+      <g transform="translate(685.948202 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_24">
+     <!-- Dispersion axis -->
+     <g transform="translate(604.700814 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_10"/>
+   <g id="patch_19">
+    <path d="M 568.358117 145.740616 
+L 568.358117 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 716.99976 145.740616 
+L 716.99976 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 568.358117 145.740616 
+L 716.99976 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 568.358117 34.259384 
+L 716.99976 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_25">
+    <!-- Mask -->
+    <g transform="translate(627.225189 28.259384) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-61" x="86.279297"/>
+     <use xlink:href="#DejaVuSans-73" x="147.558594"/>
+     <use xlink:href="#DejaVuSans-6b" x="199.658203"/>
+    </g>
+   </g>
+  </g>
+  <g id="text_26">
+   <!-- apply_mask_only -->
+   <g transform="translate(324.067188 86.52001) scale(0.1 -0.1)">
+    <defs>
+     <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-61"/>
+    <use xlink:href="#DejaVuSans-70" x="61.279297"/>
+    <use xlink:href="#DejaVuSans-70" x="124.755859"/>
+    <use xlink:href="#DejaVuSans-6c" x="188.232422"/>
+    <use xlink:href="#DejaVuSans-79" x="216.015625"/>
+    <use xlink:href="#DejaVuSans-5f" x="275.195312"/>
+    <use xlink:href="#DejaVuSans-6d" x="325.195312"/>
+    <use xlink:href="#DejaVuSans-61" x="422.607422"/>
+    <use xlink:href="#DejaVuSans-73" x="483.886719"/>
+    <use xlink:href="#DejaVuSans-6b" x="535.986328"/>
+    <use xlink:href="#DejaVuSans-5f" x="593.896484"/>
+    <use xlink:href="#DejaVuSans-6f" x="643.896484"/>
+    <use xlink:href="#DejaVuSans-6e" x="705.078125"/>
+    <use xlink:href="#DejaVuSans-6c" x="768.457031"/>
+    <use xlink:href="#DejaVuSans-79" x="796.240234"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pc74b6ababd">
+   <rect x="16.678365" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="p0c509362d6">
+   <rect x="171.320488" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="pa560371a2f">
+   <rect x="413.715994" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="p6d1468af1a">
+   <rect x="568.358117" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/mask_treatment/fig_masking_apply_nan_only.svg
+++ b/docs/mask_treatment/fig_masking_apply_nan_only.svg
@@ -1,0 +1,1102 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="180pt" viewBox="0 0 720 180" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-02-27T11:02:29.756590</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 180 
+L 720 180 
+L 720 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 16.678365 145.740616 
+L 165.320008 145.740616 
+L 165.320008 34.259384 
+L 16.678365 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p6010602ff2)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB5UlEQVR4nO3c0QmEMAAFQe+4vhMr92pwwYgy00ACYcnf+8w5jw047Xv3BeCpxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCD63X2BpxpjXH7Gvu+Xn0Hn54FIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oHIYmhkzfO8FSur27bubfw8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigWjZ6OHbBu84721v4+eBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBaNli6NvWIsHPA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EfuboRRmbCNVMAAAAASUVORK5CYII=" id="imagecd18ef57fc" transform="scale(1 -1) translate(0 -111.6)" x="16.678365" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="mca59581440" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mca59581440" x="25.968468" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(22.787218 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#mca59581440" x="63.128878" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2 -->
+      <g transform="translate(59.947628 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#mca59581440" x="100.289289" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 4 -->
+      <g transform="translate(97.108039 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mca59581440" x="137.4497" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 6 -->
+      <g transform="translate(134.26845 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_5">
+     <!-- Dispersion axis -->
+     <g transform="translate(53.021061 174.017179) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="text_6">
+     <!-- Cross-dispersion axis -->
+     <g transform="translate(10.598678 142.809375) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-72" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-6f" x="108.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="169.869141"/>
+      <use xlink:href="#DejaVuSans-73" x="221.96875"/>
+      <use xlink:href="#DejaVuSans-2d" x="274.068359"/>
+      <use xlink:href="#DejaVuSans-64" x="310.152344"/>
+      <use xlink:href="#DejaVuSans-69" x="373.628906"/>
+      <use xlink:href="#DejaVuSans-73" x="401.412109"/>
+      <use xlink:href="#DejaVuSans-70" x="453.511719"/>
+      <use xlink:href="#DejaVuSans-65" x="516.988281"/>
+      <use xlink:href="#DejaVuSans-72" x="578.511719"/>
+      <use xlink:href="#DejaVuSans-73" x="619.625"/>
+      <use xlink:href="#DejaVuSans-69" x="671.724609"/>
+      <use xlink:href="#DejaVuSans-6f" x="699.507812"/>
+      <use xlink:href="#DejaVuSans-6e" x="760.689453"/>
+      <use xlink:href="#DejaVuSans-20" x="824.068359"/>
+      <use xlink:href="#DejaVuSans-61" x="855.855469"/>
+      <use xlink:href="#DejaVuSans-78" x="917.134766"/>
+      <use xlink:href="#DejaVuSans-69" x="976.314453"/>
+      <use xlink:href="#DejaVuSans-73" x="1004.097656"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 16.678365 145.740616 
+L 16.678365 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 165.320008 145.740616 
+L 165.320008 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 16.678365 145.740616 
+L 165.320008 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 16.678365 34.259384 
+L 165.320008 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_7">
+    <!-- Image -->
+    <g transform="translate(72.206999 28.259384) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-49"/>
+     <use xlink:href="#DejaVuSans-6d" x="29.492188"/>
+     <use xlink:href="#DejaVuSans-61" x="126.904297"/>
+     <use xlink:href="#DejaVuSans-67" x="188.183594"/>
+     <use xlink:href="#DejaVuSans-65" x="251.660156"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 171.320488 145.740616 
+L 319.962131 145.740616 
+L 319.962131 34.259384 
+L 171.320488 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#pfe9e52ccd0)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB30lEQVR4nO3csRECMQwAQcR8/y2bCgi4wH5gtwEpuVGmWWutB/Cx5+kF4FuJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBBdpxfgf8zMljm7nuC6PBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBD5GMo2uz557uLyQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiK7TC/DezGyZs9baMufXuDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQ+Rh6Yz553pvLA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EL0T0RNCcVrOQAAAAASUVORK5CYII=" id="image2baa6ba004" transform="scale(1 -1) translate(0 -111.6)" x="171.320488" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#mca59581440" x="180.610591" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0 -->
+      <g transform="translate(177.429341 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mca59581440" x="217.771001" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 2 -->
+      <g transform="translate(214.589751 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#mca59581440" x="254.931412" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 4 -->
+      <g transform="translate(251.750162 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mca59581440" x="292.091823" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 6 -->
+      <g transform="translate(288.910573 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- Dispersion axis -->
+     <g transform="translate(207.663184 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4"/>
+   <g id="patch_8">
+    <path d="M 171.320488 145.740616 
+L 171.320488 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 319.962131 145.740616 
+L 319.962131 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 171.320488 145.740616 
+L 319.962131 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 171.320488 34.259384 
+L 319.962131 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- Mask -->
+    <g transform="translate(230.187559 28.259384) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-61" x="86.279297"/>
+     <use xlink:href="#DejaVuSans-73" x="147.558594"/>
+     <use xlink:href="#DejaVuSans-6b" x="199.658203"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_12">
+    <path d="M 334.137901 93.47999 
+Q 366.839063 93.47999 397.304156 93.47999 
+" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 393.304156 91.47999 
+L 397.304156 93.47999 
+L 393.304156 95.47999 
+" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linecap: round"/>
+   </g>
+   <g id="matplotlib.axis_5"/>
+   <g id="matplotlib.axis_6"/>
+  </g>
+  <g id="axes_4">
+   <g id="patch_13">
+    <path d="M 413.715994 145.740616 
+L 562.357637 145.740616 
+L 562.357637 34.259384 
+L 413.715994 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p4b3d89f47c)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB5UlEQVR4nO3c0QmEMAAFQe+4vhMr92pwwYgy00ACYcnf+8w5jw047Xv3BeCpxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCD63X2BpxpjXH7Gvu+Xn0Hn54FIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oHIYmhkzfO8FSur27bubfw8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigWjZ6OHbBu84721v4+eBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBaNli6NvWIsHPA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EfuboRRmbCNVMAAAAASUVORK5CYII=" id="image42e60db7a7" transform="scale(1 -1) translate(0 -111.6)" x="413.715994" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_7">
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#mca59581440" x="423.006097" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 0 -->
+      <g transform="translate(419.824847 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#mca59581440" x="460.166508" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 2 -->
+      <g transform="translate(456.985258 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#mca59581440" x="497.326918" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 4 -->
+      <g transform="translate(494.145668 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#mca59581440" x="534.487329" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 6 -->
+      <g transform="translate(531.306079 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- Dispersion axis -->
+     <g transform="translate(450.058691 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_8"/>
+   <g id="patch_14">
+    <path d="M 413.715994 145.740616 
+L 413.715994 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 562.357637 145.740616 
+L 562.357637 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 413.715994 145.740616 
+L 562.357637 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 413.715994 34.259384 
+L 562.357637 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_19">
+    <!-- Image -->
+    <g transform="translate(469.244628 28.259384) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-49"/>
+     <use xlink:href="#DejaVuSans-6d" x="29.492188"/>
+     <use xlink:href="#DejaVuSans-61" x="126.904297"/>
+     <use xlink:href="#DejaVuSans-67" x="188.183594"/>
+     <use xlink:href="#DejaVuSans-65" x="251.660156"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_5">
+   <g id="patch_18">
+    <path d="M 568.358117 145.740616 
+L 716.99976 145.740616 
+L 716.99976 34.259384 
+L 568.358117 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p904bb2c154)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB40lEQVR4nO3c0QmEMBRFQbPYf8tva/CAEWWmgQTCIX93zcwcwGW/py8AbyUeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQD0fn0Bd5qrXX7GTNz+xl0fh6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6ILIZG1jyv27Gyehz73sbPA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHoi2jR5+bfCO6772Nn4eiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiLYthn5tLRL8PBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBD9AWvEFzFhFyI0AAAAAElFTkSuQmCC" id="image3265ae2aa9" transform="scale(1 -1) translate(0 -111.6)" x="568.358117" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_9">
+    <g id="xtick_13">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#mca59581440" x="577.64822" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 0 -->
+      <g transform="translate(574.46697 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#mca59581440" x="614.808631" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 2 -->
+      <g transform="translate(611.627381 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#mca59581440" x="651.969041" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 4 -->
+      <g transform="translate(648.787791 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#mca59581440" x="689.129452" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 6 -->
+      <g transform="translate(685.948202 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_24">
+     <!-- Dispersion axis -->
+     <g transform="translate(604.700814 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_10"/>
+   <g id="patch_19">
+    <path d="M 568.358117 145.740616 
+L 568.358117 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 716.99976 145.740616 
+L 716.99976 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 568.358117 145.740616 
+L 716.99976 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 568.358117 34.259384 
+L 716.99976 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_25">
+    <!-- Mask -->
+    <g transform="translate(627.225189 28.259384) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-61" x="86.279297"/>
+     <use xlink:href="#DejaVuSans-73" x="147.558594"/>
+     <use xlink:href="#DejaVuSans-6b" x="199.658203"/>
+    </g>
+   </g>
+  </g>
+  <g id="text_26">
+   <!-- apply_nan_only -->
+   <g transform="translate(328.1 86.52001) scale(0.1 -0.1)">
+    <defs>
+     <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-61"/>
+    <use xlink:href="#DejaVuSans-70" x="61.279297"/>
+    <use xlink:href="#DejaVuSans-70" x="124.755859"/>
+    <use xlink:href="#DejaVuSans-6c" x="188.232422"/>
+    <use xlink:href="#DejaVuSans-79" x="216.015625"/>
+    <use xlink:href="#DejaVuSans-5f" x="275.195312"/>
+    <use xlink:href="#DejaVuSans-6e" x="325.195312"/>
+    <use xlink:href="#DejaVuSans-61" x="388.574219"/>
+    <use xlink:href="#DejaVuSans-6e" x="449.853516"/>
+    <use xlink:href="#DejaVuSans-5f" x="513.232422"/>
+    <use xlink:href="#DejaVuSans-6f" x="563.232422"/>
+    <use xlink:href="#DejaVuSans-6e" x="624.414062"/>
+    <use xlink:href="#DejaVuSans-6c" x="687.792969"/>
+    <use xlink:href="#DejaVuSans-79" x="715.576172"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p6010602ff2">
+   <rect x="16.678365" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="pfe9e52ccd0">
+   <rect x="171.320488" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="p4b3d89f47c">
+   <rect x="413.715994" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="p904bb2c154">
+   <rect x="568.358117" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/mask_treatment/fig_masking_ignore.svg
+++ b/docs/mask_treatment/fig_masking_ignore.svg
@@ -1,0 +1,1061 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="180pt" viewBox="0 0 720 180" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-02-27T11:02:27.971940</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 180 
+L 720 180 
+L 720 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 16.678365 145.740616 
+L 165.320008 145.740616 
+L 165.320008 34.259384 
+L 16.678365 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#pa34c36ddf2)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB5UlEQVR4nO3c0QmEMAAFQe+4vhMr92pwwYgy00ACYcnf+8w5jw047Xv3BeCpxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCD63X2BpxpjXH7Gvu+Xn0Hn54FIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oHIYmhkzfO8FSur27bubfw8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigWjZ6OHbBu84721v4+eBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBaNli6NvWIsHPA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EfuboRRmbCNVMAAAAASUVORK5CYII=" id="image5863304359" transform="scale(1 -1) translate(0 -111.6)" x="16.678365" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m1bc81c52ac" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m1bc81c52ac" x="25.968468" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(22.787218 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m1bc81c52ac" x="63.128878" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2 -->
+      <g transform="translate(59.947628 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m1bc81c52ac" x="100.289289" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 4 -->
+      <g transform="translate(97.108039 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m1bc81c52ac" x="137.4497" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 6 -->
+      <g transform="translate(134.26845 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_5">
+     <!-- Dispersion axis -->
+     <g transform="translate(53.021061 174.017179) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="text_6">
+     <!-- Cross-dispersion axis -->
+     <g transform="translate(10.598678 142.809375) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-72" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-6f" x="108.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="169.869141"/>
+      <use xlink:href="#DejaVuSans-73" x="221.96875"/>
+      <use xlink:href="#DejaVuSans-2d" x="274.068359"/>
+      <use xlink:href="#DejaVuSans-64" x="310.152344"/>
+      <use xlink:href="#DejaVuSans-69" x="373.628906"/>
+      <use xlink:href="#DejaVuSans-73" x="401.412109"/>
+      <use xlink:href="#DejaVuSans-70" x="453.511719"/>
+      <use xlink:href="#DejaVuSans-65" x="516.988281"/>
+      <use xlink:href="#DejaVuSans-72" x="578.511719"/>
+      <use xlink:href="#DejaVuSans-73" x="619.625"/>
+      <use xlink:href="#DejaVuSans-69" x="671.724609"/>
+      <use xlink:href="#DejaVuSans-6f" x="699.507812"/>
+      <use xlink:href="#DejaVuSans-6e" x="760.689453"/>
+      <use xlink:href="#DejaVuSans-20" x="824.068359"/>
+      <use xlink:href="#DejaVuSans-61" x="855.855469"/>
+      <use xlink:href="#DejaVuSans-78" x="917.134766"/>
+      <use xlink:href="#DejaVuSans-69" x="976.314453"/>
+      <use xlink:href="#DejaVuSans-73" x="1004.097656"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 16.678365 145.740616 
+L 16.678365 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 165.320008 145.740616 
+L 165.320008 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 16.678365 145.740616 
+L 165.320008 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 16.678365 34.259384 
+L 165.320008 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_7">
+    <!-- Image -->
+    <g transform="translate(72.206999 28.259384) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-49"/>
+     <use xlink:href="#DejaVuSans-6d" x="29.492188"/>
+     <use xlink:href="#DejaVuSans-61" x="126.904297"/>
+     <use xlink:href="#DejaVuSans-67" x="188.183594"/>
+     <use xlink:href="#DejaVuSans-65" x="251.660156"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 171.320488 145.740616 
+L 319.962131 145.740616 
+L 319.962131 34.259384 
+L 171.320488 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p9ac4400944)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB30lEQVR4nO3csRECMQwAQcR8/y2bCgi4wH5gtwEpuVGmWWutB/Cx5+kF4FuJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBBdpxfgf8zMljm7nuC6PBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBD5GMo2uz557uLyQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiK7TC/DezGyZs9baMufXuDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQ+Rh6Yz553pvLA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EL0T0RNCcVrOQAAAAASUVORK5CYII=" id="imagef84499758a" transform="scale(1 -1) translate(0 -111.6)" x="171.320488" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m1bc81c52ac" x="180.610591" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0 -->
+      <g transform="translate(177.429341 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m1bc81c52ac" x="217.771001" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 2 -->
+      <g transform="translate(214.589751 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m1bc81c52ac" x="254.931412" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 4 -->
+      <g transform="translate(251.750162 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m1bc81c52ac" x="292.091823" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 6 -->
+      <g transform="translate(288.910573 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- Dispersion axis -->
+     <g transform="translate(207.663184 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4"/>
+   <g id="patch_8">
+    <path d="M 171.320488 145.740616 
+L 171.320488 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 319.962131 145.740616 
+L 319.962131 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 171.320488 145.740616 
+L 319.962131 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 171.320488 34.259384 
+L 319.962131 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- Mask -->
+    <g transform="translate(230.187559 28.259384) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-61" x="86.279297"/>
+     <use xlink:href="#DejaVuSans-73" x="147.558594"/>
+     <use xlink:href="#DejaVuSans-6b" x="199.658203"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_12">
+    <path d="M 334.137901 93.47999 
+Q 366.839063 93.47999 397.304156 93.47999 
+" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 393.304156 91.47999 
+L 397.304156 93.47999 
+L 393.304156 95.47999 
+" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linecap: round"/>
+   </g>
+   <g id="matplotlib.axis_5"/>
+   <g id="matplotlib.axis_6"/>
+  </g>
+  <g id="axes_4">
+   <g id="patch_13">
+    <path d="M 413.715994 145.740616 
+L 562.357637 145.740616 
+L 562.357637 34.259384 
+L 413.715994 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#pc146ffe32d)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB5UlEQVR4nO3c0QmEMAAFQe+4vhMr92pwwYgy00ACYcnf+8w5jw047Xv3BeCpxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCD63X2BpxpjXH7Gvu+Xn0Hn54FIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oHIYmhkzfO8FSur27bubfw8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigWjZ6OHbBu84721v4+eBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBaNli6NvWIsHPA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EfuboRRmbCNVMAAAAASUVORK5CYII=" id="image15f27cd0cf" transform="scale(1 -1) translate(0 -111.6)" x="413.715994" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_7">
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m1bc81c52ac" x="423.006097" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 0 -->
+      <g transform="translate(419.824847 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m1bc81c52ac" x="460.166508" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 2 -->
+      <g transform="translate(456.985258 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m1bc81c52ac" x="497.326918" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 4 -->
+      <g transform="translate(494.145668 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m1bc81c52ac" x="534.487329" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 6 -->
+      <g transform="translate(531.306079 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- Dispersion axis -->
+     <g transform="translate(450.058691 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_8"/>
+   <g id="patch_14">
+    <path d="M 413.715994 145.740616 
+L 413.715994 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 562.357637 145.740616 
+L 562.357637 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 413.715994 145.740616 
+L 562.357637 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 413.715994 34.259384 
+L 562.357637 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_19">
+    <!-- Image -->
+    <g transform="translate(469.244628 28.259384) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-49"/>
+     <use xlink:href="#DejaVuSans-6d" x="29.492188"/>
+     <use xlink:href="#DejaVuSans-61" x="126.904297"/>
+     <use xlink:href="#DejaVuSans-67" x="188.183594"/>
+     <use xlink:href="#DejaVuSans-65" x="251.660156"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_5">
+   <g id="patch_18">
+    <path d="M 568.358117 145.740616 
+L 716.99976 145.740616 
+L 716.99976 34.259384 
+L 568.358117 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p53fbc67cb3)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAABuElEQVR4nO3TwQ3AIBDAsNL9dz5mIB+EZE+QT9bMzAcc+28HwKvMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA9EGPxAFMtsl+ykAAAAASUVORK5CYII=" id="imageb5f1896906" transform="scale(1 -1) translate(0 -111.6)" x="568.358117" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_9">
+    <g id="xtick_13">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m1bc81c52ac" x="577.64822" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 0 -->
+      <g transform="translate(574.46697 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m1bc81c52ac" x="614.808631" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 2 -->
+      <g transform="translate(611.627381 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m1bc81c52ac" x="651.969041" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 4 -->
+      <g transform="translate(648.787791 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m1bc81c52ac" x="689.129452" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 6 -->
+      <g transform="translate(685.948202 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_24">
+     <!-- Dispersion axis -->
+     <g transform="translate(604.700814 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_10"/>
+   <g id="patch_19">
+    <path d="M 568.358117 145.740616 
+L 568.358117 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 716.99976 145.740616 
+L 716.99976 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 568.358117 145.740616 
+L 716.99976 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 568.358117 34.259384 
+L 716.99976 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_25">
+    <!-- Mask -->
+    <g transform="translate(627.225189 28.259384) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-61" x="86.279297"/>
+     <use xlink:href="#DejaVuSans-73" x="147.558594"/>
+     <use xlink:href="#DejaVuSans-6b" x="199.658203"/>
+    </g>
+   </g>
+  </g>
+  <g id="text_26">
+   <!-- ignore -->
+   <g transform="translate(351.028125 86.52001) scale(0.1 -0.1)">
+    <use xlink:href="#DejaVuSans-69"/>
+    <use xlink:href="#DejaVuSans-67" x="27.783203"/>
+    <use xlink:href="#DejaVuSans-6e" x="91.259766"/>
+    <use xlink:href="#DejaVuSans-6f" x="154.638672"/>
+    <use xlink:href="#DejaVuSans-72" x="215.820312"/>
+    <use xlink:href="#DejaVuSans-65" x="254.683594"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pa34c36ddf2">
+   <rect x="16.678365" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="p9ac4400944">
+   <rect x="171.320488" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="pc146ffe32d">
+   <rect x="413.715994" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="p53fbc67cb3">
+   <rect x="568.358117" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/mask_treatment/fig_masking_nan_fill.svg
+++ b/docs/mask_treatment/fig_masking_nan_fill.svg
@@ -1033,7 +1033,7 @@ L 716.99976 34.259384
    </g>
   </g>
   <g id="text_26">
-   <!-- nan-fill -->
+   <!-- nan_fill -->
    <g transform="translate(349.70625 86.52001) scale(0.1 -0.1)">
     <defs>
      <path id="DejaVuSans-66" d="M 2375 4863 

--- a/docs/mask_treatment/fig_masking_nan_fill.svg
+++ b/docs/mask_treatment/fig_masking_nan_fill.svg
@@ -1,0 +1,1093 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="180pt" viewBox="0 0 720 180" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-02-27T11:02:29.355840</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 180 
+L 720 180 
+L 720 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 16.678365 145.740616 
+L 165.320008 145.740616 
+L 165.320008 34.259384 
+L 16.678365 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#pc808f221d7)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB5UlEQVR4nO3c0QmEMAAFQe+4vhMr92pwwYgy00ACYcnf+8w5jw047Xv3BeCpxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCD63X2BpxpjXH7Gvu+Xn0Hn54FIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oHIYmhkzfO8FSur27bubfw8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigWjZ6OHbBu84721v4+eBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBaNli6NvWIsHPA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EfuboRRmbCNVMAAAAASUVORK5CYII=" id="image0e86af0f0a" transform="scale(1 -1) translate(0 -111.6)" x="16.678365" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m99dcc39220" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m99dcc39220" x="25.968468" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(22.787218 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m99dcc39220" x="63.128878" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2 -->
+      <g transform="translate(59.947628 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m99dcc39220" x="100.289289" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 4 -->
+      <g transform="translate(97.108039 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m99dcc39220" x="137.4497" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 6 -->
+      <g transform="translate(134.26845 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_5">
+     <!-- Dispersion axis -->
+     <g transform="translate(53.021061 174.017179) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="text_6">
+     <!-- Cross-dispersion axis -->
+     <g transform="translate(10.598678 142.809375) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-72" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-6f" x="108.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="169.869141"/>
+      <use xlink:href="#DejaVuSans-73" x="221.96875"/>
+      <use xlink:href="#DejaVuSans-2d" x="274.068359"/>
+      <use xlink:href="#DejaVuSans-64" x="310.152344"/>
+      <use xlink:href="#DejaVuSans-69" x="373.628906"/>
+      <use xlink:href="#DejaVuSans-73" x="401.412109"/>
+      <use xlink:href="#DejaVuSans-70" x="453.511719"/>
+      <use xlink:href="#DejaVuSans-65" x="516.988281"/>
+      <use xlink:href="#DejaVuSans-72" x="578.511719"/>
+      <use xlink:href="#DejaVuSans-73" x="619.625"/>
+      <use xlink:href="#DejaVuSans-69" x="671.724609"/>
+      <use xlink:href="#DejaVuSans-6f" x="699.507812"/>
+      <use xlink:href="#DejaVuSans-6e" x="760.689453"/>
+      <use xlink:href="#DejaVuSans-20" x="824.068359"/>
+      <use xlink:href="#DejaVuSans-61" x="855.855469"/>
+      <use xlink:href="#DejaVuSans-78" x="917.134766"/>
+      <use xlink:href="#DejaVuSans-69" x="976.314453"/>
+      <use xlink:href="#DejaVuSans-73" x="1004.097656"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 16.678365 145.740616 
+L 16.678365 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 165.320008 145.740616 
+L 165.320008 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 16.678365 145.740616 
+L 165.320008 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 16.678365 34.259384 
+L 165.320008 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_7">
+    <!-- Image -->
+    <g transform="translate(72.206999 28.259384) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-49"/>
+     <use xlink:href="#DejaVuSans-6d" x="29.492188"/>
+     <use xlink:href="#DejaVuSans-61" x="126.904297"/>
+     <use xlink:href="#DejaVuSans-67" x="188.183594"/>
+     <use xlink:href="#DejaVuSans-65" x="251.660156"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 171.320488 145.740616 
+L 319.962131 145.740616 
+L 319.962131 34.259384 
+L 171.320488 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p7b2dfe42f4)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB30lEQVR4nO3csRECMQwAQcR8/y2bCgi4wH5gtwEpuVGmWWutB/Cx5+kF4FuJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBBdpxfgf8zMljm7nuC6PBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBD5GMo2uz557uLyQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiK7TC/DezGyZs9baMufXuDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQ+Rh6Yz553pvLA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EL0T0RNCcVrOQAAAAASUVORK5CYII=" id="image0429565e27" transform="scale(1 -1) translate(0 -111.6)" x="171.320488" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m99dcc39220" x="180.610591" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0 -->
+      <g transform="translate(177.429341 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m99dcc39220" x="217.771001" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 2 -->
+      <g transform="translate(214.589751 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m99dcc39220" x="254.931412" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 4 -->
+      <g transform="translate(251.750162 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m99dcc39220" x="292.091823" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 6 -->
+      <g transform="translate(288.910573 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- Dispersion axis -->
+     <g transform="translate(207.663184 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4"/>
+   <g id="patch_8">
+    <path d="M 171.320488 145.740616 
+L 171.320488 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 319.962131 145.740616 
+L 319.962131 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 171.320488 145.740616 
+L 319.962131 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 171.320488 34.259384 
+L 319.962131 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- Mask -->
+    <g transform="translate(230.187559 28.259384) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-61" x="86.279297"/>
+     <use xlink:href="#DejaVuSans-73" x="147.558594"/>
+     <use xlink:href="#DejaVuSans-6b" x="199.658203"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_12">
+    <path d="M 334.137901 93.47999 
+Q 366.839063 93.47999 397.304156 93.47999 
+" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 393.304156 91.47999 
+L 397.304156 93.47999 
+L 393.304156 95.47999 
+" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linecap: round"/>
+   </g>
+   <g id="matplotlib.axis_5"/>
+   <g id="matplotlib.axis_6"/>
+  </g>
+  <g id="axes_4">
+   <g id="patch_13">
+    <path d="M 413.715994 145.740616 
+L 562.357637 145.740616 
+L 562.357637 34.259384 
+L 413.715994 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#pa0f04c0fa7)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB90lEQVR4nO3cwW3DMBAAQTpI36Iqd2rIPk4wPdMAKRGL+91r7/1ewL/9PH0B+FTigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0S/T1+A73Fd18g5932PnGPyQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQGRjaDSx/XJq8+WU077H5IFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oHIxtDotO2XEya2rK419zYmD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCAaW3p42sK7Caf9s5PeZi2TBzLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJB6LX3vv99CXgE5k8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EP0BlSMZxPSsN6MAAAAASUVORK5CYII=" id="image1e8e5ed3a1" transform="scale(1 -1) translate(0 -111.6)" x="413.715994" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_7">
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m99dcc39220" x="423.006097" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 0 -->
+      <g transform="translate(419.824847 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m99dcc39220" x="460.166508" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 2 -->
+      <g transform="translate(456.985258 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m99dcc39220" x="497.326918" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 4 -->
+      <g transform="translate(494.145668 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m99dcc39220" x="534.487329" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 6 -->
+      <g transform="translate(531.306079 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- Dispersion axis -->
+     <g transform="translate(450.058691 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_8"/>
+   <g id="patch_14">
+    <path d="M 413.715994 145.740616 
+L 413.715994 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 562.357637 145.740616 
+L 562.357637 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 413.715994 145.740616 
+L 562.357637 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 413.715994 34.259384 
+L 562.357637 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_19">
+    <!-- Image -->
+    <g transform="translate(469.244628 28.259384) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-49"/>
+     <use xlink:href="#DejaVuSans-6d" x="29.492188"/>
+     <use xlink:href="#DejaVuSans-61" x="126.904297"/>
+     <use xlink:href="#DejaVuSans-67" x="188.183594"/>
+     <use xlink:href="#DejaVuSans-65" x="251.660156"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_5">
+   <g id="patch_18">
+    <path d="M 568.358117 145.740616 
+L 716.99976 145.740616 
+L 716.99976 34.259384 
+L 568.358117 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p7198bdd11b)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAABuElEQVR4nO3TwQ3AIBDAsNL9dz5mIB+EZE+QT9bMzAcc+28HwKvMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA9EGPxAFMtsl+ykAAAAASUVORK5CYII=" id="imagec32e657d30" transform="scale(1 -1) translate(0 -111.6)" x="568.358117" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_9">
+    <g id="xtick_13">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m99dcc39220" x="577.64822" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 0 -->
+      <g transform="translate(574.46697 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m99dcc39220" x="614.808631" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 2 -->
+      <g transform="translate(611.627381 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m99dcc39220" x="651.969041" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 4 -->
+      <g transform="translate(648.787791 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m99dcc39220" x="689.129452" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 6 -->
+      <g transform="translate(685.948202 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_24">
+     <!-- Dispersion axis -->
+     <g transform="translate(604.700814 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_10"/>
+   <g id="patch_19">
+    <path d="M 568.358117 145.740616 
+L 568.358117 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 716.99976 145.740616 
+L 716.99976 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 568.358117 145.740616 
+L 716.99976 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 568.358117 34.259384 
+L 716.99976 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_25">
+    <!-- Mask -->
+    <g transform="translate(627.225189 28.259384) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-61" x="86.279297"/>
+     <use xlink:href="#DejaVuSans-73" x="147.558594"/>
+     <use xlink:href="#DejaVuSans-6b" x="199.658203"/>
+    </g>
+   </g>
+  </g>
+  <g id="text_26">
+   <!-- nan-fill -->
+   <g transform="translate(349.70625 86.52001) scale(0.1 -0.1)">
+    <defs>
+     <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-6e"/>
+    <use xlink:href="#DejaVuSans-61" x="63.378906"/>
+    <use xlink:href="#DejaVuSans-6e" x="124.658203"/>
+    <use xlink:href="#DejaVuSans-2d" x="188.037109"/>
+    <use xlink:href="#DejaVuSans-66" x="224.121094"/>
+    <use xlink:href="#DejaVuSans-69" x="259.326172"/>
+    <use xlink:href="#DejaVuSans-6c" x="287.109375"/>
+    <use xlink:href="#DejaVuSans-6c" x="314.892578"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pc808f221d7">
+   <rect x="16.678365" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="p7b2dfe42f4">
+   <rect x="171.320488" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="pa0f04c0fa7">
+   <rect x="413.715994" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="p7198bdd11b">
+   <rect x="568.358117" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/mask_treatment/fig_masking_propagate.svg
+++ b/docs/mask_treatment/fig_masking_propagate.svg
@@ -1,0 +1,1087 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="180pt" viewBox="0 0 720 180" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-02-27T11:02:28.520732</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 180 
+L 720 180 
+L 720 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 16.678365 145.740616 
+L 165.320008 145.740616 
+L 165.320008 34.259384 
+L 16.678365 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p85a9425e75)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB5UlEQVR4nO3c0QmEMAAFQe+4vhMr92pwwYgy00ACYcnf+8w5jw047Xv3BeCpxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCD63X2BpxpjXH7Gvu+Xn0Hn54FIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oHIYmhkzfO8FSur27bubfw8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigWjZ6OHbBu84721v4+eBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBaNli6NvWIsHPA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EfuboRRmbCNVMAAAAASUVORK5CYII=" id="image8d4c12fc23" transform="scale(1 -1) translate(0 -111.6)" x="16.678365" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m2c1bd8bb10" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m2c1bd8bb10" x="25.968468" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(22.787218 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m2c1bd8bb10" x="63.128878" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2 -->
+      <g transform="translate(59.947628 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m2c1bd8bb10" x="100.289289" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 4 -->
+      <g transform="translate(97.108039 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m2c1bd8bb10" x="137.4497" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 6 -->
+      <g transform="translate(134.26845 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_5">
+     <!-- Dispersion axis -->
+     <g transform="translate(53.021061 174.017179) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="text_6">
+     <!-- Cross-dispersion axis -->
+     <g transform="translate(10.598678 142.809375) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-72" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-6f" x="108.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="169.869141"/>
+      <use xlink:href="#DejaVuSans-73" x="221.96875"/>
+      <use xlink:href="#DejaVuSans-2d" x="274.068359"/>
+      <use xlink:href="#DejaVuSans-64" x="310.152344"/>
+      <use xlink:href="#DejaVuSans-69" x="373.628906"/>
+      <use xlink:href="#DejaVuSans-73" x="401.412109"/>
+      <use xlink:href="#DejaVuSans-70" x="453.511719"/>
+      <use xlink:href="#DejaVuSans-65" x="516.988281"/>
+      <use xlink:href="#DejaVuSans-72" x="578.511719"/>
+      <use xlink:href="#DejaVuSans-73" x="619.625"/>
+      <use xlink:href="#DejaVuSans-69" x="671.724609"/>
+      <use xlink:href="#DejaVuSans-6f" x="699.507812"/>
+      <use xlink:href="#DejaVuSans-6e" x="760.689453"/>
+      <use xlink:href="#DejaVuSans-20" x="824.068359"/>
+      <use xlink:href="#DejaVuSans-61" x="855.855469"/>
+      <use xlink:href="#DejaVuSans-78" x="917.134766"/>
+      <use xlink:href="#DejaVuSans-69" x="976.314453"/>
+      <use xlink:href="#DejaVuSans-73" x="1004.097656"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 16.678365 145.740616 
+L 16.678365 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 165.320008 145.740616 
+L 165.320008 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 16.678365 145.740616 
+L 165.320008 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 16.678365 34.259384 
+L 165.320008 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_7">
+    <!-- Image -->
+    <g transform="translate(72.206999 28.259384) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-49"/>
+     <use xlink:href="#DejaVuSans-6d" x="29.492188"/>
+     <use xlink:href="#DejaVuSans-61" x="126.904297"/>
+     <use xlink:href="#DejaVuSans-67" x="188.183594"/>
+     <use xlink:href="#DejaVuSans-65" x="251.660156"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 171.320488 145.740616 
+L 319.962131 145.740616 
+L 319.962131 34.259384 
+L 171.320488 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p169d0d1b75)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB30lEQVR4nO3csRECMQwAQcR8/y2bCgi4wH5gtwEpuVGmWWutB/Cx5+kF4FuJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBBdpxfgf8zMljm7nuC6PBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBD5GMo2uz557uLyQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiK7TC/DezGyZs9baMufXuDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQ+Rh6Yz553pvLA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EL0T0RNCcVrOQAAAAASUVORK5CYII=" id="imageaee9afc836" transform="scale(1 -1) translate(0 -111.6)" x="171.320488" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m2c1bd8bb10" x="180.610591" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0 -->
+      <g transform="translate(177.429341 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m2c1bd8bb10" x="217.771001" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 2 -->
+      <g transform="translate(214.589751 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m2c1bd8bb10" x="254.931412" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 4 -->
+      <g transform="translate(251.750162 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m2c1bd8bb10" x="292.091823" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 6 -->
+      <g transform="translate(288.910573 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- Dispersion axis -->
+     <g transform="translate(207.663184 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4"/>
+   <g id="patch_8">
+    <path d="M 171.320488 145.740616 
+L 171.320488 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 319.962131 145.740616 
+L 319.962131 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 171.320488 145.740616 
+L 319.962131 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 171.320488 34.259384 
+L 319.962131 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- Mask -->
+    <g transform="translate(230.187559 28.259384) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-61" x="86.279297"/>
+     <use xlink:href="#DejaVuSans-73" x="147.558594"/>
+     <use xlink:href="#DejaVuSans-6b" x="199.658203"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_12">
+    <path d="M 334.137901 93.47999 
+Q 366.839063 93.47999 397.304156 93.47999 
+" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 393.304156 91.47999 
+L 397.304156 93.47999 
+L 393.304156 95.47999 
+" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linecap: round"/>
+   </g>
+   <g id="matplotlib.axis_5"/>
+   <g id="matplotlib.axis_6"/>
+  </g>
+  <g id="axes_4">
+   <g id="patch_13">
+    <path d="M 413.715994 145.740616 
+L 562.357637 145.740616 
+L 562.357637 34.259384 
+L 413.715994 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p1cd9c3adea)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB5UlEQVR4nO3c0QmEMAAFQe+4vhMr92pwwYgy00ACYcnf+8w5jw047Xv3BeCpxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCD63X2BpxpjXH7Gvu+Xn0Hn54FIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oHIYmhkzfO8FSur27bubfw8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigWjZ6OHbBu84721v4+eBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBaNli6NvWIsHPA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EfuboRRmbCNVMAAAAASUVORK5CYII=" id="image83c9cba5e4" transform="scale(1 -1) translate(0 -111.6)" x="413.715994" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_7">
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m2c1bd8bb10" x="423.006097" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 0 -->
+      <g transform="translate(419.824847 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m2c1bd8bb10" x="460.166508" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 2 -->
+      <g transform="translate(456.985258 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m2c1bd8bb10" x="497.326918" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 4 -->
+      <g transform="translate(494.145668 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m2c1bd8bb10" x="534.487329" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 6 -->
+      <g transform="translate(531.306079 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- Dispersion axis -->
+     <g transform="translate(450.058691 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_8"/>
+   <g id="patch_14">
+    <path d="M 413.715994 145.740616 
+L 413.715994 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 562.357637 145.740616 
+L 562.357637 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 413.715994 145.740616 
+L 562.357637 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 413.715994 34.259384 
+L 562.357637 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_19">
+    <!-- Image -->
+    <g transform="translate(469.244628 28.259384) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-49"/>
+     <use xlink:href="#DejaVuSans-6d" x="29.492188"/>
+     <use xlink:href="#DejaVuSans-61" x="126.904297"/>
+     <use xlink:href="#DejaVuSans-67" x="188.183594"/>
+     <use xlink:href="#DejaVuSans-65" x="251.660156"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_5">
+   <g id="patch_18">
+    <path d="M 568.358117 145.740616 
+L 716.99976 145.740616 
+L 716.99976 34.259384 
+L 568.358117 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#pb7733bf188)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAABx0lEQVR4nO3TsQ3AMAwEMTv776zscIUKg1xAeAF3Z2bOgnvvxpmzNGdtz4bXfra151u5Ag8SD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0Q/qJ8OMgC1qKIAAAAASUVORK5CYII=" id="imagee8402f0452" transform="scale(1 -1) translate(0 -111.6)" x="568.358117" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_9">
+    <g id="xtick_13">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m2c1bd8bb10" x="577.64822" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 0 -->
+      <g transform="translate(574.46697 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m2c1bd8bb10" x="614.808631" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 2 -->
+      <g transform="translate(611.627381 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m2c1bd8bb10" x="651.969041" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 4 -->
+      <g transform="translate(648.787791 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m2c1bd8bb10" x="689.129452" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 6 -->
+      <g transform="translate(685.948202 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_24">
+     <!-- Dispersion axis -->
+     <g transform="translate(604.700814 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_10"/>
+   <g id="patch_19">
+    <path d="M 568.358117 145.740616 
+L 568.358117 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 716.99976 145.740616 
+L 716.99976 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 568.358117 145.740616 
+L 716.99976 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 568.358117 34.259384 
+L 716.99976 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_25">
+    <!-- Mask -->
+    <g transform="translate(627.225189 28.259384) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-61" x="86.279297"/>
+     <use xlink:href="#DejaVuSans-73" x="147.558594"/>
+     <use xlink:href="#DejaVuSans-6b" x="199.658203"/>
+    </g>
+   </g>
+  </g>
+  <g id="text_26">
+   <!-- propagate -->
+   <g transform="translate(341.149219 86.52001) scale(0.1 -0.1)">
+    <defs>
+     <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-70"/>
+    <use xlink:href="#DejaVuSans-72" x="63.476562"/>
+    <use xlink:href="#DejaVuSans-6f" x="102.339844"/>
+    <use xlink:href="#DejaVuSans-70" x="163.521484"/>
+    <use xlink:href="#DejaVuSans-61" x="226.998047"/>
+    <use xlink:href="#DejaVuSans-67" x="288.277344"/>
+    <use xlink:href="#DejaVuSans-61" x="351.753906"/>
+    <use xlink:href="#DejaVuSans-74" x="413.033203"/>
+    <use xlink:href="#DejaVuSans-65" x="452.242188"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p85a9425e75">
+   <rect x="16.678365" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="p169d0d1b75">
+   <rect x="171.320488" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="p1cd9c3adea">
+   <rect x="413.715994" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="pb7733bf188">
+   <rect x="568.358117" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/mask_treatment/fig_masking_zero_fill.svg
+++ b/docs/mask_treatment/fig_masking_zero_fill.svg
@@ -1033,7 +1033,7 @@ L 716.99976 34.259384
    </g>
   </g>
   <g id="text_26">
-   <!-- zero-fill -->
+   <!-- zero_fill -->
    <g transform="translate(348.310938 86.52001) scale(0.1 -0.1)">
     <defs>
      <path id="DejaVuSans-7a" d="M 353 3500 

--- a/docs/mask_treatment/fig_masking_zero_fill.svg
+++ b/docs/mask_treatment/fig_masking_zero_fill.svg
@@ -1,0 +1,1107 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="180pt" viewBox="0 0 720 180" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-02-27T11:02:28.955119</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 180 
+L 720 180 
+L 720 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 16.678365 145.740616 
+L 165.320008 145.740616 
+L 165.320008 34.259384 
+L 16.678365 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p6d6863eb9b)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB5UlEQVR4nO3c0QmEMAAFQe+4vhMr92pwwYgy00ACYcnf+8w5jw047Xv3BeCpxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCD63X2BpxpjXH7Gvu+Xn0Hn54FIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oHIYmhkzfO8FSur27bubfw8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigWjZ6OHbBu84721v4+eBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBaNli6NvWIsHPA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EfuboRRmbCNVMAAAAASUVORK5CYII=" id="imageb70e1628b9" transform="scale(1 -1) translate(0 -111.6)" x="16.678365" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m33975f8f96" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m33975f8f96" x="25.968468" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(22.787218 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m33975f8f96" x="63.128878" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2 -->
+      <g transform="translate(59.947628 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m33975f8f96" x="100.289289" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 4 -->
+      <g transform="translate(97.108039 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m33975f8f96" x="137.4497" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 6 -->
+      <g transform="translate(134.26845 160.339054) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_5">
+     <!-- Dispersion axis -->
+     <g transform="translate(53.021061 174.017179) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="text_6">
+     <!-- Cross-dispersion axis -->
+     <g transform="translate(10.598678 142.809375) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-72" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-6f" x="108.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="169.869141"/>
+      <use xlink:href="#DejaVuSans-73" x="221.96875"/>
+      <use xlink:href="#DejaVuSans-2d" x="274.068359"/>
+      <use xlink:href="#DejaVuSans-64" x="310.152344"/>
+      <use xlink:href="#DejaVuSans-69" x="373.628906"/>
+      <use xlink:href="#DejaVuSans-73" x="401.412109"/>
+      <use xlink:href="#DejaVuSans-70" x="453.511719"/>
+      <use xlink:href="#DejaVuSans-65" x="516.988281"/>
+      <use xlink:href="#DejaVuSans-72" x="578.511719"/>
+      <use xlink:href="#DejaVuSans-73" x="619.625"/>
+      <use xlink:href="#DejaVuSans-69" x="671.724609"/>
+      <use xlink:href="#DejaVuSans-6f" x="699.507812"/>
+      <use xlink:href="#DejaVuSans-6e" x="760.689453"/>
+      <use xlink:href="#DejaVuSans-20" x="824.068359"/>
+      <use xlink:href="#DejaVuSans-61" x="855.855469"/>
+      <use xlink:href="#DejaVuSans-78" x="917.134766"/>
+      <use xlink:href="#DejaVuSans-69" x="976.314453"/>
+      <use xlink:href="#DejaVuSans-73" x="1004.097656"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 16.678365 145.740616 
+L 16.678365 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 165.320008 145.740616 
+L 165.320008 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 16.678365 145.740616 
+L 165.320008 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 16.678365 34.259384 
+L 165.320008 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_7">
+    <!-- Image -->
+    <g transform="translate(72.206999 28.259384) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-49"/>
+     <use xlink:href="#DejaVuSans-6d" x="29.492188"/>
+     <use xlink:href="#DejaVuSans-61" x="126.904297"/>
+     <use xlink:href="#DejaVuSans-67" x="188.183594"/>
+     <use xlink:href="#DejaVuSans-65" x="251.660156"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 171.320488 145.740616 
+L 319.962131 145.740616 
+L 319.962131 34.259384 
+L 171.320488 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p4aa381a97f)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB30lEQVR4nO3csRECMQwAQcR8/y2bCgi4wH5gtwEpuVGmWWutB/Cx5+kF4FuJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBBdpxfgf8zMljm7nuC6PBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBD5GMo2uz557uLyQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiK7TC/DezGyZs9baMufXuDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQ+Rh6Yz553pvLA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9EL0T0RNCcVrOQAAAAASUVORK5CYII=" id="imagec4bfda1fca" transform="scale(1 -1) translate(0 -111.6)" x="171.320488" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m33975f8f96" x="180.610591" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0 -->
+      <g transform="translate(177.429341 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m33975f8f96" x="217.771001" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 2 -->
+      <g transform="translate(214.589751 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m33975f8f96" x="254.931412" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 4 -->
+      <g transform="translate(251.750162 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m33975f8f96" x="292.091823" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 6 -->
+      <g transform="translate(288.910573 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- Dispersion axis -->
+     <g transform="translate(207.663184 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4"/>
+   <g id="patch_8">
+    <path d="M 171.320488 145.740616 
+L 171.320488 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 319.962131 145.740616 
+L 319.962131 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 171.320488 145.740616 
+L 319.962131 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 171.320488 34.259384 
+L 319.962131 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- Mask -->
+    <g transform="translate(230.187559 28.259384) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-61" x="86.279297"/>
+     <use xlink:href="#DejaVuSans-73" x="147.558594"/>
+     <use xlink:href="#DejaVuSans-6b" x="199.658203"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_12">
+    <path d="M 334.137901 93.47999 
+Q 366.839063 93.47999 397.304156 93.47999 
+" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 393.304156 91.47999 
+L 397.304156 93.47999 
+L 393.304156 95.47999 
+" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linecap: round"/>
+   </g>
+   <g id="matplotlib.axis_5"/>
+   <g id="matplotlib.axis_6"/>
+  </g>
+  <g id="axes_4">
+   <g id="patch_13">
+    <path d="M 413.715994 145.740616 
+L 562.357637 145.740616 
+L 562.357637 34.259384 
+L 413.715994 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p4e44e4988b)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAAB7UlEQVR4nO3cwQ3CMBAAwYAo/DqHGtjHRZiZBuw4Wt3vHjPzvoCvPe++APwq8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQei190X4H/MzFHnmDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQ2RgabWyl3Np8ueW07zF5IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4ILIxNDpt++WGrTfbOsfkgUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0TigUg8EIkHIvFAJB6IxAOReCASD0RrSw9PW3i34bQ3O+nfXJfJA5l4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA5F4IBIPROKBSDwQiQci8UAkHojEA9FjZt53XwJ+kckDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQDkXggEg9E4oFIPBCJByLxQCQeiMQD0QffEhm7yof0GgAAAABJRU5ErkJggg==" id="image7b660ad769" transform="scale(1 -1) translate(0 -111.6)" x="413.715994" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_7">
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m33975f8f96" x="423.006097" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 0 -->
+      <g transform="translate(419.824847 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m33975f8f96" x="460.166508" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 2 -->
+      <g transform="translate(456.985258 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m33975f8f96" x="497.326918" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 4 -->
+      <g transform="translate(494.145668 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m33975f8f96" x="534.487329" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 6 -->
+      <g transform="translate(531.306079 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- Dispersion axis -->
+     <g transform="translate(450.058691 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_8"/>
+   <g id="patch_14">
+    <path d="M 413.715994 145.740616 
+L 413.715994 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 562.357637 145.740616 
+L 562.357637 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 413.715994 145.740616 
+L 562.357637 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 413.715994 34.259384 
+L 562.357637 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_19">
+    <!-- Image -->
+    <g transform="translate(469.244628 28.259384) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-49"/>
+     <use xlink:href="#DejaVuSans-6d" x="29.492188"/>
+     <use xlink:href="#DejaVuSans-61" x="126.904297"/>
+     <use xlink:href="#DejaVuSans-67" x="188.183594"/>
+     <use xlink:href="#DejaVuSans-65" x="251.660156"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_5">
+   <g id="patch_18">
+    <path d="M 568.358117 145.740616 
+L 716.99976 145.740616 
+L 716.99976 34.259384 
+L 568.358117 34.259384 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#pf809412ad5)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM8AAACbCAYAAADFns++AAABuElEQVR4nO3TwQ3AIBDAsNL9dz5mIB+EZE+QT9bMzAcc+28HwKvMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA5F5IDIPROaByDwQmQci80BkHojMA9EGPxAFMtsl+ykAAAAASUVORK5CYII=" id="image1c4782d9a3" transform="scale(1 -1) translate(0 -111.6)" x="568.358117" y="-34.140616" width="149.04" height="111.6"/>
+   </g>
+   <g id="matplotlib.axis_9">
+    <g id="xtick_13">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m33975f8f96" x="577.64822" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 0 -->
+      <g transform="translate(574.46697 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m33975f8f96" x="614.808631" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 2 -->
+      <g transform="translate(611.627381 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m33975f8f96" x="651.969041" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 4 -->
+      <g transform="translate(648.787791 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m33975f8f96" x="689.129452" y="145.740616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 6 -->
+      <g transform="translate(685.948202 160.339054) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_24">
+     <!-- Dispersion axis -->
+     <g transform="translate(604.700814 174.017179) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-69" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-73" x="104.785156"/>
+      <use xlink:href="#DejaVuSans-70" x="156.884766"/>
+      <use xlink:href="#DejaVuSans-65" x="220.361328"/>
+      <use xlink:href="#DejaVuSans-72" x="281.884766"/>
+      <use xlink:href="#DejaVuSans-73" x="322.998047"/>
+      <use xlink:href="#DejaVuSans-69" x="375.097656"/>
+      <use xlink:href="#DejaVuSans-6f" x="402.880859"/>
+      <use xlink:href="#DejaVuSans-6e" x="464.0625"/>
+      <use xlink:href="#DejaVuSans-20" x="527.441406"/>
+      <use xlink:href="#DejaVuSans-61" x="559.228516"/>
+      <use xlink:href="#DejaVuSans-78" x="620.507812"/>
+      <use xlink:href="#DejaVuSans-69" x="679.6875"/>
+      <use xlink:href="#DejaVuSans-73" x="707.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_10"/>
+   <g id="patch_19">
+    <path d="M 568.358117 145.740616 
+L 568.358117 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 716.99976 145.740616 
+L 716.99976 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 568.358117 145.740616 
+L 716.99976 145.740616 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 568.358117 34.259384 
+L 716.99976 34.259384 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_25">
+    <!-- Mask -->
+    <g transform="translate(627.225189 28.259384) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-61" x="86.279297"/>
+     <use xlink:href="#DejaVuSans-73" x="147.558594"/>
+     <use xlink:href="#DejaVuSans-6b" x="199.658203"/>
+    </g>
+   </g>
+  </g>
+  <g id="text_26">
+   <!-- zero-fill -->
+   <g transform="translate(348.310938 86.52001) scale(0.1 -0.1)">
+    <defs>
+     <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-7a"/>
+    <use xlink:href="#DejaVuSans-65" x="52.490234"/>
+    <use xlink:href="#DejaVuSans-72" x="114.013672"/>
+    <use xlink:href="#DejaVuSans-6f" x="152.876953"/>
+    <use xlink:href="#DejaVuSans-2d" x="215.933594"/>
+    <use xlink:href="#DejaVuSans-66" x="252.017578"/>
+    <use xlink:href="#DejaVuSans-69" x="287.222656"/>
+    <use xlink:href="#DejaVuSans-6c" x="315.005859"/>
+    <use xlink:href="#DejaVuSans-6c" x="342.789062"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p6d6863eb9b">
+   <rect x="16.678365" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="p4aa381a97f">
+   <rect x="171.320488" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="p4e44e4988b">
+   <rect x="413.715994" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+  <clipPath id="pf809412ad5">
+   <rect x="568.358117" y="34.259384" width="148.641643" height="111.481232"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/mask_treatment/mask_treatment.rst
+++ b/docs/mask_treatment/mask_treatment.rst
@@ -31,14 +31,14 @@ Available Options
 
 .. image:: fig_masking_propagate.svg
 
-- ``zero-fill``
+- ``zero_fill``
   All pixels that are masked or non-finite are replaced with ``0.0`` and the the mask
   is cleared from the image.
 
 .. image:: fig_masking_zero_fill.svg
 
-- ``nan-fill``
-  Similar to zero-fill, but instead of replacing invalid pixels with ``0.0``, they are replaced
+- ``nan_fill``
+  Similar to zero_fill, but instead of replacing invalid pixels with ``0.0``, they are replaced
   with ``nan``. The mask is then removed from the image.
 
 .. image:: fig_masking_nan_fill.svg

--- a/docs/mask_treatment/mask_treatment.rst
+++ b/docs/mask_treatment/mask_treatment.rst
@@ -1,0 +1,56 @@
+.. _mask_treatment:
+
+Treatment of masked and non-finite pixel values
+===============================================
+
+Specreduce provides several options for handling images that contain masked or non-finite pixels.
+These options allow users to decide whether to preserve, modify, or remove invalid data.
+
+The mask treatment option is selected using the ``mask_treatment`` argument in class initializers,
+methods, and functions where applicable. Note that different classes and procedures within Specreduce
+may support only a subset of these options.
+
+Available Options
+-----------------
+
+- ``apply``
+  The input image is left unmodified. Any pixel that is non-finite (e.g., NaN or infinity) is marked as
+  masked, and if an existing mask is present, it is combined with the mask derived from non-finite values.
+
+.. image:: fig_masking_apply.svg
+
+- ``ignore``
+  The input image remains unchanged, and any existing mask is discarded. Non-finite values are neither
+  masked nor replaced.
+
+.. image:: fig_masking_ignore.svg
+
+- ``propagate``
+  The image data remains unchanged. However, if any pixel is masked or non-finite, the entire
+  cross-dispersion axis containing that pixel is marked as masked.
+
+.. image:: fig_masking_propagate.svg
+
+- ``zero-fill``
+  All pixels that are masked or non-finite are replaced with ``0.0`` and the the mask
+  is cleared from the image.
+
+.. image:: fig_masking_zero_fill.svg
+
+- ``nan-fill``
+  Similar to zero-fill, but instead of replacing invalid pixels with ``0.0``, they are replaced
+  with ``nan``. The mask is then removed from the image.
+
+.. image:: fig_masking_nan_fill.svg
+
+- ``apply_mask_only``
+  The image and its mask are returned as provided. Only the existing mask is applied without
+  incorporating non-finite value checks.
+
+.. image:: fig_masking_apply_mask_only.svg
+
+- ``apply_nan_only``
+  The input image is returned unaltered, but any existing mask is ignored. A new mask is generated
+  solely based on non-finite pixels.
+
+.. image:: fig_masking_apply_nan_only.svg

--- a/notebook_sandbox/compare_extractions.ipynb
+++ b/notebook_sandbox/compare_extractions.ipynb
@@ -1,31 +1,28 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "id": "d1f2d88b-b715-487d-8e96-0e644ed3e7d2",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "# Extraction algorithm comparison\n",
     "\n",
     "We create a synthetic 2D image, upon which we compare the results of `specreduce`'s `BoxcarExtract` and `HorneExtract` algorithms.\n",
     "\n",
     "Since we control amplitude/uncertainty/etc., we can check that the results match our expectations. Among other things, we expect the Horne extraction's signal-to-noise ratio to outperform the boxcar's when using the whole scene as the aperture."
-   ]
+   ],
+   "id": "e90e12a515e145e4"
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "d1b17df2-81fe-49e7-9083-d5ce3f278937",
-   "metadata": {},
-   "source": [
-    "## Import packages"
-   ]
+   "source": "## Import packages",
+   "id": "3e96a678b6bbdc01"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fc741345-720e-4189-9748-b3bb98d2d693",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "import astropy.units as u\n",
     "import matplotlib as mpl\n",
@@ -35,179 +32,171 @@
     "from astropy.nddata import CCDData, VarianceUncertainty\n",
     "from specreduce.extract import BoxcarExtract, HorneExtract\n",
     "from specreduce.tracing import FlatTrace"
-   ]
+   ],
+   "id": "dfc7fa7d74146ac4"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "000a0fc1-90e8-4472-bc8e-42a1c1b67506",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "mpl.rcParams.update({'axes.titlesize': 18, 'axes.labelsize': 12,\n",
     "                     'legend.fontsize': 12,  'axes.grid': False,\n",
     "                     'grid.alpha': .5, 'grid.color': 'k',\n",
     "                     'axes.edgecolor': 'k'})\n",
     "np.random.seed(7) # use same random values in different sessions"
-   ]
+   ],
+   "id": "31d03d7febb6b07c"
   },
   {
-   "cell_type": "markdown",
-   "id": "13866c09-5b84-4fa9-be19-04e6aafa8ac1",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "## Create a 2D image\n",
     "\n",
     "The flux in each column will follow a Gaussian distribution that we set using `astropy`'s modeling functionality.\n",
     "\n",
     "We also add normally distributed noise throughout the image to make the extraction more difficult."
-   ]
+   ],
+   "id": "8019455fcc2a41d5"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e0471b5d-907c-4c23-8b24-9ac2e7a619a6",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "nrows = 50*4\n",
     "ncols = 40*4\n",
     "sigma_pix = 4\n",
     "sigma_noise = 1"
-   ]
+   ],
+   "id": "cba1910c63fbf143"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ff677978-744f-4264-a1d5-c51a32727d64",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "col_model = models.Gaussian1D(amplitude=1, mean=nrows/2, stddev=sigma_pix)\n",
     "noise = np.random.normal(scale=sigma_noise, size=(nrows, ncols))"
-   ]
+   ],
+   "id": "52e2767921465621"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9f96eb2e-b6ac-4396-88ec-f2011e335107",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "index_arr = np.broadcast_to(np.arange(nrows)[:, np.newaxis], (nrows, ncols))\n",
     "index_arr"
-   ]
+   ],
+   "id": "b390c4c4b23f452f"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7c5fb4b1-9c7d-4846-9963-b476070662ac",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": [
-    "img = col_model(index_arr) + noise"
-   ]
+   "execution_count": null,
+   "source": "img = col_model(index_arr) + noise",
+   "id": "8b9af6c553d6e0ae"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "05c8c9be-e553-4ab1-8f01-1edd84d3ca25",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "fig, ax = plt.subplots(figsize=(10,8))\n",
     "im1 = ax.imshow(img, cmap='magma', origin='lower', vmin=0, vmax=1)\n",
     "ax.set_title('synthetic 2D image')\n",
     "fig.colorbar(im1)"
-   ]
+   ],
+   "id": "b645fd80b47f1906"
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "7161a77b-87ee-40ec-b780-64a1e0510c8b",
-   "metadata": {},
-   "source": [
-    "In addition to the image, we also create variance and mask images for `HorneExtract`. The former was defined above; we use an array of zeros for the latter since this image has no \"bad\" pixels."
-   ]
+   "source": "In addition to the image, we also create variance and mask images for `HorneExtract`. The former was defined above; we use an array of zeros for the latter since this image has no \"bad\" pixels.",
+   "id": "1f863a76703c7f36"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "17ba40e0-8bc9-49c1-80f7-943697c43cfa",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "variance = np.tile(sigma_noise, img.shape)\n",
     "mask = np.zeros_like(img)"
-   ]
+   ],
+   "id": "42da99a75e63f527"
   },
   {
-   "cell_type": "markdown",
-   "id": "fe8bfe43-54d8-44e0-b60e-c0ee835e4621",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "## Create a trace\n",
     "\n",
     "Here, we manually set the trace to the middle row of the 2D image's y-axis."
-   ]
+   ],
+   "id": "f371bae11156cf7c"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bb3e2f73-e863-4fed-b919-4a1991344c9e",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": [
-    "trace = FlatTrace(img, nrows/2)"
-   ]
+   "execution_count": null,
+   "source": "trace = FlatTrace(img, nrows/2)",
+   "id": "1f553a70c6946797"
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "9341c3a4-6ca4-4460-9aa1-37f8332f4193",
-   "metadata": {},
-   "source": [
-    "## Calculate the extractions"
-   ]
+   "source": "## Calculate the extractions",
+   "id": "5d51976ee8ea5ded"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e7103992-4462-4bd9-8805-89c21ac17ed0",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "bxc = BoxcarExtract(img, trace)\n",
     "bxc_result1d_slice = bxc(width=14)\n",
     "bxc_result1d_whole = bxc(width=nrows)"
-   ]
+   ],
+   "id": "ad7e8842ed76823f"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "be1c3f96-efd4-4108-803f-7f1698fe2564",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "hrn = HorneExtract(img, trace)\n",
     "hrn_result1d_whole = hrn(variance=variance,\n",
     "                         mask=mask, unit=u.DN) # whole image is aperture"
-   ]
+   ],
+   "id": "4a0ce602d2bcb547"
   },
   {
-   "cell_type": "markdown",
-   "id": "d547548e-6ff9-4672-bd03-aa666b3affdf",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "Note that `HorneExtract` can also take an `NDData` or `CCDData` image object as an argument. These are convenient because they allow for compiling the image, the variance, a mask, and any units into a single object. \n",
     "\n",
     "Once that's created, the only other argument needed is the trace. See this example with `CCDData`:"
-   ]
+   ],
+   "id": "293f2105a34fb6a8"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d4b31779-2080-4541-b0b4-6a3d08b37062",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "mask = np.zeros_like(img)\n",
     "var_obj = VarianceUncertainty(variance)\n",
@@ -215,44 +204,37 @@
     "\n",
     "hrn2 = HorneExtract(img_obj, trace)\n",
     "hrn2_result1d_whole = hrn2()"
-   ]
+   ],
+   "id": "cd8095c84b2c2f6a"
   },
   {
-   "cell_type": "markdown",
-   "id": "53e45324-a42b-46cf-9512-04cb0be8db47",
    "metadata": {},
-   "source": [
-    "The results are the same either way:"
-   ]
+   "cell_type": "markdown",
+   "source": "The results are the same either way:",
+   "id": "d24f7080fe5d718"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4cbf978f-1567-4558-8789-3e8783d29be4",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
    "outputs": [],
-   "source": [
-    "np.array_equal(hrn_result1d_whole.flux, hrn2_result1d_whole.flux)"
-   ]
+   "execution_count": null,
+   "source": "np.array_equal(hrn_result1d_whole.flux, hrn2_result1d_whole.flux)",
+   "id": "83b0a4df47aff159"
   },
   {
-   "cell_type": "markdown",
-   "id": "9a9de2c3-f318-4d9e-bbd0-21f883da4650",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "## Compare results\n",
     "The whole-image extractions come out as expected, with the Horne-extracted 1D spectrum showing a noticeably better signal-to-noise ratio than its windowless boxcar equivalent."
-   ]
+   ],
+   "id": "a2b771a90d72a9f8"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4fd7c15f-c8a0-40e2-af68-173eaaad0a61",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "fig2, ax2 = plt.subplots(figsize=(10, 8))\n",
     "\n",
@@ -266,22 +248,20 @@
     "\n",
     "ax2.legend(fontsize=12)#, loc=(1.05,.5))\n",
     "ax2.set_title('extracted 1D spectra')"
-   ]
+   ],
+   "id": "183c44d576699870"
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "44ef28f4-959f-491a-8e0c-d5477f66d7be",
-   "metadata": {},
-   "source": [
-    "The boxcar extraction can produce a similar result when its aperture is sliced to remove edge pixels. (Of course, that comes with the cost of losing any information those pixels contained.)"
-   ]
+   "source": "The boxcar extraction can produce a similar result when its aperture is sliced to remove edge pixels. (Of course, that comes with the cost of losing any information those pixels contained.)",
+   "id": "e51712c915ba677a"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bb606fad-34fc-4adf-b52b-06035f4d1f23",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "fig3, ax3 = plt.subplots(figsize=(10, 4))\n",
     "\n",
@@ -294,7 +274,16 @@
     "\n",
     "ax3.legend(fontsize=12)\n",
     "ax3.set_title('extracted 1D spectra, normalized')"
-   ]
+   ],
+   "id": "df071df274a6adfb"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "",
+   "id": "81ff37acb6a2c7c5"
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ build-backend = 'setuptools.build_meta'
 
 [tool.black]
 line-length = 100
-target-version = ['py310', 'py311', 'py312']
+target-version = ['py311', 'py312', 'py313']
 
 [tool.pytest.ini_options]
 minversion = 7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ requires = ["setuptools",
 ]
 build-backend = 'setuptools.build_meta'
 
+[tool.black]
+line-length = 100
+target-version = ['py310', 'py311', 'py312']
+
 [tool.pytest.ini_options]
 minversion = 7.0
 testpaths = [

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -47,16 +47,21 @@ class Background(_ImageParser):
     mask_treatment
         Specifies how to handle masked or non-finite values in the input image.
         The accepted values are:
-          - ``apply``: The image is left unmodified and any existing mask is combined
+
+        - ``apply``: The image remains unchanged, and any existing mask is combined\
             with a mask derived from non-finite values.
-          - ``ignore``: The image remains unchanged, and any existing mask is dropped.
-          - ``propagate``: The image remains unchanged, and any masked or non-finite pixel
-                causes the mask to extend across the entire cross-dispersion axis.
-          - ``zero-fill``: Pixels that are either masked or non-finite are replaced with 0.0
+        - ``ignore``: The image remains unchanged, and any existing mask is dropped.
+        - ``propagate``: The image remains unchanged, and any masked or non-finite pixel\
+            causes the mask to extend across the entire cross-dispersion axis.
+        - ``zero-fill``: Pixels that are either masked or non-finite are replaced with 0.0,\
             and the mask is dropped.
-          - ``nan-fill``:  Pixels that are either masked or non-finite are replaced with nan
+        - ``nan-fill``:  Pixels that are either masked or non-finite are replaced with nan,\
             and the mask is dropped.
-    """
+        - ``apply_mask_only``: The  image and mask are left unmodified.
+        - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a\
+            new mask is created based on non-finite values.
+
+"""
 
     # required so numpy won't call __rsub__ on individual elements
     # https://stackoverflow.com/a/58409215
@@ -69,7 +74,15 @@ class Background(_ImageParser):
     disp_axis: int = 1
     crossdisp_axis: int = 0
     mask_treatment: MaskingOption = "apply"
-    _valid_mask_treatment_methods = ("apply", "ignore", "propagate", "zero-fill", "nan-fill")
+    _valid_mask_treatment_methods = (
+        "apply",
+        "ignore",
+        "propagate",
+        "zero-fill",
+        "nan-fill",
+        "apply_mask_only",
+        "apply_nan_only",
+    )
 
     # TO-DO: update bkg_array with Spectrum1D alternative (is bkg_image enough?)
     bkg_array = deprecated_attribute("bkg_array", "1.3")

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -49,6 +49,9 @@ class Background(_ImageParser):
         The accepted values are:
           - ``apply``: The image is left unmodified and any existing mask is combined
             with a mask derived from non-finite values.
+          - ``ignore``: The image remains unchanged, and any existing mask is dropped.
+          - ``propagate``: The image remains unchanged, and any masked or non-finite pixel
+                causes the mask to extend across the entire cross-dispersion axis.
           - ``zero-fill``: Pixels that are either masked or non-finite are replaced with 0.0
             and the mask is dropped.
           - ``nan-fill``:  Pixels that are either masked or non-finite are replaced with nan
@@ -66,7 +69,7 @@ class Background(_ImageParser):
     disp_axis: int = 1
     crossdisp_axis: int = 0
     mask_treatment: MaskingOption = "apply"
-    _valid_mask_treatment_methods = ("apply", "ignore", "zero-fill", "nan-fill")
+    _valid_mask_treatment_methods = ("apply", "ignore", "propagate", "zero-fill", "nan-fill")
 
     # TO-DO: update bkg_array with Spectrum1D alternative (is bkg_image enough?)
     bkg_array = deprecated_attribute("bkg_array", "1.3")

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -53,9 +53,9 @@ class Background(_ImageParser):
         - ``ignore``: The image remains unchanged, and any existing mask is dropped.
         - ``propagate``: The image remains unchanged, and any masked or non-finite pixel\
             causes the mask to extend across the entire cross-dispersion axis.
-        - ``zero-fill``: Pixels that are either masked or non-finite are replaced with 0.0,\
+        - ``zero_fill``: Pixels that are either masked or non-finite are replaced with 0.0,\
             and the mask is dropped.
-        - ``nan-fill``:  Pixels that are either masked or non-finite are replaced with nan,\
+        - ``nan_fill``:  Pixels that are either masked or non-finite are replaced with nan,\
             and the mask is dropped.
         - ``apply_mask_only``: The  image and mask are left unmodified.
         - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a\
@@ -78,8 +78,8 @@ class Background(_ImageParser):
         "apply",
         "ignore",
         "propagate",
-        "zero-fill",
-        "nan-fill",
+        "zero_fill",
+        "nan_fill",
         "apply_mask_only",
         "apply_nan_only",
     )
@@ -226,11 +226,11 @@ class Background(_ImageParser):
             cross-dispersion axis
         mask_treatment : string
             The method for handling masked or non-finite data. Choice of ``filter``,
-            ``omit`, or ``zero-fill``. If `filter` is chosen, masked/non-finite data
+            ``omit`, or ``zero_fill``. If `filter` is chosen, masked/non-finite data
             will be filtered during the fit to each bin/column (along disp. axis) to
             find the peak. If ``omit`` is chosen, columns along disp_axis with any
             masked/non-finite data values will be fully masked (i.e, 2D mask is
-            collapsed to 1D and applied). If ``zero-fill`` is chosen, masked/non-finite
+            collapsed to 1D and applied). If ``zero_fill`` is chosen, masked/non-finite
             data will be replaced with 0.0 in the input image, and the mask will then
             be dropped. For all three options, the input mask (optional on input
             NDData object) will be combined with a mask generated from any non-finite
@@ -275,11 +275,11 @@ class Background(_ImageParser):
             cross-dispersion axis
         mask_treatment : string
             The method for handling masked or non-finite data. Choice of ``filter``,
-            ``omit``, or ``zero-fill``. If `filter` is chosen, masked/non-finite data
+            ``omit``, or ``zero_fill``. If `filter` is chosen, masked/non-finite data
             will be filtered during the fit to each bin/column (along disp. axis) to
             find the peak. If ``omit`` is chosen, columns along disp_axis with any
             masked/non-finite data values will be fully masked (i.e, 2D mask is
-            collapsed to 1D and applied). If ``zero-fill`` is chosen, masked/non-finite
+            collapsed to 1D and applied). If ``zero_fill`` is chosen, masked/non-finite
             data will be replaced with 0.0 in the input image, and the mask will then
             be dropped. For all three options, the input mask (optional on input
             NDData object) will be combined with a mask generated from any non-finite

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -5,22 +5,20 @@ from dataclasses import dataclass, field
 
 import numpy as np
 from astropy import units as u
-from astropy.nddata import NDData
 from astropy.utils.decorators import deprecated_attribute
 from specutils import Spectrum1D
 
-from specreduce.core import _ImageParser
+from specreduce.core import _ImageParser, MaskingOption, ImageLike
 from specreduce.extract import _ap_weight_image
 from specreduce.tracing import Trace, FlatTrace
 
-__all__ = ['Background']
+__all__ = ["Background"]
 
 
 @dataclass
 class Background(_ImageParser):
     """
     Determine the background from an image for subtraction.
-
 
     Example: ::
 
@@ -30,95 +28,56 @@ class Background(_ImageParser):
 
     Parameters
     ----------
-    image : `~astropy.nddata.NDData`-like or array-like
-        image with 2-D spectral image data
+    image
+        Image with 2-D spectral image data
     traces : List, `specreduce.tracing.Trace`, int, float
         Individual or list of trace object(s) (or integers/floats to define
         FlatTraces) to extract the background. If None, a ``FlatTrace`` at the
         center of the image (according to ``disp_axis``) will be used.
-    width : float
-        width of extraction aperture in pixels
-    statistic: string
-        statistic to use when computing the background.  ``average`` will
+    width
+        Width of extraction aperture in pixels.
+    statistic
+        Statistic to use when computing the background.  ``average`` will
         account for partial pixel weights, ``median`` will include all partial
         pixels.
-    disp_axis : int
-        dispersion axis
-        [default: 1]
-    crossdisp_axis : int
-        cross-dispersion axis
-        [default: 0]
-    mask_treatment : string, optional
-        The method for handling masked or non-finite data. Choice of ``filter``,
-        ``omit``, or ``zero-fill``. If `filter` is chosen, masked and non-finite
-        data will not contribute to the background statistic that is calculated
-        in each column along ``disp_axis``. If ``omit`` is chosen, columns along
-        disp_axis with any masked/non-finite data values will be fully masked
-        (i.e, 2D mask is collapsed to 1D and applied). If ``zero-fill`` is chosen,
-        masked/non-finite data will be replaced with 0.0 in the input image,
-        and the mask will then be dropped. For all three options, the input mask
-        (optional on input NDData object) will be combined with a mask generated
-        from any non-finite values in the image data.
-        [default: ``filter``]
+    disp_axis
+        Dispersion axis.
+    crossdisp_axis
+        Cross-dispersion axis.
+    mask_treatment
+        Specifies how to handle masked or non-finite values in the input image.
+        The accepted values are:
+          - ``apply``: The image is left unmodified and any existing mask is combined
+            with a mask derived from non-finite values.
+          - ``zero-fill``: Pixels that are either masked or non-finite are replaced with 0.0
+            and the mask is dropped.
+          - ``nan-fill``:  Pixels that are either masked or non-finite are replaced with nan
+            and the mask is dropped.
     """
+
     # required so numpy won't call __rsub__ on individual elements
     # https://stackoverflow.com/a/58409215
     __array_ufunc__ = None
 
-    image: NDData
+    image: ImageLike
     traces: list = field(default_factory=list)
     width: float = 5
-    statistic: str = 'average'
+    statistic: str = "average"
     disp_axis: int = 1
     crossdisp_axis: int = 0
-    mask_treatment: str = 'filter'
-    _valid_mask_treatment_methods = ('filter', 'omit', 'zero-fill')
+    mask_treatment: MaskingOption = "apply"
+    _valid_mask_treatment_methods = ("apply", "ignore", "zero-fill", "nan-fill")
 
     # TO-DO: update bkg_array with Spectrum1D alternative (is bkg_image enough?)
-    bkg_array = deprecated_attribute('bkg_array', '1.3')
+    bkg_array = deprecated_attribute("bkg_array", "1.3")
 
     def __post_init__(self):
-        """
-        Determine the background from an image for subtraction.
-
-        Parameters
-        ----------
-        image : `~astropy.nddata.NDData`-like or array-like
-            image with 2-D spectral image data
-        traces : List
-            list of trace objects (or integers to define FlatTraces) to
-            extract the background
-        width : float
-            width of each background aperture in pixels
-        statistic: string
-            statistic to use when computing the background.  'average' will
-            account for partial pixel weights, 'median' will include all partial
-            pixels.
-        disp_axis : int
-            dispersion axis
-        crossdisp_axis : int
-            cross-dispersion axis
-        mask_treatment : string
-            The method for handling masked or non-finite data. Choice of `filter`,
-            `omit`, or `zero-fill`. If `filter` is chosen, masked/non-finite data
-            will be filtered during the fit to each bin/column (along disp. axis) to
-            find the peak. If `omit` is chosen, columns along disp_axis with any
-            masked/non-finite data values will be fully masked (i.e, 2D mask is
-            collapsed to 1D and applied). If `zero-fill` is chosen, masked/non-finite
-            data will be replaced with 0.0 in the input image, and the mask will then
-            be dropped. For all three options, the input mask (optional on input
-            NDData object) will be combined with a mask generated from any non-finite
-            values in the image data.
-        """
-
-        # Parse image, including masked/nonfinite data handling based on
-        # choice of `mask_treatment`. Any uncaught nonfinte data values will be
-        # masked as well. Returns a Spectrum1D.
-        self.image = self._parse_image(self.image, disp_axis=self.disp_axis,
-                                       mask_treatment=self.mask_treatment)
+        self.image = self._parse_image(
+            self.image, disp_axis=self.disp_axis, mask_treatment=self.mask_treatment
+        )
 
         # always work with masked array, even if there is no masked
-        # or nonfinite data, in case padding is needed. if not, mask will be
+        # or non-finite data, in case padding is needed. if not, mask will be
         # dropped at the end and a regular array will be returned.
         img = np.ma.masked_array(self.image.data, self.image.mask)
 
@@ -135,43 +94,46 @@ class Background(_ImageParser):
             # note: ArrayTrace can have masked values, but if it does a MaskedArray
             # will be returned so this should be reflected in the window size here
             # (i.e, np.nanmax is not required.)
-            windows_max = trace.trace.data.max() + self.width/2
-            windows_min = trace.trace.data.min() - self.width/2
+            windows_max = trace.trace.data.max() + self.width / 2
+            windows_min = trace.trace.data.min() - self.width / 2
 
             if windows_max > self.image.shape[self.crossdisp_axis]:
-                warnings.warn("background window extends beyond image boundaries " +
-                              f"({windows_max} >= {self.image.shape[self.crossdisp_axis]})")
+                warnings.warn(
+                    "background window extends beyond image boundaries "
+                    + f"({windows_max} >= {self.image.shape[self.crossdisp_axis]})"
+                )
             if windows_min < 0:
-                warnings.warn("background window extends beyond image boundaries " +
-                              f"({windows_min} < 0)")
+                warnings.warn(
+                    "background window extends beyond image boundaries " + f"({windows_min} < 0)"
+                )
 
             # pass trace.trace.data to ignore any mask on the trace
-            bkg_wimage += _ap_weight_image(trace,
-                                           self.width,
-                                           self.disp_axis,
-                                           self.crossdisp_axis,
-                                           self.image.shape)
+            bkg_wimage += _ap_weight_image(
+                trace, self.width, self.disp_axis, self.crossdisp_axis, self.image.shape
+            )
 
         if np.any(bkg_wimage > 1):
             raise ValueError("background regions overlapped")
         if np.any(np.sum(bkg_wimage, axis=self.crossdisp_axis) == 0):
-            raise ValueError("background window does not remain in bounds across entire dispersion axis")  # noqa
+            raise ValueError(
+                "background window does not remain in bounds across entire dispersion axis"
+            )  # noqa
         # check if image contained within background window is fully-nonfinite and raise an error
         if np.all(img.mask[bkg_wimage > 0]):
-            raise ValueError("Image is fully masked within background window determined by `width`.")  # noqa
+            raise ValueError(
+                "Image is fully masked within background window determined by `width`."
+            )  # noqa
 
-        if self.statistic == 'median':
+        if self.statistic == "median":
             # make it clear in the expose image that partial pixels are fully-weighted
             bkg_wimage[bkg_wimage > 0] = 1
 
         self.bkg_wimage = bkg_wimage
 
-        if self.statistic == 'average':
-            self._bkg_array = np.ma.average(img,
-                                            weights=self.bkg_wimage,
-                                            axis=self.crossdisp_axis)
+        if self.statistic == "average":
+            self._bkg_array = np.ma.average(img, weights=self.bkg_wimage, axis=self.crossdisp_axis)
 
-        elif self.statistic == 'median':
+        elif self.statistic == "median":
             # combine where background weight image is 0 with image masked (which already
             # accounts for non-finite data that wasn't already masked)
             img.mask = np.logical_or(self.bkg_wimage == 0, self.image.mask)
@@ -181,15 +143,15 @@ class Background(_ImageParser):
 
     def _set_traces(self):
         """Determine `traces` from input. If an integer/float or list if int/float
-           is passed in, use these to construct FlatTrace objects. These values
-           must be positive. If None (which is initialized to an empty list),
-           construct a FlatTrace using the center of image (according to disp.
-           axis). Otherwise, any Trace object or list of Trace objects can be
-           passed in."""
+        is passed in, use these to construct FlatTrace objects. These values
+        must be positive. If None (which is initialized to an empty list),
+        construct a FlatTrace using the center of image (according to disp.
+        axis). Otherwise, any Trace object or list of Trace objects can be
+        passed in."""
 
         if self.traces == []:
             # assume a flat trace at the image center if nothing is passed in.
-            trace_pos = self.image.shape[self.disp_axis] / 2.
+            trace_pos = self.image.shape[self.disp_axis] / 2.0
             self.traces = [FlatTrace(self.image, trace_pos)]
 
         if isinstance(self.traces, Trace):
@@ -207,10 +169,12 @@ class Background(_ImageParser):
 
         else:
             if not np.all([isinstance(x, Trace) for x in self.traces]):
-                raise ValueError('`traces` must be a `Trace` object or list of '
-                                 '`Trace` objects, a number or list of numbers to '
-                                 'define FlatTraces, or None to use a FlatTrace in '
-                                 'the middle of the image.')
+                raise ValueError(
+                    "`traces` must be a `Trace` object or list of "
+                    "`Trace` objects, a number or list of numbers to "
+                    "define FlatTraces, or None to use a FlatTrace in "
+                    "the middle of the image."
+                )
 
     @classmethod
     def two_sided(cls, image, trace_object, separation, **kwargs):
@@ -258,7 +222,7 @@ class Background(_ImageParser):
         """
 
         image = _ImageParser._get_data_from_image(image) if image is not None else cls.image
-        kwargs['traces'] = [trace_object-separation, trace_object+separation]
+        kwargs["traces"] = [trace_object - separation, trace_object + separation]
         return cls(image=image, **kwargs)
 
     @classmethod
@@ -306,7 +270,7 @@ class Background(_ImageParser):
             values in the image data.
         """
         image = _ImageParser._get_data_from_image(image) if image is not None else cls.image
-        kwargs['traces'] = [trace_object+separation]
+        kwargs["traces"] = [trace_object + separation]
         return cls(image=image, **kwargs)
 
     def bkg_image(self, image=None):
@@ -326,9 +290,10 @@ class Background(_ImageParser):
         `~specutils.Spectrum1D` object with same shape as ``image``.
         """
         image = self._parse_image(image)
-        return Spectrum1D(np.tile(self._bkg_array,
-                                  (image.shape[0], 1)) * image.unit,
-                          spectral_axis=image.spectral_axis)
+        return Spectrum1D(
+            np.tile(self._bkg_array, (image.shape[0], 1)) * image.unit,
+            spectral_axis=image.spectral_axis,
+        )
 
     def bkg_spectrum(self, image=None, bkg_statistic="sum"):
         """
@@ -395,8 +360,7 @@ class Background(_ImageParser):
         # a compare_wcs argument is needed for Spectrum1D.subtract() in order to
         # avoid a TypeError from SpectralCoord when image's spectral axis is in
         # pixels. it is not needed when image's spectral axis has physical units
-        kwargs = ({'compare_wcs': None} if image.spectral_axis.unit == u.pix
-                  else {})
+        kwargs = {"compare_wcs": None} if image.spectral_axis.unit == u.pix else {}
 
         # https://docs.astropy.org/en/stable/nddata/mixins/ndarithmetic.html
         return image.subtract(self.bkg_image(image), **kwargs)

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -181,12 +181,12 @@ class _ImageParser:
         """
         if mask_treatment not in _ImageParser.implemented_mask_treatment_methods:
             raise ValueError(
-                "`mask_treatment` must be one of "
+                "'mask_treatment' must be one of "
                 f"{_ImageParser.implemented_mask_treatment_methods}"
             )
 
         if mask is not None and (mask.dtype not in (bool, int)):
-            raise ValueError("`mask` must be a boolean or integer array.")
+            raise ValueError("'mask' must be a boolean or integer array.")
 
         match mask_treatment:
             case "apply":
@@ -210,7 +210,7 @@ class _ImageParser:
             case "apply_nan_only":
                 mask = ~np.isfinite(image)
             case "apply_mask_only":
-                mask = mask if mask is not None else np.zeros(image.shape, dtype=bool)
+                mask = mask.copy() if mask is not None else np.zeros(image.shape, dtype=bool)
 
         if mask.all():
             raise ValueError("Image is fully masked. Check for invalid values.")

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -242,7 +242,7 @@ class SpecreduceOperation(_ImageParser):
         ``Operation(arg2, keyword=value)(arg1)`` (if the ``__call__`` of
         ``Operation`` has only one argument)
         """
-        argspec = inspect.getargs(SpecreduceOperation.__call__.__code__)
+        argspec = inspect.getargs(cls.__call__.__code__)
         if argspec.varargs:
             raise NotImplementedError(
                 "There is not a way to determine the "

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -65,17 +65,18 @@ class _ImageParser:
         mask_treatment
             Specifies how to handle masked or non-finite values in the input image.
             The accepted values are:
-              - ``apply``: The image remains unchanged, and any existing mask is combined
+
+            - ``apply``: The image remains unchanged, and any existing mask is combined\
                 with a mask derived from non-finite values.
-              - ``ignore``: The image remains unchanged, and any existing mask is dropped.
-              - ``propagate``: The image remains unchanged, and any masked or non-finite pixel
+            - ``ignore``: The image remains unchanged, and any existing mask is dropped.
+            - ``propagate``: The image remains unchanged, and any masked or non-finite pixel\
                 causes the mask to extend across the entire cross-dispersion axis.
-              - ``zero-fill``: Pixels that are either masked or non-finite are replaced with 0.0,
+            - ``zero-fill``: Pixels that are either masked or non-finite are replaced with 0.0,\
                 and the mask is dropped.
-              - ``nan-fill``:  Pixels that are either masked or non-finite are replaced with nan,
+            - ``nan-fill``:  Pixels that are either masked or non-finite are replaced with nan,\
                 and the mask is dropped.
-              - ``apply_mask_only``: The  image and mask are left unmodified.
-              - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a
+            - ``apply_mask_only``: The  image and mask are left unmodified.
+            - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a\
                 new mask is created based on non-finite values.
 
         Returns

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -13,7 +13,7 @@ from specutils import Spectrum1D
 __all__ = ["SpecreduceOperation"]
 
 MaskingOption = Literal[
-    "apply", "ignore", "propagate", "zero-fill", "nan-fill", "apply_mask_only", "apply_nan_only"
+    "apply", "ignore", "propagate", "zero_fill", "nan_fill", "apply_mask_only", "apply_nan_only"
 ]
 
 ImageLike = np.ndarray | NDData | u.Quantity
@@ -41,8 +41,8 @@ class _ImageParser:
         "apply",
         "ignore",
         "propagate",
-        "zero-fill",
-        "nan-fill",
+        "zero_fill",
+        "nan_fill",
         "apply_mask_only",
         "apply_nan_only",
     )
@@ -71,9 +71,9 @@ class _ImageParser:
             - ``ignore``: The image remains unchanged, and any existing mask is dropped.
             - ``propagate``: The image remains unchanged, and any masked or non-finite pixel\
                 causes the mask to extend across the entire cross-dispersion axis.
-            - ``zero-fill``: Pixels that are either masked or non-finite are replaced with 0.0,\
+            - ``zero_fill``: Pixels that are either masked or non-finite are replaced with 0.0,\
                 and the mask is dropped.
-            - ``nan-fill``:  Pixels that are either masked or non-finite are replaced with nan,\
+            - ``nan_fill``:  Pixels that are either masked or non-finite are replaced with nan,\
                 and the mask is dropped.
             - ``apply_mask_only``: The  image and mask are left unmodified.
             - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a\
@@ -166,7 +166,7 @@ class _ImageParser:
         part of the input NDData.
 
         There are five options currently implemented for the treatment
-        of masked and non-finite data - apply, ignore, zero-fill, nan-fill,
+        of masked and non-finite data - apply, ignore, zero_fill, nan_fill,
         apply_mask_only, and apply_nan_only. Depending on the routine,
         all or a subset of these three options are valid.
 
@@ -200,10 +200,10 @@ class _ImageParser:
                 else:
                     mask = mask | (~np.isfinite(image))
                 mask[:] = mask.any(axis=crossdisp_axis, keepdims=True)
-            case "zero-fill" | "nan-fill":
+            case "zero_fill" | "nan_fill":
                 mask = mask | (~np.isfinite(image)) if mask is not None else ~np.isfinite(image)
                 image = deepcopy(image)
-                if mask_treatment == "zero-fill":
+                if mask_treatment == "zero_fill":
                     image[mask] = 0.0
                 else:
                     image[mask] = np.nan

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -196,6 +196,8 @@ class _ImageParser:
             case "propagate":
                 if mask is None:
                     mask = ~np.isfinite(image)
+                else:
+                    mask = mask | (~np.isfinite(image))
                 mask[:] = mask.any(axis=crossdisp_axis, keepdims=True)
             case "zero-fill" | "nan-fill":
                 mask = mask | (~np.isfinite(image)) if mask is not None else ~np.isfinite(image)

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -3,13 +3,20 @@
 from copy import deepcopy
 import inspect
 from dataclasses import dataclass
+from typing import Literal
 
 import numpy as np
 from astropy import units as u
-from astropy.nddata import VarianceUncertainty
+from astropy.nddata import VarianceUncertainty, NDData
 from specutils import Spectrum1D
 
-__all__ = ['SpecreduceOperation']
+__all__ = ["SpecreduceOperation"]
+
+MaskingOption = Literal[
+    "apply", "ignore", "zero-fill", "nan-fill", "apply_mask_only", "apply_nan_only"
+]
+
+ImageLike = np.ndarray | NDData | u.Quantity
 
 
 class _ImageParser:
@@ -30,11 +37,18 @@ class _ImageParser:
 
     # The '_valid_mask_treatment_methods' in the Background, Trace, and Extract
     # classes is a subset of implemented methods.
-    implemented_mask_treatment_methods = 'filter', 'zero-fill', 'omit'
+    implemented_mask_treatment_methods = (
+        "apply",
+        "ignore",
+        "zero-fill",
+        "nan-fill",
+        "apply_mask_only",
+        "apply_nan_only",
+    )
 
-    def _parse_image(self, image,
-                     disp_axis: int = 1,
-                     mask_treatment: str = 'filter') -> Spectrum1D:
+    def _parse_image(
+        self, image: ImageLike, disp_axis: int = 1, mask_treatment: MaskingOption = "apply"
+    ) -> Spectrum1D:
         """
         Convert all accepted image types to a consistently formatted Spectrum1D object.
 
@@ -46,19 +60,20 @@ class _ImageParser:
         disp_axis
             The index of the image's dispersion axis. Should not be
             changed until operations can handle variable image
-            orientations. [default: 1]
+            orientations.
         mask_treatment
-            The method for handling masked or non-finite data. Choice of ``filter``,
-            ``omit``, or ``zero-fill``. If ``filter`` is chosen, masked and non-finite
-            data will not contribute to the background statistic that is calculated
-            in each column along `disp_axis`. If `omit` is chosen, columns along
-            disp_axis with any masked/non-finite data values will be fully masked
-            (i.e, 2D mask is collapsed to 1D and applied). If ``zero-fill`` is chosen,
-            masked/non-finite data will be replaced with 0.0 in the input image,
-            and the mask will then be dropped. For all three options, the input mask
-            (optional on input NDData object) will be combined with a mask generated
-            from any non-finite values in the image data.
-            [default: ``filter``]
+            Specifies how to handle masked or non-finite values in the input image.
+            The accepted values are:
+              - ``apply``: The image is left unmodified and any existing mask is combined
+                with a mask derived from non-finite values.
+              - ``zero-fill``: Pixels that are either masked or non-finite are replaced with 0.0,
+                and the mask is dropped.
+              - ``nan-fill``:  Pixels that are either masked or non-finite are replaced with nan,
+                and the mask is dropped.
+              - ``ignore``: The image is left unmodified and any existing mask is dropped.
+              - ``apply_mask_only``: The  image and mask are left unmodified.
+              - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a
+                new mask is created based on non-finite values.
 
         Returns
         -------
@@ -72,36 +87,30 @@ class _ImageParser:
             # useful for Background's instance methods
             return self.image
 
-        return self._get_data_from_image(image, disp_axis=disp_axis,
-                                         mask_treatment=mask_treatment)
+        return self._get_data_from_image(image, disp_axis=disp_axis, mask_treatment=mask_treatment)
 
     @staticmethod
-    def _get_data_from_image(image,
+    def _get_data_from_image(image: ImageLike,
                              disp_axis: int = 1,
-                             mask_treatment: str = 'filter') -> Spectrum1D:
+                             mask_treatment: MaskingOption = "apply"
+                             ) -> Spectrum1D:
         """
         Extract data array from various input types for `image`.
 
         Parameters
         ----------
-        image : array-like or Quantity
+        image
             Input image from which data is extracted. This can be a 2D numpy
             array, Quantity, or an NDData object.
-        disp_axis : int, optional
+        disp_axis
             The dispersion axis of the image.
-        mask_treatment : str, optional
-            Treatment method for the mask:
-            - 'filter' (default): Return the unmodified input image and combined mask.
-            - 'zero-fill': Set masked values in the image to zero.
-            - 'omit': Mask all pixels along the cross dispersion axis if any value is masked.
+        mask_treatment
+            Specifies how to handle masked or non-finite values in the input image.
 
         Returns
         -------
         Spectrum1D
         """
-        # This works only with 2D images.
-        crossdisp_axis = (disp_axis + 1) % 2
-
         if isinstance(image, u.quantity.Quantity):
             img = image.value
         elif isinstance(image, np.ndarray):
@@ -109,115 +118,89 @@ class _ImageParser:
         else:  # NDData, including CCDData and Spectrum1D
             img = image.data
 
-        mask = getattr(image, 'mask', None)
+        mask = getattr(image, "mask", None)
 
-        # next, handle masked and nonfinite data in image.
-        # A mask will be created from any nonfinite image data, and combined
+        # next, handle masked and non-finite data in image.
+        # A mask will be created from any non-finite image data, and combined
         # with any additional 'mask' passed in. If image is being parsed within
         # a specreduce operation that has 'mask_treatment' options, this will be
         # handled as well. Note that input data may be modified if a fill value
         # is chosen to handle masked data. The returned image will always have
-        # `image.mask` even if there are no nonfinte or masked values.
-        img, mask = _ImageParser._mask_and_nonfinite_data_handling(image=img,
-                                                                   mask=mask,
-                                                                   mask_treatment=mask_treatment,
-                                                                   crossdisp_axis=crossdisp_axis)
+        # `image.mask` even if there are no non-finite or masked values.
+        img, mask = _ImageParser._mask_and_nonfinite_data_handling(
+            image=img, mask=mask, mask_treatment=mask_treatment
+        )
 
         # mask (handled above) and uncertainty are set as None when they aren't
         # specified upon creating a Spectrum1D object, so we must check whether
         # these attributes are absent *and* whether they are present but set as None
-        if hasattr(image, 'uncertainty'):
+        if hasattr(image, "uncertainty"):
             uncertainty = image.uncertainty
         else:
             uncertainty = VarianceUncertainty(np.ones(img.shape))
 
-        unit = getattr(image, 'unit', u.Unit('DN'))
+        unit = getattr(image, "unit", u.Unit("DN"))
 
-        spectral_axis = getattr(image, 'spectral_axis',
-                                np.arange(img.shape[disp_axis]) * u.pix)
+        spectral_axis = getattr(image, "spectral_axis", np.arange(img.shape[disp_axis]) * u.pix)
 
-        img = Spectrum1D(img * unit, spectral_axis=spectral_axis,
-                         uncertainty=uncertainty, mask=mask)
+        img = Spectrum1D(
+            img * unit, spectral_axis=spectral_axis, uncertainty=uncertainty, mask=mask
+        )
         return img
 
     @staticmethod
-    def _mask_and_nonfinite_data_handling(image, mask,
-                                          mask_treatment: str = 'filter',
-                                          crossdisp_axis: int = 0) -> tuple[np.ndarray, np.ndarray]:
+    def _mask_and_nonfinite_data_handling(
+        image: ImageLike,
+        mask: ImageLike | None = None,
+        mask_treatment: str = "apply"
+    ) -> tuple[np.ndarray, np.ndarray]:
         """
-        Handle the treatment of masked and nonfinite data.
+        Handle the treatment of masked and non-finite data.
 
         All operations in Specreduce can take in a mask for the data as
-        part of the input NDData. Additionally, any non-finite values in the
-        data that aren't in the user-supplied mask will be combined bitwise
-        with the input mask.
+        part of the input NDData.
 
-        There are three options currently implemented for the treatment
-        of masked and nonfinite data - filter, omit, and zero-fill.
-        Depending on the step, all or a subset of these three options are valid.
+        There are five options currently implemented for the treatment
+        of masked and non-finite data - apply, ignore, zero-fill, nan-fill,
+        apply_mask_only, and apply_nan_only. Depending on the routine,
+        all or a subset of these three options are valid.
 
         Parameters
         ----------
         image : array-like
-            The input image data array that may contain nonfinite values.
+            The input image data array that may contain non-finite values.
         mask : array-like of bool or None
-            An optional Boolean mask array. Nonfinite values in the image will be added
+            An optional Boolean mask array. Non-finite values in the image will be added
             to this mask.
-        mask_treatment : str
-            Specifies how to handle masked data:
-            - 'filter' (default): Returns the unmodified input image and combined mask.
-            - 'zero-fill': Sets masked values in the image to zero.
-            - 'omit': Masks entire columns or rows if any value is masked.
-        crossdisp_axis : int
-            Axis along which to collapse the 2D mask into a 1D mask for treatment 'omit'.
+        mask_treatment
+            Specifies how to handle masked or non-finite values in the input image.
         """
         if mask_treatment not in _ImageParser.implemented_mask_treatment_methods:
-            raise ValueError("`mask_treatment` must be one of "
-                             f"{_ImageParser.implemented_mask_treatment_methods}")
+            raise ValueError(
+                "`mask_treatment` must be one of "
+                f"{_ImageParser.implemented_mask_treatment_methods}"
+            )
 
-        # make sure there is always a 'mask', even when all data is unmasked and finite.
-        if mask is not None:
-            # always mask any previously uncaught nonfinite values in image array
-            # combining these with the (optional) user-provided mask on `image.mask`
-            mask = np.logical_or(mask, ~np.isfinite(image))
-        else:
-            mask = ~np.isfinite(image)
+        match mask_treatment:
+            case "apply":
+                mask = mask | (~np.isfinite(image)) if mask is not None else ~np.isfinite(image)
+            case "ignore":
+                mask = np.zeros(image.shape, dtype=bool)
+            case "zero-fill" | "nan-fill":
+                mask = mask | (~np.isfinite(image)) if mask is not None else ~np.isfinite(image)
+                image = deepcopy(image)
+                if mask_treatment == "zero-fill":
+                    image[mask] = 0.0
+                else:
+                    image[mask] = np.nan
+                mask[:] = False
+            case "apply_nan_only":
+                mask = ~np.isfinite(image)
+            case "apply_mask_only":
+                mask = mask if mask is not None else np.zeros(image.shape, dtype=bool)
 
-        # if mask option is the default 'filter' option,
-        # nothing needs to be done. input mask (combined with nonfinite data)
-        # remains with data as-is.
-
-        if mask_treatment == 'zero-fill':
-            # make a copy of the input image since we will be modifying it
-            image = deepcopy(image)
-
-            # if mask_treatment is 'zero_fill', set masked values to zero in
-            # image data and drop image.mask. note that this is done after
-            # _combine_mask_with_nonfinite_from_data, so non-finite values in
-            # data (which are now in the mask) will also be set to zero.
-            # set masked values to zero
-            image[mask] = 0.
-
-            # masked array with no masked values, so accessing image.mask works
-            # but we don't need the actual mask anymore since data has been set to 0
-            mask = np.zeros(image.shape, dtype=bool)
-
-        elif mask_treatment == 'omit':
-            # collapse 2d mask (after accounting for addl non-finite values in
-            # data) to a 1d mask, along dispersion axis, to fully mask columns
-            # that have any masked values.
-
-            # create a 1d mask along crossdisp axis - if any column has a single nan,
-            # the entire column should be masked
-            reduced_mask = np.logical_or.reduce(mask, axis=crossdisp_axis)
-
-            # back to a 2D mask
-            shape = (image.shape[0], 1) if crossdisp_axis == 0 else (1, image.shape[1])
-            mask = np.tile(reduced_mask, shape)
-
-        # check for case where entire image is masked.
         if mask.all():
-            raise ValueError('Image is fully masked. Check for invalid values.')
+            raise ValueError("Image is fully masked. Check for invalid values.")
 
         return image, mask
 
@@ -233,9 +216,9 @@ class SpecreduceOperation(_ImageParser):
     the operation, which then *return* the data objects resulting from the
     operation.
     """
+
     def __call__(self):
-        raise NotImplementedError('__call__ on a SpecreduceOperation needs to '
-                                  'be overridden')
+        raise NotImplementedError("__call__ on a SpecreduceOperation needs to " "be overridden")
 
     @classmethod
     def as_function(cls, *args, **kwargs):
@@ -247,9 +230,11 @@ class SpecreduceOperation(_ImageParser):
         """
         argspec = inspect.getargs(SpecreduceOperation.__call__.__code__)
         if argspec.varargs:
-            raise NotImplementedError('There is not a way to determine the '
-                                      'number of inputs of a *args style '
-                                      'operation')
+            raise NotImplementedError(
+                "There is not a way to determine the "
+                "number of inputs of a *args style "
+                "operation"
+            )
         ninputs = len(argspec.args) - 1
 
         callargs = args[:ninputs]

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -249,7 +249,11 @@ class BoxcarExtract(SpecreduceOperation):
         if self.mask_treatment == "apply":
             image_cleaned = np.where(~self.image.mask, self.image.data * window_weights, 0.0)
             weights = np.where(~self.image.mask, window_weights, 0.0)
-            spectrum = image_cleaned.sum(axis=cdisp_axis) / weights.sum(axis=cdisp_axis) * window_weights.sum(axis=cdisp_axis)
+            spectrum = (
+                image_cleaned.sum(axis=cdisp_axis)
+                / weights.sum(axis=cdisp_axis)
+                * window_weights.sum(axis=cdisp_axis)
+            )
         else:
             image_windowed = np.where(window_weights, self.image.data * window_weights, 0.0)
             spectrum = np.sum(image_windowed, axis=cdisp_axis)

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -654,7 +654,7 @@ class HorneExtract(SpecreduceOperation):
         profile_choices = ("gaussian", "interpolated_profile")
 
         if not isinstance(profile, (str, dict)):
-            raise ValueError("``spatial_profile`` must either be string or dictionary.")
+            raise ValueError("spatial_profile must be a string or dictionary.")
         if isinstance(profile, str):
             profile = dict(name=profile)
 
@@ -664,8 +664,6 @@ class HorneExtract(SpecreduceOperation):
 
         n_bins_interpolated_profile = profile.get("n_bins_interpolated_profile", 10)
         interp_degree_interpolated_profile = profile.get("interp_degree_interpolated_profile", 1)
-        if profile_type == "interpolated_profile":
-            bkgrd_prof = None
 
         self.image = self._parse_image(image, variance, mask, unit, disp_axis)
         variance = self.image.uncertainty.represent_as(VarianceUncertainty).array

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -2,7 +2,6 @@
 
 import warnings
 from dataclasses import dataclass, field
-from typing import Literal
 
 import numpy as np
 from astropy import units as u
@@ -13,10 +12,10 @@ from scipy.integrate import trapezoid
 from scipy.interpolate import RectBivariateSpline
 from specutils import Spectrum1D
 
-from specreduce.core import SpecreduceOperation
+from specreduce.core import SpecreduceOperation, ImageLike, MaskingOption
 from specreduce.tracing import Trace, FlatTrace
 
-__all__ = ['BoxcarExtract', 'HorneExtract', 'OptimalExtract']
+__all__ = ["BoxcarExtract", "HorneExtract", "OptimalExtract"]
 
 
 def _get_boxcar_weights(center, hwidth, npix):
@@ -52,12 +51,12 @@ def _get_boxcar_weights(center, hwidth, npix):
         # (negative widths should be avoided by earlier logic!)
         return weights
 
-    if center-hwidth > npix-0.5 or center+hwidth < -0.5:
+    if center - hwidth > npix - 0.5 or center + hwidth < -0.5:
         # entire window is out-of-bounds
         return weights
 
-    lower_edge = max(-0.5, center-hwidth)  # where -0.5 is lower bound of the image
-    upper_edge = min(center+hwidth, npix-0.5)  # where npix-0.5 is upper bound of the image
+    lower_edge = max(-0.5, center - hwidth)  # where -0.5 is lower bound of the image
+    upper_edge = min(center + hwidth, npix - 0.5)  # where npix-0.5 is upper bound of the image
 
     # let's avoid recomputing the round repeatedly
     int_round_lower_edge = int(round(lower_edge))
@@ -68,21 +67,24 @@ def _get_boxcar_weights(center, hwidth, npix):
     # the upper bound doesn't have the +1 because array slicing is inclusive on the lower index and
     # exclusive on the upper-index
     # NOTE: round(-0.5) == 0, which is helpful here for the case where lower_edge == -0.5
-    weights[int_round_lower_edge+1:int_round_upper_edge] = 1
+    weights[int_round_lower_edge + 1 : int_round_upper_edge] = 1
 
     # handle edge pixels (for cases where an edge pixel is fully-weighted, this will set it again,
     # but should still compute a weight of 1.  By using N:N+1, we avoid index errors if the edge
     # is outside the image bounds.  But we do need to avoid negative indices which would count
     # from the end of the array.
     if int_round_lower_edge >= 0:
-        weights[int_round_lower_edge:int_round_lower_edge+1] = round(lower_edge) + 0.5 - lower_edge
-    weights[int_round_upper_edge:int_round_upper_edge+1] = upper_edge - (round(upper_edge) - 0.5)
+        weights[int_round_lower_edge : int_round_lower_edge + 1] = (
+            round(lower_edge) + 0.5 - lower_edge
+        )
+    weights[int_round_upper_edge : int_round_upper_edge + 1] = upper_edge - (
+        round(upper_edge) - 0.5
+    )
 
     return weights
 
 
 def _ap_weight_image(trace, width, disp_axis, crossdisp_axis, image_shape):
-
     """
     Create a weight image that defines the desired extraction aperture.
 
@@ -149,41 +151,47 @@ class BoxcarExtract(SpecreduceOperation):
     crossdisp_axis
         cross-dispersion axis
     mask_treatment
-        The method for handling masked or non-finite data. Choice of ``filter``,
-        ``omit``, or ``exclude``. If ``filter`` is chosen, the mask is ignored
-        and the non-finite data will passed to the extraction as is. If ``omit``
-        is chosen, columns along disp_axis with any masked or non-finite data
-        values will be fully masked (i.e, 2D mask is collapsed to 1D and applied).
-        If ``exclude`` is chosen, masked and non-finite data will be excluded
-        from the extraction and the spectrum extraction is carried out as a
-        weighted sum. For all three options, the input mask (optional on input
-        NDData object) will be combined with a mask generated from any non-finite
-        values in the image data.
+        Specifies how to handle masked or non-finite values in the input image.
+        The accepted values are:
+          - ``apply``: The image is left unmodified and any existing mask is combined
+            with a mask derived from non-finite values.
+          - ``zero-fill``: Pixels that are either masked or non-finite are replaced with 0.0,
+            and the mask is dropped.
+          - ``nan-fill``:  Pixels that are either masked or non-finite are replaced with nan,
+            and the mask is dropped.
+          - ``ignore``: The image is left unmodified and any existing mask is dropped.
+          - ``apply_mask_only``: The  image and mask are left unmodified.
+          - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a
+            new mask is created based on non-finite values.
+
 
     Returns
     -------
     spec : `~specutils.Spectrum1D`
         The extracted 1d spectrum expressed in DN and pixel units
     """
-    image: NDData | np.ndarray
+
+    image: ImageLike
     trace_object: Trace
     width: float = 5
     disp_axis: int = 1
     crossdisp_axis: int = 0
     # TODO: should disp_axis and crossdisp_axis be defined in the Trace object?
-    # TODO: should the 'filter' option be changed to 'propagate'
-    mask_treatment: Literal['filter', 'omit', 'exclude'] = 'exclude'
-    _valid_mask_treatment_methods = ('filter', 'omit', 'exclude')
+    mask_treatment: MaskingOption = "apply"
+    _valid_mask_treatment_methods = ("apply", "ignore", "zero-fill", "nan-fill")
 
     @property
     def spectrum(self):
         return self.__call__()
 
-    def __call__(self, image: NDData | None = None,
-                 trace: Trace | None = None,
-                 width: float | None = None,
-                 disp_axis: int | None = None,
-                 crossdisp_axis: int | None = None) -> Spectrum1D:
+    def __call__(
+        self,
+        image: ImageLike | None = None,
+        trace: Trace | None = None,
+        width: float | None = None,
+        disp_axis: int | None = None,
+        crossdisp_axis: int | None = None,
+    ) -> Spectrum1D:
         """
         Extract the 1D spectrum using the boxcar method.
 
@@ -211,16 +219,13 @@ class BoxcarExtract(SpecreduceOperation):
         width = width or self.width
         disp_axis = disp_axis or self.disp_axis
         cdisp_axis = crossdisp_axis or self.crossdisp_axis
-        mask_mapping = {'filter': 'filter', 'exclude': 'filter', 'omit': 'omit'}
 
         if width <= 0:
             raise ValueError("The window width must be positive")
 
-        # Parse image, including masked/nonfinite data handling based on
-        # choice of `mask_treatment`, which for BoxcarExtract can be filter, omit, or
-        # exclude. non-finite data will be masked, always. Returns a Spectrum1D.
-        self.image = self._parse_image(image, disp_axis=disp_axis,
-                                       mask_treatment=mask_mapping[self.mask_treatment])
+        self.image = self._parse_image(
+            image, disp_axis=disp_axis, mask_treatment=self.mask_treatment
+        )
 
         # Spectrum extraction
         # ===================
@@ -231,12 +236,12 @@ class BoxcarExtract(SpecreduceOperation):
         # the window multiplied by the window width.
         window_weights = _ap_weight_image(trace, width, disp_axis, cdisp_axis, self.image.shape)
 
-        if self.mask_treatment == 'exclude':
-            image_cleaned = np.where(~self.image.mask, self.image.data*window_weights, 0.0)
+        if self.mask_treatment == "exclude":
+            image_cleaned = np.where(~self.image.mask, self.image.data * window_weights, 0.0)
             weights = np.where(~self.image.mask, window_weights, 0.0)
             spectrum = image_cleaned.sum(axis=cdisp_axis) / weights.sum(axis=cdisp_axis) * width
         else:
-            image_windowed = np.where(window_weights, self.image.data*window_weights, 0.0)
+            image_windowed = np.where(window_weights, self.image.data * window_weights, 0.0)
             spectrum = np.sum(image_windowed, axis=cdisp_axis)
 
         return Spectrum1D(spectrum * self.image.unit, spectral_axis=self.image.spectral_axis)
@@ -319,10 +324,11 @@ class HorneExtract(SpecreduceOperation):
         fluxes are interpreted in DN. [default: None]
 
     """
+
     image: NDData
     trace_object: Trace
     bkgrd_prof: Model = field(default=models.Polynomial1D(2))
-    spatial_profile: str | dict = 'gaussian'
+    spatial_profile: str | dict = "gaussian"
     variance: np.ndarray = field(default=None)
     mask: np.ndarray = field(default=None)
     unit: np.ndarray = field(default=None)
@@ -334,8 +340,7 @@ class HorneExtract(SpecreduceOperation):
     def spectrum(self):
         return self.__call__()
 
-    def _parse_image(self, image,
-                     variance=None, mask=None, unit=None, disp_axis=1):
+    def _parse_image(self, image, variance=None, mask=None, unit=None, disp_axis=1):
         """
         Convert all accepted image types to a consistently formatted
         Spectrum1D object.
@@ -383,7 +388,7 @@ class HorneExtract(SpecreduceOperation):
         # mask is set as None when not specified upon creating a Spectrum1D
         # object, so we must check whether it is absent *and* whether it's
         # present but set as None
-        if getattr(image, 'mask', None) is not None:
+        if getattr(image, "mask", None) is not None:
             mask = image.mask
         elif mask is not None:
             pass
@@ -392,37 +397,41 @@ class HorneExtract(SpecreduceOperation):
             mask = np.zeros_like(img)
 
         if img.shape != mask.shape:
-            raise ValueError('image and mask shapes must match.')
+            raise ValueError("image and mask shapes must match.")
 
         # Process uncertainties, converting to variances when able and throwing
         # an error when uncertainties are missing or less easily converted
-        if (hasattr(image, 'uncertainty')
-                and image.uncertainty is not None):
-            if image.uncertainty.uncertainty_type == 'var':
+        if hasattr(image, "uncertainty") and image.uncertainty is not None:
+            if image.uncertainty.uncertainty_type == "var":
                 variance = image.uncertainty.array
-            elif image.uncertainty.uncertainty_type == 'std':
-                warnings.warn("image NDData object's uncertainty "
-                              "interpreted as standard deviation. if "
-                              "incorrect, use VarianceUncertainty when "
-                              "assigning image object's uncertainty.")
+            elif image.uncertainty.uncertainty_type == "std":
+                warnings.warn(
+                    "image NDData object's uncertainty "
+                    "interpreted as standard deviation. if "
+                    "incorrect, use VarianceUncertainty when "
+                    "assigning image object's uncertainty."
+                )
                 variance = image.uncertainty.array**2
-            elif image.uncertainty.uncertainty_type == 'ivar':
+            elif image.uncertainty.uncertainty_type == "ivar":
                 variance = 1 / image.uncertainty.array
             else:
                 # other options are InverseUncertainty and UnknownUncertainty
-                raise ValueError("image NDData object has unexpected "
-                                 "uncertainty type. instead, try "
-                                 "VarianceUncertainty or StdDevUncertainty.")
-        elif (hasattr(image, 'uncertainty')
-              and image.uncertainty is None):
+                raise ValueError(
+                    "image NDData object has unexpected "
+                    "uncertainty type. instead, try "
+                    "VarianceUncertainty or StdDevUncertainty."
+                )
+        elif hasattr(image, "uncertainty") and image.uncertainty is None:
             # ignore variance arg to focus on updating NDData object
-            raise ValueError('image NDData object lacks uncertainty')
+            raise ValueError("image NDData object lacks uncertainty")
         else:
             if variance is None:
-                raise ValueError("if image is a numpy or Quantity array, a "
-                                 "variance must be specified. consider "
-                                 "wrapping it into one object by instead "
-                                 "passing an NDData image.")
+                raise ValueError(
+                    "if image is a numpy or Quantity array, a "
+                    "variance must be specified. consider "
+                    "wrapping it into one object by instead "
+                    "passing an NDData image."
+                )
             elif image.shape != variance.shape:
                 raise ValueError("image and variance shapes must match")
 
@@ -440,17 +449,15 @@ class HorneExtract(SpecreduceOperation):
 
         variance = VarianceUncertainty(variance)
 
-        unit = getattr(image, 'unit',
-                       u.Unit(unit) if unit is not None else u.Unit('DN'))
+        unit = getattr(image, "unit", u.Unit(unit) if unit is not None else u.Unit("DN"))
 
-        spectral_axis = getattr(image, 'spectral_axis',
-                                np.arange(img.shape[disp_axis]) * u.pix)
+        spectral_axis = getattr(image, "spectral_axis", np.arange(img.shape[disp_axis]) * u.pix)
 
-        return Spectrum1D(img * unit, spectral_axis=spectral_axis,
-                          uncertainty=variance, mask=mask)
+        return Spectrum1D(img * unit, spectral_axis=spectral_axis, uncertainty=variance, mask=mask)
 
-    def _fit_gaussian_spatial_profile(self, img: ndarray, disp_axis: int, crossdisp_axis: int,
-                                      or_mask: ndarray, bkgrd_prof: Model):
+    def _fit_gaussian_spatial_profile(
+        self, img: ndarray, disp_axis: int, crossdisp_axis: int, or_mask: ndarray, bkgrd_prof: Model
+    ):
         """Fit a 1D Gaussian spatial profile to spectrum in `img`.
 
         Fits an 1D Gaussian profile to spectrum in `img`. Takes the weighted mean
@@ -467,8 +474,7 @@ class HorneExtract(SpecreduceOperation):
 
         # use the sum of brightest row as an inital guess for Gaussian amplitude,
         # the the location of the brightest row as an initial guess for the mean
-        gauss_prof = models.Gaussian1D(amplitude=coadd.max(),
-                                       mean=coadd.argmax(), stddev=2)
+        gauss_prof = models.Gaussian1D(amplitude=coadd.max(), mean=coadd.argmax(), stddev=2)
 
         # Fit extraction kernel (Gaussian + background model) to coadded rows
         # with combined model (must exclude masked indices manually;
@@ -477,18 +483,24 @@ class HorneExtract(SpecreduceOperation):
             ext_prof = gauss_prof + bkgrd_prof
         else:
             # add a trivial constant model so attribute names are the same
-            ext_prof = gauss_prof + models.Const1D(0, fixed={'amplitude': True})
+            ext_prof = gauss_prof + models.Const1D(0, fixed={"amplitude": True})
 
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
+            warnings.simplefilter("ignore")
             fitter = fitting.LMLSQFitter()
             fit_ext_kernel = fitter(ext_prof, xd_pixels[~coadd.mask], coadd.compressed())
         return fit_ext_kernel
 
-    def _fit_spatial_profile(self, img: ndarray, disp_axis: int, crossdisp_axis: int,
-                             mask: ndarray, n_bins: int,
-                             kx: int, ky: int) -> RectBivariateSpline:
-
+    def _fit_spatial_profile(
+        self,
+        img: ndarray,
+        disp_axis: int,
+        crossdisp_axis: int,
+        mask: ndarray,
+        n_bins: int,
+        kx: int,
+        ky: int,
+    ) -> RectBivariateSpline:
         """
         Fit a spatial profile by sampling the median profile along the dispersion direction.
 
@@ -528,21 +540,30 @@ class HorneExtract(SpecreduceOperation):
         samples = np.zeros((n_bins, nrows))
 
         sample_locs = np.linspace(0, ncols - 1, n_bins + 1, dtype=int)
-        bin_centers = [(sample_locs[i]+sample_locs[i+1]) // 2 for i in
-                       range(len(sample_locs) - 1)]
+        bin_centers = [
+            (sample_locs[i] + sample_locs[i + 1]) // 2 for i in range(len(sample_locs) - 1)
+        ]
 
         for i in range(n_bins):
-            bin_median = np.nanmedian(img[:, sample_locs[i]:sample_locs[i+1]], axis=disp_axis)
+            bin_median = np.nanmedian(img[:, sample_locs[i] : sample_locs[i + 1]], axis=disp_axis)
             samples[i, :] = bin_median / bin_median.sum()
 
         return RectBivariateSpline(x=bin_centers, y=np.arange(nrows), z=samples, kx=kx, ky=ky)
 
-    def __call__(self, image=None, trace_object=None,
-                 disp_axis=None, crossdisp_axis=None,
-                 bkgrd_prof=None, spatial_profile=None,
-                 n_bins_interpolated_profile=None,
-                 interp_degree_interpolated_profile=None,
-                 variance=None, mask=None, unit=None):
+    def __call__(
+        self,
+        image=None,
+        trace_object=None,
+        disp_axis=None,
+        crossdisp_axis=None,
+        bkgrd_prof=None,
+        spatial_profile=None,
+        n_bins_interpolated_profile=None,
+        interp_degree_interpolated_profile=None,
+        variance=None,
+        mask=None,
+        unit=None,
+    ):
         """
         Run the Horne calculation on a region of an image and extract a 1D spectrum.
 
@@ -611,25 +632,25 @@ class HorneExtract(SpecreduceOperation):
         disp_axis = disp_axis if disp_axis is not None else self.disp_axis
         crossdisp_axis = crossdisp_axis if crossdisp_axis is not None else self.crossdisp_axis
         bkgrd_prof = bkgrd_prof if bkgrd_prof is not None else self.bkgrd_prof
-        profile = (spatial_profile if spatial_profile is not None else self.spatial_profile)
+        profile = spatial_profile if spatial_profile is not None else self.spatial_profile
         variance = variance if variance is not None else self.variance
         mask = mask if mask is not None else self.mask
         unit = unit if unit is not None else self.unit
 
-        profile_choices = ('gaussian', 'interpolated_profile')
+        profile_choices = ("gaussian", "interpolated_profile")
 
         if not isinstance(profile, (str, dict)):
-            raise ValueError('``spatial_profile`` must either be string or dictionary.')
+            raise ValueError("``spatial_profile`` must either be string or dictionary.")
         if isinstance(profile, str):
             profile = dict(name=profile)
 
-        profile_type = profile['name'].lower()
+        profile_type = profile["name"].lower()
         if profile_type not in profile_choices:
             raise ValueError("spatial_profile must be one of" f"{', '.join(profile_choices)}")
 
-        n_bins_interpolated_profile = profile.get('n_bins_interpolated_profile', 10)
-        interp_degree_interpolated_profile = profile.get('interp_degree_interpolated_profile', 1)
-        if profile_type == 'interpolated_profile':
+        n_bins_interpolated_profile = profile.get("n_bins_interpolated_profile", 10)
+        interp_degree_interpolated_profile = profile.get("interp_degree_interpolated_profile", 1)
+        if profile_type == "interpolated_profile":
             bkgrd_prof = None
 
         self.image = self._parse_image(image, variance, mask, unit, disp_axis)
@@ -645,29 +666,27 @@ class HorneExtract(SpecreduceOperation):
         # so the image is aligned along the trace:
         if not isinstance(trace_object, FlatTrace):
             img = _align_along_trace(
-                img,
-                trace_object.trace,
-                disp_axis=disp_axis,
-                crossdisp_axis=crossdisp_axis)
+                img, trace_object.trace, disp_axis=disp_axis, crossdisp_axis=crossdisp_axis
+            )
 
-        if profile_type == 'gaussian':
-            fit_ext_kernel = self._fit_gaussian_spatial_profile(img,
-                                                                disp_axis,
-                                                                crossdisp_axis,
-                                                                mask,
-                                                                bkgrd_prof)
+        if profile_type == "gaussian":
+            fit_ext_kernel = self._fit_gaussian_spatial_profile(
+                img, disp_axis, crossdisp_axis, mask, bkgrd_prof
+            )
             if isinstance(trace_object, FlatTrace):
                 mean_cross_pix = trace_object.trace
             else:
-                mean_cross_pix = np.broadcast_to(ncross//2, ndisp)
+                mean_cross_pix = np.broadcast_to(ncross // 2, ndisp)
         else:  # interpolated_profile
             # for now, bkgrd_prof must be None because a compound model can't
             # be created with a interpolator + model. i think there is a way
             # around this, but will follow up later
             if bkgrd_prof is not None:
-                raise ValueError('When `spatial_profile`is `interpolated_profile`,'
-                                 '`bkgrd_prof` must be None. Background should'
-                                 ' be fit and subtracted from `img` beforehand.')
+                raise ValueError(
+                    "When `spatial_profile`is `interpolated_profile`,"
+                    "`bkgrd_prof` must be None. Background should"
+                    " be fit and subtracted from `img` beforehand."
+                )
 
             # determine interpolation degree from input and make tuple if int
             # this can also be moved to another method to parse the input
@@ -676,18 +695,20 @@ class HorneExtract(SpecreduceOperation):
                 kx = ky = interp_degree_interpolated_profile
             else:  # if input is tuple of ints
                 if not isinstance(interp_degree_interpolated_profile, tuple):
-                    raise ValueError("``interp_degree_interpolated_profile`` must be ",
-                                     "an integer or tuple of integers.")
+                    raise ValueError(
+                        "``interp_degree_interpolated_profile`` must be ",
+                        "an integer or tuple of integers.",
+                    )
                 if not all(isinstance(x, int) for x in interp_degree_interpolated_profile):
-                    raise ValueError("``interp_degree_interpolated_profile`` must be ",
-                                     "an integer or tuple of integers.")
+                    raise ValueError(
+                        "``interp_degree_interpolated_profile`` must be ",
+                        "an integer or tuple of integers.",
+                    )
                 kx, ky = interp_degree_interpolated_profile
 
-            interp_spatial_prof = self._fit_spatial_profile(img, disp_axis,
-                                                            crossdisp_axis,
-                                                            mask,
-                                                            n_bins_interpolated_profile,
-                                                            kx, ky)
+            interp_spatial_prof = self._fit_spatial_profile(
+                img, disp_axis, crossdisp_axis, mask, n_bins_interpolated_profile, kx, ky
+            )
 
             # add private attribute to save fit profile. should this be public?
             self._interp_spatial_prof = interp_spatial_prof
@@ -697,13 +718,13 @@ class HorneExtract(SpecreduceOperation):
         norms = np.full(ndisp, np.nan)
         valid = ~mask
 
-        if profile_type == 'gaussian':
-            norms[:] = fit_ext_kernel.amplitude_0 * fit_ext_kernel.stddev_0 * np.sqrt(2*np.pi)
+        if profile_type == "gaussian":
+            norms[:] = fit_ext_kernel.amplitude_0 * fit_ext_kernel.stddev_0 * np.sqrt(2 * np.pi)
 
         for idisp in range(ndisp):
             if not np.any(valid[:, idisp]):
                 continue
-            if profile_type == 'gaussian':
+            if profile_type == "gaussian":
                 fit_ext_kernel.mean_0 = mean_cross_pix[idisp]
                 fitted_col = fit_ext_kernel(xd_pixels)
                 kernel_vals[:, idisp] = fitted_col
@@ -712,7 +733,7 @@ class HorneExtract(SpecreduceOperation):
                 kernel_vals[:, idisp] = fitted_col
                 norms[idisp] = trapezoid(fitted_col, dx=1)[0]
 
-        with np.errstate(divide='ignore', invalid='ignore'):
+        with np.errstate(divide="ignore", invalid="ignore"):
             num = np.sum(np.where(valid, img * kernel_vals / variance, 0.0), axis=crossdisp_axis)
             den = np.sum(np.where(valid, kernel_vals**2 / variance, 0.0), axis=crossdisp_axis)
             extraction = (num / den) * norms
@@ -753,5 +774,6 @@ class OptimalExtract(HorneExtract):
     """
     An alias for `HorneExtract`.
     """
+
     __doc__ += HorneExtract.__doc__
     pass

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -159,9 +159,9 @@ class BoxcarExtract(SpecreduceOperation):
         - ``ignore``: The image remains unchanged, and any existing mask is dropped.
         - ``propagate``: The image remains unchanged, and any masked or non-finite pixel\
             causes the mask to extend across the entire cross-dispersion axis.
-        - ``zero-fill``: Pixels that are either masked or non-finite are replaced with 0.0,\
+        - ``zero_fill``: Pixels that are either masked or non-finite are replaced with 0.0,\
             and the mask is dropped.
-        - ``nan-fill``:  Pixels that are either masked or non-finite are replaced with nan,\
+        - ``nan_fill``:  Pixels that are either masked or non-finite are replaced with nan,\
             and the mask is dropped.
         - ``apply_mask_only``: The  image and mask are left unmodified.
         - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a\
@@ -184,8 +184,8 @@ class BoxcarExtract(SpecreduceOperation):
         "apply",
         "ignore",
         "propagate",
-        "zero-fill",
-        "nan-fill",
+        "zero_fill",
+        "nan_fill",
         "apply_mask_only",
         "apply_nan_only",
     )

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -155,15 +155,16 @@ class BoxcarExtract(SpecreduceOperation):
         The accepted values are:
           - ``apply``: The image is left unmodified and any existing mask is combined
             with a mask derived from non-finite values.
+          - ``ignore``: The image is left unmodified and any existing mask is dropped.
+          - ``propagate``: The image remains unchanged, and any masked or non-finite pixel
+                causes the mask to extend across the entire cross-dispersion axis.
           - ``zero-fill``: Pixels that are either masked or non-finite are replaced with 0.0,
             and the mask is dropped.
           - ``nan-fill``:  Pixels that are either masked or non-finite are replaced with nan,
             and the mask is dropped.
-          - ``ignore``: The image is left unmodified and any existing mask is dropped.
           - ``apply_mask_only``: The  image and mask are left unmodified.
           - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a
             new mask is created based on non-finite values.
-
 
     Returns
     -------
@@ -178,7 +179,7 @@ class BoxcarExtract(SpecreduceOperation):
     crossdisp_axis: int = 0
     # TODO: should disp_axis and crossdisp_axis be defined in the Trace object?
     mask_treatment: MaskingOption = "apply"
-    _valid_mask_treatment_methods = ("apply", "ignore", "zero-fill", "nan-fill")
+    _valid_mask_treatment_methods = ("apply", "ignore", "propagate", "zero-fill", "nan-fill")
 
     @property
     def spectrum(self):

--- a/specreduce/tests/test_background.py
+++ b/specreduce/tests/test_background.py
@@ -82,15 +82,18 @@ def test_background(
         assert np.isnan(bg.bkg_spectrum().flux).sum() == 0
         assert np.isnan(bg.sub_spectrum().flux).sum() == 0
 
-    bkg_spec_avg = bg1.bkg_spectrum(bkg_statistic='average')
+    bkg_spec_avg = bg1.bkg_spectrum(bkg_statistic="average")
     assert_allclose(bkg_spec_avg.mean().value, 14.5, rtol=0.5)
 
-    bkg_spec_median = bg1.bkg_spectrum(bkg_statistic='median')
+    bkg_spec_median = bg1.bkg_spectrum(bkg_statistic="median")
     assert_allclose(bkg_spec_median.mean().value, 14.5, rtol=0.5)
 
-    with pytest.raises(ValueError, match="Background statistic max is not supported. "
-                                         "Please choose from: average, median, or sum."):
-        bg1.bkg_spectrum(bkg_statistic='max')
+    with pytest.raises(
+        ValueError,
+        match="Background statistic max is not supported. "
+        "Please choose from: average, median, or sum.",
+    ):
+        bg1.bkg_spectrum(bkg_statistic="max")
 
 
 def test_warnings_errors(mk_test_spec_no_spectral_axis):

--- a/specreduce/tests/test_background.py
+++ b/specreduce/tests/test_background.py
@@ -181,7 +181,7 @@ class TestMasksBackground:
 
         return img * u.DN
 
-    @pytest.mark.parametrize("mask", ["apply", "propagate", "zero-fill"])
+    @pytest.mark.parametrize("mask", ["apply", "propagate", "zero_fill"])
     def test_fully_masked_column(self, mask):
         """
         Test background with some fully-masked columns (not fully masked image).
@@ -229,7 +229,7 @@ class TestMasksBackground:
                 np.array([0.0, 2.0, 3.0, 0.0, 5.0, 6.0, 7.0, 0.0, 9.0, 10.0, 11.0, 12.0]),
             ),
             (
-                "zero-fill",
+                "zero_fill",
                 np.array(
                     [
                         0.58333333,
@@ -334,7 +334,7 @@ class TestMasksBackground:
 
         assert np.all(np.isfinite(subtracted_img_propagate.data) == np.isfinite(image.data))
 
-        # Calculate a background value using mask_treatment = 'zero-fill'. Data
+        # Calculate a background value using mask_treatment = 'zero_fill'. Data
         # values at masked locations are set to 0 in the image array, and the
         # background value calculated for that column will be subtracted
         # resulting in a negative value. The resulting background subtracted
@@ -342,7 +342,7 @@ class TestMasksBackground:
         # (all unmasked)
 
         background_zero_fill = Background(
-            image, mask_treatment="zero-fill", traces=FlatTrace(image, 6), width=2
+            image, mask_treatment="zero_fill", traces=FlatTrace(image, 6), width=2
         )
         subtracted_img_zero_fill = background_zero_fill.sub_image()
 

--- a/specreduce/tests/test_background.py
+++ b/specreduce/tests/test_background.py
@@ -9,8 +9,9 @@ from specreduce.background import Background
 from specreduce.tracing import FlatTrace, ArrayTrace
 
 
-def test_background(mk_test_img_raw, mk_test_spec_no_spectral_axis,
-                    mk_test_spec_with_spectral_axis):
+def test_background(
+    mk_test_img_raw, mk_test_spec_no_spectral_axis, mk_test_spec_with_spectral_axis
+):
     img = mk_test_img_raw
     image = mk_test_spec_no_spectral_axis
     image_um = mk_test_spec_with_spectral_axis
@@ -72,7 +73,7 @@ def test_background(mk_test_img_raw, mk_test_spec_no_spectral_axis,
     # the final 1D spectra.
     img[0, 0] = np.nan  # out of window
     img[trace_pos, 0] = np.nan  # in window
-    stats = ['average', 'median']
+    stats = ["average", "median"]
 
     for st in stats:
         bg = Background(img, trace - bkg_sep, width=bkg_width, statistic=st)
@@ -114,8 +115,10 @@ def test_warnings_errors(mk_test_spec_no_spectral_axis):
 
     trace = ArrayTrace(image, trace=np.arange(10) + 20)  # from 20 to 29
     with pytest.warns(match="background window extends beyond image boundaries"):
-        with pytest.raises(ValueError,
-                           match="background window does not remain in bounds across entire dispersion axis"):  # noqa
+        with pytest.raises(
+            ValueError,
+            match="background window does not remain in bounds across entire dispersion axis",
+        ):  # noqa
             # 20 + 10 - 3 = 27 (lower edge of window on-image at right side of trace)
             # 29 + 10 - 3 = 36 (lower edge of window off-image at right side of trace)
             Background.one_sided(image, trace, 10, width=3)
@@ -136,27 +139,28 @@ def test_trace_inputs(mk_test_img_raw):
     # When `Background` object is created with no Trace object passed in it should
     # create a FlatTrace in the middle of the image (according to disp. axis)
     background = Background(image, width=5)
-    assert np.all(background.traces[0].trace.data == image.shape[1] / 2.)
+    assert np.all(background.traces[0].trace.data == image.shape[1] / 2.0)
 
     # FlatTrace(s) should be created if number or list of numbers is passed in for `traces`
-    background = Background(image, 10., width=5)
+    background = Background(image, 10.0, width=5)
     assert isinstance(background.traces[0], FlatTrace)
-    assert background.traces[0].trace_pos == 10.
+    assert background.traces[0].trace_pos == 10.0
 
-    traces = [10., 15]
+    traces = [10.0, 15]
     background = Background(image, traces, width=5)
     for i, trace_pos in enumerate(traces):
         assert background.traces[i].trace_pos == trace_pos
 
     # make sure error is raised if input for `traces` is invalid
-    match_str = 'objects, a number or list of numbers to define FlatTraces, ' +\
-                'or None to use a FlatTrace in the middle of the image.'
+    match_str = (
+        "objects, a number or list of numbers to define FlatTraces, "
+        + "or None to use a FlatTrace in the middle of the image."
+    )
     with pytest.raises(ValueError, match=match_str):
-        Background(image, 'non_valid_trace_pos')
+        Background(image, "non_valid_trace_pos")
 
 
-class TestMasksBackground():
-
+class TestMasksBackground:
     """
     Various test functions to test how masked and non-finite data is handled
     in `Background.
@@ -169,7 +173,7 @@ class TestMasksBackground():
         u.DN.
         """
 
-        img = np.tile((np.arange(1., ncols + 1)), (nrows, 1))
+        img = np.tile((np.arange(1.0, ncols + 1)), (nrows, 1))
 
         if nan_slices:  # add nans in data
             for s in nan_slices:
@@ -198,33 +202,53 @@ class TestMasksBackground():
         is fully masked/NaN.
         """
 
-        with pytest.raises(ValueError, match='Image is fully masked.'):
+        with pytest.raises(ValueError, match="Image is fully masked."):
             # fully NaN image
             img = self.mk_img() * np.nan
             Background(img, traces=FlatTrace(self.mk_img(), 2), mask_treatment=mask)
 
-        with pytest.raises(ValueError, match='Image is fully masked.'):
+        with pytest.raises(ValueError, match="Image is fully masked."):
             # fully masked image (should be equivalent)
             img = NDData(np.ones((4, 5)), mask=np.ones((4, 5), dtype=bool))
             Background(img, traces=FlatTrace(self.mk_img(), 2), mask_treatment=mask)
 
         # Now test that an image that isn't fully masked, but is fully masked
         # within the window determined by `width`, produces the correct result.
-        msg = 'Image is fully masked within background window determined by `width`.'
+        msg = "Image is fully masked within background window determined by `width`."
         with pytest.raises(ValueError, match=msg):
             img = self.mk_img(nrows=12, ncols=12, nan_slices=[np.s_[3:10, :]])
             Background(img, traces=FlatTrace(img, 6), width=7)
 
     @pytest.mark.filterwarnings("ignore:background window extends beyond image boundaries")
-    @pytest.mark.parametrize("method,expected",
-                             [("apply", np.array([1., 2., 3., 4., 5., 6., 7.,
-                                                  8., 9., 10., 11., 12.])),
-                              ("propagate", np.array([0., 2., 3., 0., 5., 6.,
-                                                 7., 0., 9., 10., 11., 12.])),
-                              ("zero-fill", np.array([0.58333333, 2., 3.,
-                                                      2.33333333, 5., 6., 7.,
-                                                      7.33333333, 9., 10., 11.,
-                                                      12.]))])
+    @pytest.mark.parametrize(
+        "method,expected",
+        [
+            ("apply", np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0])),
+            (
+                "propagate",
+                np.array([0.0, 2.0, 3.0, 0.0, 5.0, 6.0, 7.0, 0.0, 9.0, 10.0, 11.0, 12.0]),
+            ),
+            (
+                "zero-fill",
+                np.array(
+                    [
+                        0.58333333,
+                        2.0,
+                        3.0,
+                        2.33333333,
+                        5.0,
+                        6.0,
+                        7.0,
+                        7.33333333,
+                        9.0,
+                        10.0,
+                        11.0,
+                        12.0,
+                    ]
+                ),
+            ),
+        ],
+    )
     def test_mask_treatment_bkg_img_spectrum(self, method, expected):
         """
         This test function tests `Background.bkg_image` and
@@ -238,9 +262,9 @@ class TestMasksBackground():
         img_size = 12  # square 12 x 12 image
 
         # make image, set some value to nan, which will be masked in the function
-        image1 = self.mk_img(nrows=img_size, ncols=img_size,
-                             nan_slices=[np.s_[5:10, 0], np.s_[7:12, 3],
-                                         np.s_[2, 7]])
+        image1 = self.mk_img(
+            nrows=img_size, ncols=img_size, nan_slices=[np.s_[5:10, 0], np.s_[7:12, 3], np.s_[2, 7]]
+        )
 
         # also make an image that doesn't have nonf data values, but has
         # masked values at the same locations, to make sure they give the same
@@ -257,15 +281,13 @@ class TestMasksBackground():
             # create 'Background' object with `mask_treatment` set
             # 'width' should be > size of image to use all pix (but warning will
             # be raised, which we ignore.)
-            background = Background(image, mask_treatment=method,
-                                    traces=trace, width=img_size + 1)
+            background = Background(image, mask_treatment=method, traces=trace, width=img_size + 1)
 
             # test background image matches 'expected'
             bk_img = background.bkg_image()
             # change this and following assertions to assert_quantity_allclose once
             # issue #213 is fixed
-            np.testing.assert_allclose(bk_img.flux.value,
-                                       np.tile(expected, (img_size, 1)))
+            np.testing.assert_allclose(bk_img.flux.value, np.tile(expected, (img_size, 1)))
 
             # test background spectrum matches 'expected' times the number of rows
             # in cross disp axis, since this is a sum and all values in a col are
@@ -281,17 +303,17 @@ class TestMasksBackground():
         """
 
         # make image, set some value to nan, which will be masked in the function
-        image = self.mk_img(nrows=12, ncols=12,
-                            nan_slices=[np.s_[5:10, 0], np.s_[7:12, 3],
-                                        np.s_[2, 7]])
+        image = self.mk_img(
+            nrows=12, ncols=12, nan_slices=[np.s_[5:10, 0], np.s_[7:12, 3], np.s_[2, 7]]
+        )
 
         # Calculate a background value using mask_treatment = 'apply'.
         # For 'apply', the flag applies to how masked values are handled during
         # calculation of background for each column, but nonfinite data will
         # remain in input data array
-        background_apply = Background(image, mask_treatment='apply',
-                                       traces=FlatTrace(image, 6),
-                                       width=2)
+        background_apply = Background(
+            image, mask_treatment="apply", traces=FlatTrace(image, 6), width=2
+        )
         subtracted_img_apply = background_apply.sub_image()
 
         assert np.all(np.isfinite(subtracted_img_apply.data) == np.isfinite(image.data))
@@ -305,9 +327,9 @@ class TestMasksBackground():
         # so there are still valid background subtracted data values in this
         # case, but the corresponding mask for that entire column will be masked.
 
-        background_propagate = Background(image, mask_treatment='propagate',
-                                     traces=FlatTrace(image, 6),
-                                     width=2)
+        background_propagate = Background(
+            image, mask_treatment="propagate", traces=FlatTrace(image, 6), width=2
+        )
         subtracted_img_propagate = background_propagate.sub_image()
 
         assert np.all(np.isfinite(subtracted_img_propagate.data) == np.isfinite(image.data))
@@ -319,9 +341,9 @@ class TestMasksBackground():
         # image should be fully finite and the mask should be zero everywhere
         # (all unmasked)
 
-        background_zero_fill = Background(image, mask_treatment='zero-fill',
-                                          traces=FlatTrace(image, 6),
-                                          width=2)
+        background_zero_fill = Background(
+            image, mask_treatment="zero-fill", traces=FlatTrace(image, 6), width=2
+        )
         subtracted_img_zero_fill = background_zero_fill.sub_image()
 
         assert np.all(np.isfinite(subtracted_img_zero_fill.data))

--- a/specreduce/tests/test_core.py
+++ b/specreduce/tests/test_core.py
@@ -1,0 +1,23 @@
+import pytest
+
+from specreduce.core import SpecreduceOperation
+
+def test_sro_call():
+    sro = SpecreduceOperation()
+    with pytest.raises(NotImplementedError):
+        meh = sro()
+
+def test_sro_as_function():
+
+    class TestSRO(SpecreduceOperation):
+        def __call__(self, x):
+            return x**2
+
+    assert TestSRO.as_function(6) == 36
+
+    class TestSRO(SpecreduceOperation):
+        def __call__(self, *nargs):
+            return 5
+
+    with pytest.raises(NotImplementedError, match="There is not a way"):
+        TestSRO.as_function(6) == 36

--- a/specreduce/tests/test_core.py
+++ b/specreduce/tests/test_core.py
@@ -2,10 +2,12 @@ import pytest
 
 from specreduce.core import SpecreduceOperation
 
+
 def test_sro_call():
     sro = SpecreduceOperation()
     with pytest.raises(NotImplementedError):
-        meh = sro()
+        sro()
+
 
 def test_sro_as_function():
 

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -246,6 +246,12 @@ def test_horne_bad_profile(mk_test_img):
     with pytest.raises(ValueError, match="spatial_profile must be one of"):
         extract.spectrum
 
+    extract = HorneExtract(
+        image.data, trace, spatial_profile=models.Polynomial1D(2), variance=np.ones(image.data.shape)
+    )
+    with pytest.raises(ValueError, match="spatial_profile must be a"):
+        extract.spectrum
+
 
 def test_horne_nonfinite_column(mk_test_img):
     image = mk_test_img
@@ -264,11 +270,8 @@ def test_horne_no_bkgrnd(mk_test_img):
     # Test HorneExtract when using bkgrd_prof=None
 
     image = mk_test_img
-
     trace = FlatTrace(image, 3.0)
     extract = HorneExtract(image.data, trace, bkgrd_prof=None, variance=np.ones(image.data.shape))
-
-    # This is just testing that it runs with no errors and returns something
     assert len(extract.spectrum.flux) == 10
 
 
@@ -301,6 +304,15 @@ def test_horne_interpolated_profile(mk_test_img):
     )
 
     assert_quantity_allclose(horne_extract_gauss.spectrum.flux, horne_extract_self.spectrum.flux)
+
+    with pytest.raises(ValueError, match="When"):
+        sp = HorneExtract(
+            image.data,
+            trace,
+            spatial_profile={"name": "interpolated_profile", "n_bins_interpolated_profile": 3},
+            bkgrd_prof=models.Polynomial1D(2),
+            variance=np.ones(image.data.shape),
+        ).spectrum
 
 
 def test_horne_interpolated_profile_norm(mk_test_img):

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -96,6 +96,7 @@ def test_boxcar_nonfinite_handling(mk_test_img):
     target[4] = np.inf
     np.testing.assert_equal(spectrum.flux.value, target)
 
+
 def test_boxcar_outside_image_condition(mk_test_img):
     #
     # Trace is such that extraction aperture lays partially outside the image

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -89,20 +89,12 @@ def test_boxcar_nonfinite_handling(mk_test_img):
     image.data[14, 4] = np.inf
 
     trace = FlatTrace(image, 15.0)
-    boxcar = BoxcarExtract(image, trace, width=6, mask_treatment='filter')
+    boxcar = BoxcarExtract(image, trace, width=6, mask_treatment='apply')
     spectrum = boxcar()
     target = np.full_like(spectrum.flux.value, 90.)
     target[2] = np.nan
     target[4] = np.inf
     np.testing.assert_equal(spectrum.flux.value, target)
-
-    trace = FlatTrace(image, 15.0)
-    boxcar = BoxcarExtract(image, trace, width=6, mask_treatment='exclude')
-    spectrum = boxcar()
-    target = np.full_like(spectrum.flux.value, 90.)
-    target[[2, 4]] = 91.2
-    np.testing.assert_allclose(spectrum.flux.value, target)
-
 
 def test_boxcar_outside_image_condition(mk_test_img):
     #
@@ -111,7 +103,7 @@ def test_boxcar_outside_image_condition(mk_test_img):
     image = mk_test_img
 
     trace = FlatTrace(image, 3.0)
-    boxcar = BoxcarExtract(image, trace, mask_treatment='filter')
+    boxcar = BoxcarExtract(image, trace, mask_treatment='apply')
 
     spectrum = boxcar(width=10.)
     assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 32.0))

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -7,17 +7,14 @@ from astropy.tests.helper import assert_quantity_allclose
 from specutils import Spectrum1D
 
 from specreduce.background import Background
-from specreduce.extract import (
-    BoxcarExtract, HorneExtract, OptimalExtract, _align_along_trace
-)
+from specreduce.extract import BoxcarExtract, HorneExtract, OptimalExtract, _align_along_trace
 from specreduce.tracing import FitTrace, FlatTrace, ArrayTrace
 
 
 def add_gaussian_source(image, amps=2, stddevs=2, means=None):
-
-    """ Modify `image.data` to add a horizontal spectrum across the image.
-        Each column can have a different amplitude, stddev or mean position
-        if these are arrays (otherwise, constant across image).
+    """Modify `image.data` to add a horizontal spectrum across the image.
+    Each column can have a different amplitude, stddev or mean position
+    if these are arrays (otherwise, constant across image).
     """
 
     nrows, ncols = image.shape
@@ -33,24 +30,20 @@ def add_gaussian_source(image, amps=2, stddevs=2, means=None):
         stddevs = np.ones(ncols) * stddevs
 
     for i, col in enumerate(range(ncols)):
-        mod = models.Gaussian1D(amplitude=amps[i], mean=means[i],
-                                stddev=stddevs[i])
+        mod = models.Gaussian1D(amplitude=amps[i], mean=means[i], stddev=stddevs[i])
         image.data[:, i] = mod(np.arange(nrows))
 
 
 def test_boxcar_extraction(mk_test_img):
-    #
-    # Try combinations of extraction center, and even/odd
-    # extraction aperture sizes.
-    #
 
+    # Try combinations of extraction center, and even/odd extraction aperture sizes.
     image = mk_test_img
 
     trace = FlatTrace(image, 15.0)
     boxcar = BoxcarExtract(image, trace)
 
     spectrum = boxcar.spectrum
-    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 75.))
+    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 75.0))
     assert spectrum.unit is not None and spectrum.unit == u.Jy
 
     trace.set_position(14.5)
@@ -64,11 +57,11 @@ def test_boxcar_extraction(mk_test_img):
     trace.set_position(15.0)
     boxcar.width = 6
     spectrum = boxcar()
-    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 90.))
+    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 90.0))
 
     trace.set_position(14.5)
     spectrum = boxcar(width=6)
-    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 87.))
+    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 87.0))
 
     trace.set_position(15.0)
     spectrum = boxcar(width=4.5)
@@ -89,42 +82,41 @@ def test_boxcar_nonfinite_handling(mk_test_img):
     image.data[14, 4] = np.inf
 
     trace = FlatTrace(image, 15.0)
-    spectrum = BoxcarExtract(image, trace, width=6, mask_treatment='ignore')()
-    target = np.full_like(spectrum.flux.value, 90.)
+    spectrum = BoxcarExtract(image, trace, width=6, mask_treatment="ignore")()
+    target = np.full_like(spectrum.flux.value, 90.0)
     target[2] = np.nan
     target[4] = np.inf
     np.testing.assert_equal(spectrum.flux.value, target)
 
-    spectrum = BoxcarExtract(image, trace, width=6, mask_treatment='apply')()
+    spectrum = BoxcarExtract(image, trace, width=6, mask_treatment="apply")()
     target[[2, 4]] = 91.2
     np.testing.assert_allclose(spectrum.flux.value, target, rtol=1e-8)
 
 
 def test_boxcar_outside_image_condition(mk_test_img):
-    #
+
     # Trace is such that extraction aperture lays partially outside the image
-    #
     image = mk_test_img
 
     trace = FlatTrace(image, 3.0)
-    boxcar = BoxcarExtract(image, trace, mask_treatment='apply')
-    spectrum = boxcar(width=10.)
+    boxcar = BoxcarExtract(image, trace, mask_treatment="apply")
+    spectrum = boxcar(width=10.0)
     assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 32.0))
 
-    boxcar = BoxcarExtract(image, trace, mask_treatment='ignore')
-    spectrum = boxcar(width=10.)
+    boxcar = BoxcarExtract(image, trace, mask_treatment="ignore")
+    spectrum = boxcar(width=10.0)
     assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 32.0))
 
 
 def test_boxcar_array_trace(mk_test_img):
     image = mk_test_img
 
-    trace_array = np.ones_like(image[1]) * 15.
+    trace_array = np.ones_like(image[1]) * 15.0
     trace = ArrayTrace(image, trace_array)
 
     boxcar = BoxcarExtract(image, trace)
     spectrum = boxcar()
-    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 75.))
+    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 75.0))
 
 
 def test_horne_image_validation(mk_test_img):
@@ -138,29 +130,29 @@ def test_horne_image_validation(mk_test_img):
     extract = OptimalExtract(image.data, trace)  # equivalent to HorneExtract
 
     # an array-type image must come with a variance argument
-    with pytest.raises(ValueError, match=r'.*variance must be specified.*'):
+    with pytest.raises(ValueError, match=r".*variance must be specified.*"):
         ext = extract()
 
     # an NDData-type image can't have an empty uncertainty attribute
-    with pytest.raises(ValueError, match=r'.*NDData object lacks uncertainty'):
+    with pytest.raises(ValueError, match=r".*NDData object lacks uncertainty"):
         ext = extract(image=image)
 
     # an NDData-type image's uncertainty must be of type VarianceUncertainty
     # or type StdDevUncertainty
-    with pytest.raises(ValueError, match=r'.*unexpected uncertainty type.*'):
+    with pytest.raises(ValueError, match=r".*unexpected uncertainty type.*"):
         err = UnknownUncertainty(np.ones_like(image))
         image.uncertainty = err
         ext = extract(image=image)
 
     # an array-type image must have the same dimensions as its variance argument
-    with pytest.raises(ValueError, match=r'.*shapes must match.*'):
+    with pytest.raises(ValueError, match=r".*shapes must match.*"):
         # remember variance, mask, and unit args are only checked if image
         # object doesn't have those attributes (e.g., numpy and Quantity arrays)
         err = np.ones_like(image[0])
         ext = extract(image=image.data, variance=err)
 
     # an array-type image must have the same dimensions as its mask argument
-    with pytest.raises(ValueError, match=r'.*shapes must match.*'):
+    with pytest.raises(ValueError, match=r".*shapes must match.*"):
         err = np.ones_like(image)
         mask = np.zeros_like(image[0])
         ext = extract(image=image.data, variance=err, mask=mask)
@@ -169,9 +161,8 @@ def test_horne_image_validation(mk_test_img):
     # and produces an extraction with flux in DN and spectral axis in pixels
     err = np.ones_like(image)
     ext = extract(image=image.data, variance=err, mask=None, unit=None)
-    assert ext.unit == u.Unit('DN')
-    assert np.all(ext.spectral_axis
-                  == np.arange(image.shape[extract.disp_axis]) * u.pix)
+    assert ext.unit == u.Unit("DN")
+    assert np.all(ext.spectral_axis == np.arange(image.shape[extract.disp_axis]) * u.pix)
 
 
 # ignore Astropy warning for extractions that aren't best fit with a Gaussian:
@@ -198,11 +189,10 @@ def test_horne_variance_errors(mk_test_img):
     # single negative value raises error
     err = image.uncertainty.array
     err[0][0] = -1
-    with pytest.raises(ValueError, match='variance must be fully positive'):
+    with pytest.raises(ValueError, match="variance must be fully positive"):
         # remember variance, mask, and unit args are only checked if image
         # object doesn't have those attributes (e.g., numpy and Quantity arrays)
-        ext = extract(image=image.data, variance=err,
-                      mask=image.mask, unit=u.Jy)
+        ext = extract(image=image.data, variance=err, mask=image.mask, unit=u.Jy)
 
 
 @pytest.mark.filterwarnings("ignore:The fit may be unsuccessful")
@@ -235,14 +225,12 @@ def test_horne_non_flat_trace():
 
     # Extract the spectrum from the non-flat image+trace
     extract_non_flat = HorneExtract(
-        rolled, ArrayTrace(rolled, exact_trace),
-        variance=err, mask=mask, unit=u.Jy
+        rolled, ArrayTrace(rolled, exact_trace), variance=err, mask=mask, unit=u.Jy
     )()
 
     # Also extract the spectrum from the image after alignment with a flat trace
     extract_flat = HorneExtract(
-        unrolled, FlatTrace(unrolled, n_rows // 2),
-        variance=err, mask=mask, unit=u.Jy
+        unrolled, FlatTrace(unrolled, n_rows // 2), variance=err, mask=mask, unit=u.Jy
     )()
 
     # ensure both extractions are equivalent:
@@ -252,10 +240,10 @@ def test_horne_non_flat_trace():
 def test_horne_bad_profile(mk_test_img):
     image = mk_test_img
     trace = FlatTrace(image, 3.0)
-    extract = HorneExtract(image.data, trace,
-                           spatial_profile='bad_profile_name',
-                           variance=np.ones(image.data.shape))
-    with pytest.raises(ValueError, match='spatial_profile must be one of'):
+    extract = HorneExtract(
+        image.data, trace, spatial_profile="bad_profile_name", variance=np.ones(image.data.shape)
+    )
+    with pytest.raises(ValueError, match="spatial_profile must be one of"):
         extract.spectrum
 
 
@@ -263,9 +251,9 @@ def test_horne_nonfinite_column(mk_test_img):
     image = mk_test_img
     image.data[:, 4] = np.nan
     trace = FlatTrace(image, 3.0)
-    extract = HorneExtract(image.data, trace,
-                           spatial_profile='gaussian',
-                           variance=np.ones(image.data.shape))
+    extract = HorneExtract(
+        image.data, trace, spatial_profile="gaussian", variance=np.ones(image.data.shape)
+    )
     sp = extract.spectrum
     assert np.isnan(sp.flux.value[4])
     assert np.all(np.isfinite(sp.flux.value[:4]))
@@ -278,8 +266,7 @@ def test_horne_no_bkgrnd(mk_test_img):
     image = mk_test_img
 
     trace = FlatTrace(image, 3.0)
-    extract = HorneExtract(image.data, trace, bkgrd_prof=None,
-                           variance=np.ones(image.data.shape))
+    extract = HorneExtract(image.data, trace, bkgrd_prof=None, variance=np.ones(image.data.shape))
 
     # This is just testing that it runs with no errors and returns something
     assert len(extract.spectrum.flux) == 10
@@ -296,20 +283,24 @@ def test_horne_interpolated_profile(mk_test_img):
     trace = FlatTrace(image, image.shape[0] // 2)
 
     # horne extraction using spatial_profile=='Gaussian'
-    horne_extract_gauss = HorneExtract(image.data, trace,
-                                       spatial_profile='gaussian',
-                                       bkgrd_prof=None,
-                                       variance=np.ones(image.data.shape))
+    horne_extract_gauss = HorneExtract(
+        image.data,
+        trace,
+        spatial_profile="gaussian",
+        bkgrd_prof=None,
+        variance=np.ones(image.data.shape),
+    )
 
     # horne extraction with spatial_profile=='interpolated_profile'
-    horne_extract_self = HorneExtract(image.data, trace,
-                                      spatial_profile={'name': 'interpolated_profile',
-                                                       'n_bins_interpolated_profile': 3},
-                                      bkgrd_prof=None,
-                                      variance=np.ones(image.data.shape))
+    horne_extract_self = HorneExtract(
+        image.data,
+        trace,
+        spatial_profile={"name": "interpolated_profile", "n_bins_interpolated_profile": 3},
+        bkgrd_prof=None,
+        variance=np.ones(image.data.shape),
+    )
 
-    assert_quantity_allclose(horne_extract_gauss.spectrum.flux,
-                             horne_extract_self.spectrum.flux)
+    assert_quantity_allclose(horne_extract_gauss.spectrum.flux, horne_extract_self.spectrum.flux)
 
 
 def test_horne_interpolated_profile_norm(mk_test_img):
@@ -329,24 +320,27 @@ def test_horne_interpolated_profile_norm(mk_test_img):
 
     # add gaussian source to image with increasing amplitude and that follows
     # along the trace. looks like a sawtooth pattern of increasing brightness
-    add_gaussian_source(image, amps=np.linspace(1, 5, image.shape[1]),
-                        means=trace_shape)
+    add_gaussian_source(image, amps=np.linspace(1, 5, image.shape[1]), means=trace_shape)
 
     # horne extraction with spatial_profile=='interpolated_profile'
     # also tests that non-default parameters in the input dictionary format work
-    ex = HorneExtract(image.data, trace,
-                      spatial_profile={'name': 'interpolated_profile',
-                                       'n_bins_interpolated_profile': 3,
-                                       'interp_degree_interpolated_profile': (1, 1)},
-                      bkgrd_prof=None,
-                      variance=np.ones(image.data.shape))
+    ex = HorneExtract(
+        image.data,
+        trace,
+        spatial_profile={
+            "name": "interpolated_profile",
+            "n_bins_interpolated_profile": 3,
+            "interp_degree_interpolated_profile": (1, 1),
+        },
+        bkgrd_prof=None,
+        variance=np.ones(image.data.shape),
+    )
 
     # need to run produce extract.spectrum to access _interp_spatial_prof
     ex.spectrum
 
     # evaulate interpolated profile on entire grid
-    interp_prof = ex._interp_spatial_prof(np.arange(ncols),
-                                          np.arange(nrows)).T
+    interp_prof = ex._interp_spatial_prof(np.arange(ncols), np.arange(nrows)).T
 
     # the shifting position and amplitude should be accounted for, so the fit
     # spatial profile should just represent the shape as a function of
@@ -357,7 +351,7 @@ def test_horne_interpolated_profile_norm(mk_test_img):
     assert_quantity_allclose(np.sum(interp_prof, axis=0), 1.0)
 
     # and that shifts in trace position are accounted for (to integer level)
-    assert (np.all(np.argmax(interp_prof, axis=0) == nrows // 2))
+    assert np.all(np.argmax(interp_prof, axis=0) == nrows // 2)
 
 
 def test_horne_interpolated_nbins_fails(mk_test_img):
@@ -367,16 +361,17 @@ def test_horne_interpolated_nbins_fails(mk_test_img):
     trace = FlatTrace(image, 5)
 
     with pytest.raises(ValueError):
-        ex = HorneExtract(image.data, trace,
-                          spatial_profile={'name': 'interpolated_profile',
-                                           'n_bins_interpolated_profile': 100})
+        ex = HorneExtract(
+            image.data,
+            trace,
+            spatial_profile={"name": "interpolated_profile", "n_bins_interpolated_profile": 100},
+        )
         ex.spectrum
 
 
-class TestMasksExtract():
+class TestMasksExtract:
 
     def mk_flat_gauss_img(self, nrows=200, ncols=160, nan_slices=None, add_noise=True):
-
         """
         Makes a flat gaussian image for testing, with optional added gaussian
         nosie and optional data values set to NaN. Variance is included, which
@@ -385,8 +380,7 @@ class TestMasksExtract():
         """
 
         sigma_pix = 4
-        col_model = models.Gaussian1D(amplitude=1, mean=nrows/2,
-                                      stddev=sigma_pix)
+        col_model = models.Gaussian1D(amplitude=1, mean=nrows / 2, stddev=sigma_pix)
         spec2dvar = np.ones((nrows, ncols))
         noise = 0
         if add_noise:
@@ -402,8 +396,11 @@ class TestMasksExtract():
                 img[s] = np.nan
 
         wave = np.arange(0, img.shape[1], 1)
-        objectspec = Spectrum1D(spectral_axis=wave*u.m, flux=img*u.Jy,
-                                uncertainty=VarianceUncertainty(spec2dvar*u.Jy*u.Jy))
+        objectspec = Spectrum1D(
+            spectral_axis=wave * u.m,
+            flux=img * u.Jy,
+            uncertainty=VarianceUncertainty(spec2dvar * u.Jy * u.Jy),
+        )
 
         return objectspec
 
@@ -417,19 +414,19 @@ class TestMasksExtract():
         img = self.mk_flat_gauss_img()
         trace = FitTrace(img)
 
-        with pytest.raises(ValueError, match='Image is fully masked.'):
+        with pytest.raises(ValueError, match="Image is fully masked."):
             # fully NaN image
             img = np.zeros((4, 5)) * np.nan
             Background(img, traces=trace, width=2)
 
-        with pytest.raises(ValueError, match='Image is fully masked.'):
+        with pytest.raises(ValueError, match="Image is fully masked."):
             # fully masked image (should be equivalent)
             img = NDData(np.ones((4, 5)), mask=np.ones((4, 5)))
             Background(img, traces=trace, width=2)
 
         # Now test that an image that isn't fully masked, but is fully masked
         # within the window determined by `width`, produces the correct result
-        msg = 'Image is fully masked within background window determined by `width`.'
+        msg = "Image is fully masked within background window determined by `width`."
         with pytest.raises(ValueError, match=msg):
             img = self.mk_img(nrows=12, ncols=12, nan_slices=[np.s_[3:10, :]])
             Background(img, traces=FlatTrace(img, 6), width=7)

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -315,7 +315,7 @@ def test_horne_interpolated_profile(mk_test_img):
     assert_quantity_allclose(horne_extract_gauss.spectrum.flux, horne_extract_self.spectrum.flux)
 
     with pytest.raises(ValueError, match="When"):
-        sp = HorneExtract(
+        HorneExtract(
             image.data,
             trace,
             spatial_profile={"name": "interpolated_profile", "n_bins_interpolated_profile": 3},

--- a/specreduce/tests/test_extract.py
+++ b/specreduce/tests/test_extract.py
@@ -89,12 +89,15 @@ def test_boxcar_nonfinite_handling(mk_test_img):
     image.data[14, 4] = np.inf
 
     trace = FlatTrace(image, 15.0)
-    boxcar = BoxcarExtract(image, trace, width=6, mask_treatment='apply')
-    spectrum = boxcar()
+    spectrum = BoxcarExtract(image, trace, width=6, mask_treatment='ignore')()
     target = np.full_like(spectrum.flux.value, 90.)
     target[2] = np.nan
     target[4] = np.inf
     np.testing.assert_equal(spectrum.flux.value, target)
+
+    spectrum = BoxcarExtract(image, trace, width=6, mask_treatment='apply')()
+    target[[2, 4]] = 91.2
+    np.testing.assert_allclose(spectrum.flux.value, target, rtol=1e-8)
 
 
 def test_boxcar_outside_image_condition(mk_test_img):
@@ -105,7 +108,10 @@ def test_boxcar_outside_image_condition(mk_test_img):
 
     trace = FlatTrace(image, 3.0)
     boxcar = BoxcarExtract(image, trace, mask_treatment='apply')
+    spectrum = boxcar(width=10.)
+    assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 32.0))
 
+    boxcar = BoxcarExtract(image, trace, mask_treatment='ignore')
     spectrum = boxcar(width=10.)
     assert np.allclose(spectrum.flux.value, np.full_like(spectrum.flux.value, 32.0))
 

--- a/specreduce/tests/test_mask_treatment.py
+++ b/specreduce/tests/test_mask_treatment.py
@@ -1,0 +1,149 @@
+from copy import deepcopy
+
+import pytest
+import numpy as np
+
+from astropy.units import DN
+from astropy.nddata import NDData
+from specreduce.core import _ImageParser
+
+
+def mk_image():
+    image = np.ones((3, 5))
+    mask = np.zeros(image.shape, dtype=bool)
+    image[1, 3] = np.nan
+    mask[[0, 1], [1, 0]] = 1
+    return NDData(image * DN, mask=mask)
+
+
+def test_bad_option():
+    image = mk_image()
+    with pytest.raises(ValueError, match="'mask_treatment' must be one of"):
+        _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="bad")
+
+
+def test_bad_mask_type():
+    image = mk_image()
+    image.mask = image.mask.astype(float)
+    with pytest.raises(ValueError, match="'mask' must be a boolean or integer array."):
+        _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="apply")
+
+
+def test_apply():
+    image = mk_image()
+    parsed_image = _ImageParser()._parse_image(deepcopy(image), disp_axis=1, mask_treatment="apply")
+    np.testing.assert_array_equal(parsed_image.data, image.data)
+    mask_true = np.zeros(image.data.shape, dtype=bool)
+    mask_true[[0, 1, 1], [1, 0, 3]] = 1
+    np.testing.assert_array_equal(parsed_image.mask, mask_true)
+
+    image.mask = None
+    parsed_image = _ImageParser()._parse_image(deepcopy(image), disp_axis=1, mask_treatment="apply")
+    np.testing.assert_array_equal(parsed_image.data, image.data)
+    mask_true = np.zeros(image.data.shape, dtype=bool)
+    mask_true[1, 3] = 1
+    np.testing.assert_array_equal(parsed_image.mask, mask_true)
+
+
+def test_ignore():
+    image = mk_image()
+    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="ignore")
+    np.testing.assert_array_equal(parsed_image.data, image.data)
+    mask_true = np.zeros(image.data.shape, dtype=bool)
+    np.testing.assert_array_equal(parsed_image.mask, mask_true)
+
+    image.mask = None
+    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="ignore")
+    np.testing.assert_array_equal(parsed_image.data, image.data)
+    mask_true = np.zeros(image.data.shape, dtype=bool)
+    np.testing.assert_array_equal(parsed_image.mask, mask_true)
+
+
+def test_propagate():
+    image = mk_image()
+    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="propagate")
+    np.testing.assert_array_equal(parsed_image.data, image.data)
+    mask_true = np.zeros(image.data.shape, dtype=bool)
+    mask_true[:, [0, 1, 3]] = 1
+    np.testing.assert_array_equal(parsed_image.mask, mask_true)
+
+    image.mask = None
+    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="propagate")
+    np.testing.assert_array_equal(parsed_image.data, image.data)
+    mask_true = np.zeros(image.data.shape, dtype=bool)
+    mask_true[:, 3] = 1
+    np.testing.assert_array_equal(parsed_image.mask, mask_true)
+
+
+def test_zero_fill():
+    image = mk_image()
+    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="zero-fill")
+    image_true = np.ones(image.data.shape)
+    image_true[[0, 1, 1], [1, 0, 3]] = 0
+    np.testing.assert_array_equal(parsed_image.data, image_true)
+    mask_true = np.zeros(image.data.shape, dtype=bool)
+    np.testing.assert_array_equal(parsed_image.mask, mask_true)
+
+    image.mask = None
+    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="zero-fill")
+    image_true = np.ones(image.data.shape)
+    image_true[1, 3] = 0
+    np.testing.assert_array_equal(parsed_image.data, image_true)
+    mask_true = np.zeros(image.data.shape, dtype=bool)
+    np.testing.assert_array_equal(parsed_image.mask, mask_true)
+
+
+def test_nan_fill():
+    image = mk_image()
+    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="nan-fill")
+    image_true = np.ones(image.data.shape)
+    image_true[[0, 1, 1], [1, 0, 3]] = np.nan
+    np.testing.assert_array_equal(parsed_image.data, image_true)
+    mask_true = np.zeros(image.data.shape, dtype=bool)
+    np.testing.assert_array_equal(parsed_image.mask, mask_true)
+
+    image.mask = None
+    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="nan-fill")
+    image_true = np.ones(image.data.shape)
+    image_true[1, 3] = np.nan
+    np.testing.assert_array_equal(parsed_image.data, image_true)
+    mask_true = np.zeros(image.data.shape, dtype=bool)
+    np.testing.assert_array_equal(parsed_image.mask, mask_true)
+
+
+def test_apply_nan_only():
+    image = mk_image()
+    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="apply_nan_only")
+    np.testing.assert_array_equal(parsed_image.data, image.data)
+    mask_true = np.zeros(image.data.shape, dtype=bool)
+    mask_true[1, 3] = 1
+    np.testing.assert_array_equal(parsed_image.mask, mask_true)
+
+    image.mask = None
+    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="apply_nan_only")
+    np.testing.assert_array_equal(parsed_image.data, image.data)
+    mask_true = np.zeros(image.data.shape, dtype=bool)
+    mask_true[1, 3] = 1
+    np.testing.assert_array_equal(parsed_image.mask, mask_true)
+
+
+def test_apply_mask_only():
+    image = mk_image()
+    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="apply_mask_only")
+    np.testing.assert_array_equal(parsed_image.data, image.data)
+    mask_true = np.zeros(image.data.shape, dtype=bool)
+    mask_true[[0, 1], [1, 0]] = 1
+    np.testing.assert_array_equal(parsed_image.mask, mask_true)
+
+    image.mask = None
+    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="apply_mask_only")
+    np.testing.assert_array_equal(parsed_image.data, image.data)
+    mask_true = np.zeros(image.data.shape, dtype=bool)
+    np.testing.assert_array_equal(parsed_image.mask, mask_true)
+
+
+def test_fully_masked():
+    image = mk_image()
+    image.mask[:] = 1
+    with pytest.raises(ValueError, match="Image is fully masked."):
+        parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="apply")

--- a/specreduce/tests/test_mask_treatment.py
+++ b/specreduce/tests/test_mask_treatment.py
@@ -77,7 +77,7 @@ def test_propagate():
 
 def test_zero_fill():
     image = mk_image()
-    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="zero-fill")
+    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="zero_fill")
     image_true = np.ones(image.data.shape)
     image_true[[0, 1, 1], [1, 0, 3]] = 0
     np.testing.assert_array_equal(parsed_image.data, image_true)
@@ -85,7 +85,7 @@ def test_zero_fill():
     np.testing.assert_array_equal(parsed_image.mask, mask_true)
 
     image.mask = None
-    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="zero-fill")
+    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="zero_fill")
     image_true = np.ones(image.data.shape)
     image_true[1, 3] = 0
     np.testing.assert_array_equal(parsed_image.data, image_true)
@@ -95,7 +95,7 @@ def test_zero_fill():
 
 def test_nan_fill():
     image = mk_image()
-    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="nan-fill")
+    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="nan_fill")
     image_true = np.ones(image.data.shape)
     image_true[[0, 1, 1], [1, 0, 3]] = np.nan
     np.testing.assert_array_equal(parsed_image.data, image_true)
@@ -103,7 +103,7 @@ def test_nan_fill():
     np.testing.assert_array_equal(parsed_image.mask, mask_true)
 
     image.mask = None
-    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="nan-fill")
+    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="nan_fill")
     image_true = np.ones(image.data.shape)
     image_true[1, 3] = np.nan
     np.testing.assert_array_equal(parsed_image.data, image_true)

--- a/specreduce/tests/test_mask_treatment.py
+++ b/specreduce/tests/test_mask_treatment.py
@@ -146,4 +146,4 @@ def test_fully_masked():
     image = mk_image()
     image.mask[:] = 1
     with pytest.raises(ValueError, match="Image is fully masked."):
-        parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="apply")
+        _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="apply")

--- a/specreduce/tests/test_tracing.py
+++ b/specreduce/tests/test_tracing.py
@@ -184,7 +184,7 @@ def test_fit_trace():
 class TestMasksTracing():
     """
     There are three currently implemented options for masking in FitTrace: filter,
-    omit, and zero-fill. Trace, FlatTrace, and ArrayTrace do not have
+    omit, and zero_fill. Trace, FlatTrace, and ArrayTrace do not have
     `mask_treatment` options as input because masked/nonfinite values in the data
     are not relevant for those trace types as they are not affected by masked
     input data. The tests in this class test masking options for FitTrace, as
@@ -424,7 +424,7 @@ class TestMasksTracing():
                                    np.s_[:, 6:7], np.s_[3:9, 10:11]],
                        nrows=10, ncols=12, add_noise=False)
 
-        for method in 'ignore', 'zero-fill', 'nan-fill', 'apply_mask_only':
+        for method in 'ignore', 'zero_fill', 'nan_fill', 'apply_mask_only':
             with pytest.raises(ValueError):
                 FitTrace(image, peak_method=peak_method, mask_treatment=method)
 

--- a/specreduce/tests/test_tracing.py
+++ b/specreduce/tests/test_tracing.py
@@ -422,7 +422,7 @@ class TestMasksTracing():
 
         image = mk_img(nan_slices=[np.s_[4:8, 1:2], np.s_[2:7, 4:5],
                                    np.s_[:, 6:7], np.s_[3:9, 10:11]],
-                        nrows=10, ncols=12, add_noise=False)
+                       nrows=10, ncols=12, add_noise=False)
 
         for method in 'ignore', 'zero-fill', 'nan-fill', 'apply_mask_only':
             with pytest.raises(ValueError):

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -267,8 +267,8 @@ class FitTrace(Trace, _ImageParser):
         The fit cannot handle non-finite values, so only the ``apply``, ``propagate``,
         ``apply_nan_only`` options are supported. The ``apply`` option combines
         the existing mask with the mask derived from non-finite values, ``propagate``
-         expands the mask along the cross-dispersion axis (that is, a masked pixel
-         results in the whole cross-dispersion slice being masked), and
+        expands the mask along the cross-dispersion axis (that is, a masked pixel
+        results in the whole cross-dispersion slice being masked), and
         ``apply_nan_only`` drops the existing mask and replaces it with a mask
         derived from non-finite values.
     """

--- a/tox.ini
+++ b/tox.ini
@@ -83,4 +83,4 @@ skip_install = true
 changedir = .
 description = check code style, e.g., with flake8
 deps = flake8
-commands = flake8 specreduce --count
+commands = flake8 specreduce --count --extend-ignore E203


### PR DESCRIPTION
This PR addresses Issue #252 by renaming the existing mask treatment options and introducing a new set. It also adds a documentation page with illustrations demonstrating each option's effect in practice, and it also adds a basic Black configuration to `pyproject.toml` and modifies flake8 in `tox.ini` to ignore E203, as described [here](https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#labels-why-pycodestyle-warnings). Finally, I started running black on the code I edited, which leads to somewhat larger diffs than from the actual functional changes alone.

The complete mask treatment option set now includes: `apply`, `ignore`, `propagate`, `zero-fill`, `nan-fill`, `apply_mask_only`, and `appy_nan_only`. Now is the best time to let everyone know if you are not happy with some of these choices, so please write if you have strong feelings against any :)

I chose `propagate` over the suggested `mask_extraction_bin` and `apply_to_full_extraction_bin` because it is more generic and can be used in any method or function requiring this behavior, rather than being limited to spectrum extraction. However, I'm happy to change this to something else if anyone can suggest a good, clear alternative.

Finally, should we go for `apply_mask_only` or `apply-mask-only`? The first option is probably grammatically better, but the other would be easier to remember.