### PR TITLE
Issue #261 fix

### DIFF
--- a/notebook_sandbox/horne_extract/requirements.txt
+++ b/notebook_sandbox/horne_extract/requirements.txt
@@ -1,3 +1,0 @@
-astropy=5.0
-matplotlib==3.5.0
-numpy==1.21.4


### PR DESCRIPTION
This PR removes the `requirements.txt` file from the `notebook_sandbox/horne_extract` directory containing an early Horne extraction example notebook. The file contained a malformed requirement (`astropy=5.0` instead of `astropy==5.0`) that was likely the cause of the dependabot failures reported in #261.

Fix #261 