### PR TITLE
Background estimation with a custom callable statistic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,9 +7,12 @@ New Features
 API Changes
 ^^^^^^^^^^^
 
-- ``bkg_statistic`` keyword in ``Background.bkg_spectrum()`` now takes callable
-  instead of string. Its default is also changed from ``"sum"`` (``np.nansum``)
-  to ``np.nanmedian`` to better suit background calculation. [#253]
+- ``statistic`` argument in ``Background`` initializer can now be either ``"average"``,
+  ``"median"``, or a custom callable that takes a ``numpy.ma.MaskedArray`` masked array
+  as an input and accepts ``axis`` as an argument. [#253]
+- ``bkg_statistic`` keyword in ``Background.bkg_spectrum()`` now deprecated and raises
+  a warning if set. The ``statistic`` argument in the ``Background`` initializer should
+  be used instead. [#253]
 
 Bug Fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-1.5.1 (unreleased)
+1.5.2 (unreleased)
 ------------------
 
 New Features
@@ -7,8 +7,13 @@ New Features
 API Changes
 ^^^^^^^^^^^
 
+- ``bkg_statistic`` keyword in ``Background.bkg_spectrum()`` now takes callable
+  instead of string. Its default is also changed from ``"sum"`` (``np.nansum``)
+  to ``np.nanmedian`` to better suit background calculation. [#253]
+
 Bug Fixes
 ^^^^^^^^^
+
 - When all-zero bin encountered in fit_trace with peak_method=gaussian, the bin peak
   will be set to NaN in this caseto work better with DogBoxLSQFitter. [#257]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ API Changes
 - ``statistic`` argument in ``Background`` initializer can now be either ``"average"``,
   ``"median"``, or a custom callable that takes a ``numpy.ma.MaskedArray`` masked array
   as an input and accepts ``axis`` as an argument. [#253]
-- ``bkg_statistic`` keyword in ``Background.bkg_spectrum()`` now deprecated and raises
+- ``bkg_statistic`` keyword in ``Background.bkg_spectrum()`` is now deprecated and raises
   a warning if set. The ``statistic`` argument in the ``Background`` initializer should
   be used instead. [#253]
 

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -321,7 +321,7 @@ class Background(_ImageParser):
             kwargs = {"spectral_axis_index": arr.ndim - 1}
         return Spectrum(arr * image.unit, spectral_axis=image.spectral_axis, **kwargs)
 
-    def bkg_spectrum(self, image=None):
+    def bkg_spectrum(self, image=None, bkg_statistic=None):
         """
         Expose the 1D spectrum of the background.
 
@@ -340,6 +340,12 @@ class Background(_ImageParser):
             units as the input image (or DN if none were provided) and
             the spectral axis expressed in pixel units.
         """
+        if bkg_statistic is not None:
+            warnings.warn(
+                "'bkg_statistic' is deprecated and will be removed in a future release. "
+                "Please use the 'statistic' argument in the Background initializer instead.",
+                DeprecationWarning,
+            )
         return Spectrum(self._bkg_array * self.image.unit, spectral_axis=self.image.spectral_axis)
 
     def sub_image(self, image=None):

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -3,6 +3,7 @@
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import Literal
 
 import numpy as np
 from astropy import units as u
@@ -72,7 +73,7 @@ class Background(_ImageParser):
     image: ImageLike
     traces: list = field(default_factory=list)
     width: float = 5
-    statistic: str | Callable[..., np.ndarray] = "average"
+    statistic: Literal["average", "median"] | Callable[..., np.ndarray] = "average"
     disp_axis: int = 1
     crossdisp_axis: int = 0
     mask_treatment: MaskingOption = "apply"

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -157,7 +157,10 @@ class Background(_ImageParser):
             img.mask = (self.bkg_wimage == 0) | self.image.mask
             self._bkg_array = np.ma.median(img, axis=self.crossdisp_axis)
         else:
-            raise ValueError("statistic must be 'average' or 'median'")
+            raise ValueError(
+                "statistic must be 'average', 'median', or a callable function that takes a masked"
+                "array as input and an axis argument."
+            )
 
     def _set_traces(self):
         """Determine `traces` from input. If an integer/float or list if int/float
@@ -316,10 +319,7 @@ class Background(_ImageParser):
             kwargs = {}
         else:
             kwargs = {"spectral_axis_index": arr.ndim - 1}
-        return Spectrum(
-            arr * image.unit,
-            spectral_axis=image.spectral_axis, **kwargs
-        )
+        return Spectrum(arr * image.unit, spectral_axis=image.spectral_axis, **kwargs)
 
     def bkg_spectrum(self, image=None):
         """
@@ -340,7 +340,7 @@ class Background(_ImageParser):
             units as the input image (or DN if none were provided) and
             the spectral axis expressed in pixel units.
         """
-        return Spectrum(self._bkg_array)
+        return Spectrum(self._bkg_array * self.image.unit, spectral_axis=self.image.spectral_axis)
 
     def sub_image(self, image=None):
         """
@@ -349,7 +349,7 @@ class Background(_ImageParser):
         Parameters
         ----------
         image : nddata-compatible image or None
-            image with 2-D spectral image data.  If None, will extract
+            image with 2-D spectral image data.  If None, will subtract
             the background from ``image`` used to initialize the class.
 
         Returns

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -317,7 +317,7 @@ class Background(_ImageParser):
             spectral_axis=image.spectral_axis, **kwargs
         )
 
-    def bkg_spectrum(self, image=None, bkg_statistic="sum"):
+    def bkg_spectrum(self, image=None, bkg_statistic=np.nansum):
         """
         Expose the 1D spectrum of the background.
 
@@ -328,39 +328,28 @@ class Background(_ImageParser):
             (spatial) direction is axis 0 and dispersion (wavelength)
             direction is axis 1. If None, will extract the background
             from ``image`` used to initialize the class. [default: None]
-        bkg_statistic : {'average', 'median', 'sum'}, optional
-            Statistical method used to collapse the background image. [default: ``'sum'``]
-            Supported values are:
-
-            - ``'average'`` : Uses the mean (`numpy.nanmean`).
-            - ``'median'`` : Uses the median (`numpy.nanmedian`).
-            - ``'sum'`` : Uses the sum (`numpy.nansum`).
+        bkg_statistic : func, optional
+            Statistical method used to collapse the background image.
+            For historical reason, the default is `numpy.nansum` but
+            `numpy.nanmedian` or `numpy.nanmean` are better suited for this option.
+            If you provide your own function, it must take an `~astropy.units.Quantity`
+            array as input and accept an ``axis`` argument.
 
         Returns
         -------
         spec : `~specutils.Spectrum1D`
             The background 1-D spectrum, with flux expressed in the same
-            units as the input image (or u.DN if none were provided) and
+            units as the input image (or DN if none were provided) and
             the spectral axis expressed in pixel units.
         """
         bkg_image = self.bkg_image(image)
 
-        if bkg_statistic == 'sum':
-            statistic_function = np.nansum
-        elif bkg_statistic == 'median':
-            statistic_function = np.nanmedian
-        elif bkg_statistic == 'average':
-            statistic_function = np.nanmean
-        else:
-            raise ValueError(f"Background statistic {bkg_statistic} is not supported. "
-                             "Please choose from: average, median, or sum.")
-
         try:
-            return bkg_image.collapse(statistic_function, axis=self.crossdisp_axis)
+            return bkg_image.collapse(bkg_statistic, axis=self.crossdisp_axis)
         except u.UnitTypeError:
             # can't collapse with a spectral axis in pixels because
             # SpectralCoord only allows frequency/wavelength equivalent units...
-            ext1d = statistic_function(bkg_image.flux, axis=self.crossdisp_axis)
+            ext1d = bkg_statistic(bkg_image.flux, axis=self.crossdisp_axis)
             return Spectrum(ext1d, bkg_image.spectral_axis)
 
     def sub_image(self, image=None):

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -317,7 +317,7 @@ class Background(_ImageParser):
             spectral_axis=image.spectral_axis, **kwargs
         )
 
-    def bkg_spectrum(self, image=None, bkg_statistic=np.nansum):
+    def bkg_spectrum(self, image=None, bkg_statistic=np.nanmedian):
         """
         Expose the 1D spectrum of the background.
 
@@ -330,8 +330,6 @@ class Background(_ImageParser):
             from ``image`` used to initialize the class. [default: None]
         bkg_statistic : func, optional
             Statistical method used to collapse the background image.
-            For historical reason, the default is `numpy.nansum` but
-            `numpy.nanmedian` or `numpy.nanmean` are better suited for this option.
             If you provide your own function, it must take an `~astropy.units.Quantity`
             array as input and accept an ``axis`` argument.
 

--- a/specreduce/tests/test_background.py
+++ b/specreduce/tests/test_background.py
@@ -59,7 +59,7 @@ def test_background(
     assert np.allclose(sub4.flux, sub5.flux)
     assert np.allclose(sub5.flux, sub6.flux)
 
-    bkg_spec = bg1.bkg_spectrum()
+    bkg_spec = bg1.bkg_spectrum(bkg_statistic=np.nansum)
     assert isinstance(bkg_spec, Spectrum)
     sub_spec = bg1.sub_spectrum()
     assert isinstance(sub_spec, Spectrum)
@@ -79,7 +79,7 @@ def test_background(
         bg = Background(img, trace - bkg_sep, width=bkg_width, statistic=st)
         assert np.isnan(bg.image.flux).sum() == 2
         assert np.isnan(bg._bkg_array).sum() == 0
-        assert np.isnan(bg.bkg_spectrum().flux).sum() == 0
+        assert np.isnan(bg.bkg_spectrum(bkg_statistic=np.nansum).flux).sum() == 0
         assert np.isnan(bg.sub_spectrum().flux).sum() == 0
 
     bkg_spec_avg = bg1.bkg_spectrum(bkg_statistic=np.nanmean)
@@ -288,7 +288,7 @@ class TestMasksBackground:
             # test background spectrum matches 'expected' times the number of rows
             # in cross disp axis, since this is a sum and all values in a col are
             # the same.
-            bk_spec = background.bkg_spectrum()
+            bk_spec = background.bkg_spectrum(bkg_statistic=np.nansum)
             np.testing.assert_allclose(bk_spec.flux.value, expected * img_size)
 
     def test_sub_bkg_image(self):

--- a/specreduce/tests/test_background.py
+++ b/specreduce/tests/test_background.py
@@ -59,7 +59,7 @@ def test_background(
     assert np.allclose(sub4.flux, sub5.flux)
     assert np.allclose(sub5.flux, sub6.flux)
 
-    bkg_spec = bg1.bkg_spectrum(bkg_statistic=np.nansum)
+    bkg_spec = bg1.bkg_spectrum()
     assert isinstance(bkg_spec, Spectrum)
     sub_spec = bg1.sub_spectrum()
     assert isinstance(sub_spec, Spectrum)
@@ -73,19 +73,18 @@ def test_background(
     # the final 1D spectra.
     img[0, 0] = np.nan  # out of window
     img[trace_pos, 0] = np.nan  # in window
-    stats = ["average", "median"]
+    stats = ["average", "median", np.nanmean, np.nanmedian]
 
     for st in stats:
         bg = Background(img, trace - bkg_sep, width=bkg_width, statistic=st)
         assert np.isnan(bg.image.flux).sum() == 2
         assert np.isnan(bg._bkg_array).sum() == 0
-        assert np.isnan(bg.bkg_spectrum(bkg_statistic=np.nansum).flux).sum() == 0
-        assert np.isnan(bg.sub_spectrum().flux).sum() == 0
+        assert np.isnan(bg.bkg_spectrum().flux).sum() == 0
 
-    bkg_spec_avg = bg1.bkg_spectrum(bkg_statistic=np.nanmean)
+    bkg_spec_avg = bg1.bkg_spectrum()
     assert_allclose(bkg_spec_avg.mean().value, 14.5, rtol=0.5)
 
-    bkg_spec_median = bg1.bkg_spectrum(bkg_statistic=np.nanmedian)
+    bkg_spec_median = bg1.bkg_spectrum()
     assert_allclose(bkg_spec_median.mean().value, 14.5, rtol=0.5)
 
 
@@ -281,15 +280,11 @@ class TestMasksBackground:
 
             # test background image matches 'expected'
             bk_img = background.bkg_image()
-            # change this and following assertions to assert_quantity_allclose once
-            # issue #213 is fixed
             np.testing.assert_allclose(bk_img.flux.value, np.tile(expected, (img_size, 1)))
 
-            # test background spectrum matches 'expected' times the number of rows
-            # in cross disp axis, since this is a sum and all values in a col are
-            # the same.
-            bk_spec = background.bkg_spectrum(bkg_statistic=np.nansum)
-            np.testing.assert_allclose(bk_spec.flux.value, expected * img_size)
+            # test background spectrum matches 'expected'
+            bk_spec = background.bkg_spectrum()
+            np.testing.assert_allclose(bk_spec.flux.value, expected)
 
     def test_sub_bkg_image(self):
         """

--- a/specreduce/tests/test_background.py
+++ b/specreduce/tests/test_background.py
@@ -82,18 +82,11 @@ def test_background(
         assert np.isnan(bg.bkg_spectrum().flux).sum() == 0
         assert np.isnan(bg.sub_spectrum().flux).sum() == 0
 
-    bkg_spec_avg = bg1.bkg_spectrum(bkg_statistic="average")
+    bkg_spec_avg = bg1.bkg_spectrum(bkg_statistic=np.nanmean)
     assert_allclose(bkg_spec_avg.mean().value, 14.5, rtol=0.5)
 
-    bkg_spec_median = bg1.bkg_spectrum(bkg_statistic="median")
+    bkg_spec_median = bg1.bkg_spectrum(bkg_statistic=np.nanmedian)
     assert_allclose(bkg_spec_median.mean().value, 14.5, rtol=0.5)
-
-    with pytest.raises(
-        ValueError,
-        match="Background statistic max is not supported. "
-        "Please choose from: average, median, or sum.",
-    ):
-        bg1.bkg_spectrum(bkg_statistic="max")
 
 
 def test_warnings_errors(mk_test_spec_no_spectral_axis):


### PR DESCRIPTION
This PR continues the work done in #255 and #253, enabling the user to provide a custom callable for background calculation. The primary changes are:

- The `statistic` argument in the `Background` initializer now accepts `"average"`, `"median"`, or a custom callable. The callable should accept a `numpy.ma.MaskedArray` as input and must also support an `axis` argument.

- The `bkg_statistic` keyword in `Background.bkg_spectrum()` is now deprecated and triggers a warning if used. Instead, the `statistic` argument in the `Background` initializer should be used.

I'd prefer to include these changes in a bugfix release (v1.5.2), which is why I've opted to deprecate rather than remove the `bkg_statistic` argument. However, the current implementation ignores the `bkg_statistic` argument, meaning that although the API itself hasn't technically changed, the code's behaviour has.

Let me know your thoughts on this approach or if you have suggestions for handling this differently.