### PR TITLE
Update test and CI configuration to support python 3.14

### DIFF
--- a/.github/workflows/cron-tests.yml
+++ b/.github/workflows/cron-tests.yml
@@ -30,6 +30,6 @@ jobs:
         - name: Check URLs in docs
           linux: linkcheck
 
-        - name: Python 3.12 on Linux with pre-releases
-          linux: py312-test-alldeps-predeps
+        - name: Python 3.14 on Linux with pre-releases
+          linux: py314-test-alldeps-predeps
           toxargs: -v

--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -32,14 +32,18 @@ jobs:
         - name: Codestyle
           linux: codestyle
 
-        - name: Python 3.11 on Windows with oldest supported dependencies
-          windows: py311-test-oldestdeps
+        - name: Python 3.11 on Linux with oldest supported dependencies
+          linux: py311-test-oldestdeps
           toxargs: -v
 
-        - name: Python 3.11 on OSX with minimal dependencies
-          macos: py311-test
+        - name: Python 3.12 on OSX with minimal dependencies
+          macos: py312-test
           toxargs: -v
-        
+
+        - name: Python 3.12 on Windows with minimal dependencies
+          windows: py312-test
+          toxargs: -v
+
         - name: Python 3.12 on Linux with minimal dependencies
           linux: py312-test
           toxargs: -v

--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -44,13 +44,17 @@ jobs:
           linux: py312-test
           toxargs: -v
 
-        - name: Python 3.13 on Linux with all dependencies, remote data, and coverage
-          linux: py313-test-alldeps-cov
+        - name: Python 3.13 on Linux with minimal dependencies
+          linux: py313-test
+          toxargs: -v
+
+        - name: Python 3.14 on Linux with all dependencies, remote data, and coverage
+          linux: py314-test-alldeps-cov
           coverage: codecov
           toxargs: -v
           posargs: --remote-data=any
 
-        - name: (Allowed Failure) Python 3.13 on Linux with dev dependencies
-          linux: py313-test-devdeps-cov
+        - name: (Allowed Failure) Python 3.14 on Linux with dev dependencies
+          linux: py314-test-devdeps-cov
           coverage: codecov
           toxargs: -v

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ pip-wheel-metadata/
 
 # Mac OSX
 .DS_Store
+coverage.xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Specreduce is an Astropy coordinated package providing Python utilities for reducing and calibrating spectroscopic data. It offers modular, composable building blocks for spectral reduction workflows.
+
+## Common Commands
+
+### Testing
+```bash
+# Run all tests via tox
+tox -e py314-test
+
+# Run tests with coverage
+pytest --pyargs specreduce docs --cov specreduce --cov-config=pyproject.toml
+
+# Run a specific test file
+pytest specreduce/tests/test_background.py -v
+
+# Run tests with all optional dependencies
+tox -e py314-test-alldeps-cov
+```
+
+### Code Style
+```bash
+# Check code style
+tox -e codestyle
+
+# Direct flake8
+flake8 specreduce --count --extend-ignore E203
+```
+
+### Documentation
+```bash
+# Build HTML docs
+cd docs && make html
+
+# Or with sphinx directly
+sphinx-build -b html docs docs/_build/html
+```
+
+### Development Setup
+```bash
+pip install -e ".[test,docs,all]"
+```
+
+## Architecture
+
+The reduction workflow follows a modular pipeline: **Trace → Background → Extract → Wavelength Calibration → Flux Calibration**
+
+### Core Modules
+
+- **core.py**: Base class `SpecreduceOperation` and `_ImageParser` for image format coercion. Handles Spectrum1D, CCDData, NDData, Quantity, and ndarray inputs. Defines `MaskingOption` enum and masking strategies.
+
+- **tracing.py**: Trace determination classes
+  - `Trace`: Base trace (center of image)
+  - `FlatTrace`: Constant position trace
+  - `ArrayTrace`: Custom trace from array
+  - `FitTrace`: Fit trace to image features using peak detection (median, gaussian, centroid methods)
+
+- **background.py**: `Background` class with `two_sided()` and `one_sided()` methods for background estimation. Supports multiple traces and custom aperture definitions.
+
+- **extract.py**: 1D spectrum extraction
+  - `BoxcarExtract`: Simple aperture extraction
+  - `HorneExtract`/`OptimalExtract`: Optimal extraction with spatial profile fitting and variance propagation
+
+- **wavecal1d.py**: Current wavelength calibration implementation using `WavelengthCalibration1D`. Supports automated line matching, template matching, and produces GWCS-based WCS objects.
+
+- **wavelength_calibration.py**: Legacy wavelength calibration (deprecated in v1.7.0, removal in v2.0)
+
+- **fluxcal.py**: `FluxCalibration` class for flux calibration with magnitude-to-flux conversion and airmass extinction correction
+
+- **calibration_data.py**: Spectrophotometric standards and line lists
+
+- **utils/synth_data.py**: Synthetic spectroscopic data generation for testing
+
+- **compat.py**: Compatibility layer for specutils v1.x and v2.x
+
+### Key Design Patterns
+
+1. **Image Format Flexibility**: All operations accept multiple input formats via `_ImageParser`
+2. **Masking Strategies**: Seven masking options defined in `MaskingOption` enum
+3. **Astropy Integration**: Uses Astropy models, units, and conventions throughout
+4. **GWCS Support**: Wavelength calibration produces proper WCS objects
+
+## Dependencies
+
+- Python ≥3.11
+- Core: numpy≥1.24, astropy≥5.3, scipy≥1.10, specutils≥1.9.1, matplotlib≥3.10, gwcs
+- Optional: photutils≥1.0 (stellar profile fitting), synphot (synthetic photometry)
+
+## Code Style
+
+- Line length: 100 characters (flake8 and black)
+- Black formatter targeting Python 3.11+
+- Ignore E203 (whitespace before ':')

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -203,6 +203,12 @@ intersphinx_mapping.update(
 #     target = target.strip()
 #     nitpick_ignore.append((dtype, six.u(target)))
 
+# -- Nitpick exceptions -------------------------------------------------------
+# ArrayLike from numpy.typing is not properly resolved by intersphinx
+nitpick_ignore = [
+    ("py:class", "ArrayLike"),
+]
+
 # -- Options for linkcheck output -------------------------------------------
 linkcheck_retry = 5
 linkcheck_ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ build-backend = 'setuptools.build_meta'
 
 [tool.black]
 line-length = 100
-target-version = ['py311', 'py312', 'py313']
+target-version = ['py311', 'py312', 'py313', 'py314']
 
 [tool.pytest.ini_options]
 minversion = 7.0

--- a/specreduce/calibration_data.py
+++ b/specreduce/calibration_data.py
@@ -5,7 +5,7 @@ Utilities for defining, loading, and handling spectroscopic calibration data
 import warnings
 from pathlib import Path
 from typing import Sequence, Literal
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 
 from astropy import units as u
 from astropy.table import Table, vstack, QTable
@@ -164,6 +164,8 @@ def load_pypeit_calibration_lines(
                                           pkgname='specreduce')
                 linelists.append(Table.read(data_path, format='ascii.fixed_width', comment='#'))
             except URLError as e:
+                if isinstance(e, HTTPError):
+                    e.close()
                 warnings.warn(f"Downloading of {data_url} failed: {e}", AstropyUserWarning)
         else:
             warnings.warn(
@@ -224,6 +226,8 @@ def load_MAST_calspec(
                                       show_progress=show_progress,
                                       pkgname='specreduce')
         except URLError as e:
+            if isinstance(e, HTTPError):
+                e.close()
             warnings.warn(f"Downloading of {filename} failed: {e}", AstropyUserWarning)
             file_path = None
 
@@ -280,6 +284,8 @@ def load_onedstds(
                                   cache=cache, show_progress=show_progress, pkgname="specreduce")
         t = Table.read(data_path, format="ascii", names=['wavelength', 'ABmag', 'binsize'])
     except URLError as e:
+        if isinstance(e, HTTPError):
+            e.close()
         msg = f"Can't load {specfile} from {dataset}: {e}."
         warnings.warn(msg, AstropyUserWarning)
         return None

--- a/specreduce/tests/test_linelists.py
+++ b/specreduce/tests/test_linelists.py
@@ -1,6 +1,45 @@
+import warnings
+from unittest.mock import patch
+from urllib.error import HTTPError
+
 import pytest
 
 from specreduce.calibration_data import load_pypeit_calibration_lines
+
+
+def test_pypeit_download_httperror():
+    """
+    Test that HTTPError is properly handled and closed when download fails.
+    """
+
+    # Create a mock HTTPError that tracks if close() was called
+    mock_error = HTTPError(
+        url="http://example.com",
+        code=404,
+        msg="Not Found",
+        hdrs={},
+        fp=None
+    )
+    close_called = []
+    original_close = mock_error.close
+
+    def tracking_close():
+        close_called.append(True)
+        original_close()
+
+    mock_error.close = tracking_close
+
+    with patch('specreduce.calibration_data.download_file', side_effect=mock_error):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = load_pypeit_calibration_lines(['HeI'], cache=False)
+
+            # Check that we got the expected warnings
+            warning_messages = [str(warning.message) for warning in w]
+            assert any("Downloading of" in msg and "failed" in msg for msg in warning_messages)
+
+    assert result is None
+    assert len(close_called) == 1, "HTTPError.close() should have been called"
 
 
 @pytest.mark.remote_data

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{311,312,313}-test{,-alldeps}{,-oldestdeps,-devdeps,-predeps}{,-cov}
+    py{311,312,313,314}-test{,-alldeps}{,-oldestdeps,-devdeps,-predeps}{,-cov}
     linkcheck
     codestyle
 


### PR DESCRIPTION
I've been playing around with `claude code` and gave it a simple task of updating test and CI configuration to support the latest python, 3.14. The `CLAUDE.md` file that was generated by `claude /init` is also included. It captures the basics pretty well, but may require some fleshing out by hand if we wish to use `claude` more extensively. 