### PR TITLE
Specreduce V1.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,14 +1,14 @@
-1.7.0 (unreleased)
+1.7.0 (2025-11-13)
 ------------------
 
 New Features
 ^^^^^^^^^^^^
 
-- Added a ``disp_bounds`` argument to ``tracing.FitTrace``. The argument allows for adjusting the
-  dispersion-axis window from which the trace peaks are estimated.
 - Added a new ``specreduce.wavecal1d.WavelengthCalibration1D`` class for one-dimensional wavelength
   calibration. The old ``specreduce.wavelength_calibration.WavelengthCalibration1D`` is
   deprecated and will be removed in v. 2.0.
+- Added a ``disp_bounds`` argument to ``tracing.FitTrace``. The argument allows for adjusting the
+  dispersion-axis window from which the trace peaks are estimated.
 
 1.6.0 (2025-06-18)
 ------------------

--- a/specreduce/tests/test_wavesol1d.py
+++ b/specreduce/tests/test_wavesol1d.py
@@ -97,7 +97,7 @@ def test_resample(mk_spectrum, mk_ws_with_transform, mk_ws_without_transform):
         ws.resample(mk_spectrum)
 
     ws = mk_ws_with_transform
-    with pytest.raises(ValueError, match="Number of bins must be positive"):
+    with pytest.raises(ValueError, match="Number of bins must be non-zero and positive"):
         ws.resample(mk_spectrum, nbins=-5)
 
 

--- a/specreduce/wavesol1d.py
+++ b/specreduce/wavesol1d.py
@@ -187,7 +187,7 @@ class WavelengthSolution1D:
             1D spectrum binned to the specified wavelength bins.
         """
         if nbins is not None and nbins < 0:
-            raise ValueError("Number of bins must be positive.")
+            raise ValueError("Number of bins must be non-zero and positive.")
 
         if self._p2w is None:
             raise ValueError("Wavelength solution not set.")


### PR DESCRIPTION
This PR prepares Specreduce for the v1.7.0 release. The only changes are the addition of the release date in the changelog and a minor improvement to an error message suggested by @cshanahan1.