### PR TITLE
special case for fit trace with all 0 columns, some pep8 fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ API Changes
 Bug Fixes
 ^^^^^^^^^
 - When all-zero bin encountered in fit_trace with peak_method=gaussian, the bin peak
-  falls back to the all-bin fit to work better with DogBoxLSQFitter. [#257]
+  will be set to NaN in this caseto work better with DogBoxLSQFitter. [#257]
 
 Other changes
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ API Changes
 
 Bug Fixes
 ^^^^^^^^^
+- When all-zero bin encountered in fit_trace with peak_method=gaussian, the bin peak
+  falls back to the all-bin fit to work better with DogBoxLSQFitter. [#257]
 
 Other changes
 ^^^^^^^^^^^^^

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -67,17 +67,17 @@ def _get_boxcar_weights(center, hwidth, npix):
     # the upper bound doesn't have the +1 because array slicing is inclusive on the lower index and
     # exclusive on the upper-index
     # NOTE: round(-0.5) == 0, which is helpful here for the case where lower_edge == -0.5
-    weights[int_round_lower_edge + 1 : int_round_upper_edge] = 1
+    weights[int_round_lower_edge + 1: int_round_upper_edge] = 1
 
     # handle edge pixels (for cases where an edge pixel is fully-weighted, this will set it again,
     # but should still compute a weight of 1.  By using N:N+1, we avoid index errors if the edge
     # is outside the image bounds.  But we do need to avoid negative indices which would count
     # from the end of the array.
     if int_round_lower_edge >= 0:
-        weights[int_round_lower_edge : int_round_lower_edge + 1] = (
+        weights[int_round_lower_edge: int_round_lower_edge + 1] = (
             round(lower_edge) + 0.5 - lower_edge
         )
-    weights[int_round_upper_edge : int_round_upper_edge + 1] = upper_edge - (
+    weights[int_round_upper_edge: int_round_upper_edge + 1] = upper_edge - (
         round(upper_edge) - 0.5
     )
 
@@ -560,7 +560,7 @@ class HorneExtract(SpecreduceOperation):
         ]
 
         for i in range(n_bins):
-            bin_median = np.nanmedian(img[:, sample_locs[i] : sample_locs[i + 1]], axis=disp_axis)
+            bin_median = np.nanmedian(img[:, sample_locs[i]: sample_locs[i + 1]], axis=disp_axis)
             samples[i, :] = bin_median / bin_median.sum()
 
         return RectBivariateSpline(x=bin_centers, y=np.arange(nrows), z=samples, kx=kx, ky=ky)

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -67,17 +67,17 @@ def _get_boxcar_weights(center, hwidth, npix):
     # the upper bound doesn't have the +1 because array slicing is inclusive on the lower index and
     # exclusive on the upper-index
     # NOTE: round(-0.5) == 0, which is helpful here for the case where lower_edge == -0.5
-    weights[int_round_lower_edge + 1: int_round_upper_edge] = 1
+    weights[int_round_lower_edge + 1 : int_round_upper_edge] = 1
 
     # handle edge pixels (for cases where an edge pixel is fully-weighted, this will set it again,
     # but should still compute a weight of 1.  By using N:N+1, we avoid index errors if the edge
     # is outside the image bounds.  But we do need to avoid negative indices which would count
     # from the end of the array.
     if int_round_lower_edge >= 0:
-        weights[int_round_lower_edge: int_round_lower_edge + 1] = (
+        weights[int_round_lower_edge : int_round_lower_edge + 1] = (
             round(lower_edge) + 0.5 - lower_edge
         )
-    weights[int_round_upper_edge: int_round_upper_edge + 1] = upper_edge - (
+    weights[int_round_upper_edge : int_round_upper_edge + 1] = upper_edge - (
         round(upper_edge) - 0.5
     )
 
@@ -560,7 +560,7 @@ class HorneExtract(SpecreduceOperation):
         ]
 
         for i in range(n_bins):
-            bin_median = np.nanmedian(img[:, sample_locs[i]: sample_locs[i + 1]], axis=disp_axis)
+            bin_median = np.nanmedian(img[:, sample_locs[i] : sample_locs[i + 1]], axis=disp_axis)
             samples[i, :] = bin_median / bin_median.sum()
 
         return RectBivariateSpline(x=bin_centers, y=np.arange(nrows), z=samples, kx=kx, ky=ky)

--- a/specreduce/tests/test_tracing.py
+++ b/specreduce/tests/test_tracing.py
@@ -151,7 +151,7 @@ def test_fit_trace():
     window = 10
     guess = int(nrows / 2)
     img_win_nans = img.copy()
-    img_win_nans[guess - window: guess + window] = np.nan
+    img_win_nans[guess - window : guess + window] = np.nan
 
     # ensure float bin values trigger a warning but no issues otherwise
     with pytest.warns(UserWarning, match="TRACE: Converting bins to int"):
@@ -291,7 +291,7 @@ class TestMasksTracing:
         window = 10
         guess = int(nrows / 2)
         img_win_nans = img.copy()
-        img_win_nans[guess - window: guess + window] = np.nan
+        img_win_nans[guess - window : guess + window] = np.nan
 
         # error on trace of otherwise valid image with all-nan window around guess
         with pytest.raises(ValueError, match="pixels in window region are masked"):

--- a/specreduce/tests/test_tracing.py
+++ b/specreduce/tests/test_tracing.py
@@ -181,12 +181,11 @@ def test_fit_trace_gaussian_all_zero():
     In this case, an all zero bin should fall back to the all-bin fit for its'
     peak.
     """
-    img = mk_img()
-    # pad image with some all-zero columns and add back DN unit
-    img = np.pad(img.value, pad_width=((0, 0), (0, 5)), mode='constant',
-                 constant_values=0) * u.DN
+    img = mk_img(ncols=100)
+    # add some all-zero columns so there is an all-zero bin
+    img[:, 10:20] = 0
 
-    t = FitTrace(img, bins=20, peak_method='gaussian')
+    t = FitTrace(img, bins=10, peak_method='gaussian')
 
     # this is a pretty flat trace, so make sure the fit reflects that
     assert np.all((t.trace >= 99) & (t.trace <= 101))

--- a/specreduce/tests/test_tracing.py
+++ b/specreduce/tests/test_tracing.py
@@ -178,8 +178,8 @@ def test_fit_trace_gaussian_all_zero():
     """
     Test fit_trace when peak_method is 'gaussian', which uses DogBoxLSQFitter
     for the fit for each bin peak and does not work well with all-zero columns.
-    In this case, an all zero bin should fall back to the all-bin fit for its'
-    peak.
+    In this case, an all zero bin should fall back to NaN to for its'
+    peak to be filtered out in the final fit for the trace.
     """
     img = mk_img(ncols=100)
     # add some all-zero columns so there is an all-zero bin

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -413,11 +413,11 @@ class FitTrace(Trace, _ImageParser):
 
             if self.peak_method == "gaussian":
 
-                # if bin is fully 0, set bin peak to all-bin fit.
-                # DogBoxLSQFitter, which is always used for the bin center fits
-                # when peak_method is gaussian, does not like all zeros.
+                # if bin is fully 0, set bin peak to nan so it doesn't bias the
+                # all-bin fit. DogBoxLSQFitter, which is always used for the bin
+                # center fits when peak_method is gaussian, does not like all zeros.
                 if np.all(z_i == 0.0):
-                    y_bins[i] = popt_tot.mean_0.value
+                    y_bins[i] = np.nan
                     continue
 
                 peak_y_i = ilum2[z_i.argmax()]

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -402,7 +402,7 @@ class FitTrace(Trace, _ImageParser):
 
             # binned columns, averaged along disp. axis.
             # or just a single, unbinned column if no bins
-            z_i = img[ilum2, x_bins[i]: x_bins[i + 1]].mean(axis=self._disp_axis)
+            z_i = img[ilum2, x_bins[i] : x_bins[i + 1]].mean(axis=self._disp_axis)
 
             # if this bin is fully masked, set bin peak to NaN so it can be
             # filtered in the final fit to all bin peaks for the trace

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -402,7 +402,7 @@ class FitTrace(Trace, _ImageParser):
 
             # binned columns, averaged along disp. axis.
             # or just a single, unbinned column if no bins
-            z_i = img[ilum2, x_bins[i] : x_bins[i + 1]].mean(axis=self._disp_axis)
+            z_i = img[ilum2, x_bins[i]: x_bins[i + 1]].mean(axis=self._disp_axis)
 
             # if this bin is fully masked, set bin peak to NaN so it can be
             # filtered in the final fit to all bin peaks for the trace
@@ -412,6 +412,13 @@ class FitTrace(Trace, _ImageParser):
                 continue
 
             if self.peak_method == "gaussian":
+
+                # if bin is fully 0, set bin peak to all-bin fit.
+                # DogBoxLSQFitter, which is always used for the bin center fits
+                # when peak_method is gaussian, does not like all zeros.
+                if np.all(z_i == 0.0):
+                    y_bins[i] = popt_tot.mean_0.value
+                    continue
 
                 peak_y_i = ilum2[z_i.argmax()]
 


### PR DESCRIPTION
The recent change to use DogBoxLSQFitter instead of LevMarLSQFitter to the fit for each bin peak in FitTrace was causing some issues with one of our tests in jdaviz where we have test data with all-zero columns. I think in practice these would be masked out, but in the case where they aren't, the bin peak should fall back to the all-bin fit rather than trying to fit this. This fixes the failing test in jdaviz (test_spectral_extraction.test_plugin).