### PR TITLE
Background subtraction error propagation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
 sphinx:
   builder: html
   configuration: docs/conf.py
-  fail_on_warning: true
+  fail_on_warning: false
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ build:
   apt_packages:
     - graphviz
   tools:
-    python: "3.13"
+    python: "3.14"
 
 sphinx:
   builder: html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
 sphinx:
   builder: html
   configuration: docs/conf.py
-  fail_on_warning: false
+  fail_on_warning: true
 
 python:
   install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,14 @@ New Features
 
 - Added uncertainty propagation to ``specreduce.extract.BoxcarExtract`` and
   ``specreduce.extract.HorneExtract``. The extracted spectra have now proper uncertainties.
+- Added uncertainty propagation to ``specreduce.background.Background``. The
+  ``bkg_image()``, ``bkg_spectrum()``, ``sub_image()``, and ``sub_spectrum()`` methods
+  now return spectra with proper uncertainties. When input image has uncertainty, it is
+  propagated using variance formulas appropriate for the chosen statistic. When no
+  uncertainty is provided, it is estimated from the flux values in the background region.
+- Added optional ``sigma`` parameter to ``specreduce.background.Background`` for sigma
+  clipping outlier rejection in background estimation. Default is 5.0; set to ``None``
+  to disable.
 
 Other changes
 ^^^^^^^^^^^^^

--- a/docs/background.rst
+++ b/docs/background.rst
@@ -32,3 +32,40 @@ and the background-subtracted image via `~specreduce.background.Background.sub_i
 
 The background and trace steps can be done iteratively, to refine an automated
 trace using the background-subtracted image as input.
+
+Outlier rejection
+-----------------
+
+The background estimation supports sigma clipping for outlier rejection, which is useful
+for removing cosmic rays and other artifacts from the background region. The ``sigma``
+parameter controls the number of standard deviations used for clipping (default is 5.0).
+Set ``sigma=None`` to disable sigma clipping.
+
+.. code-block:: python
+
+  # Use tighter sigma clipping for aggressive outlier rejection
+  bg = Background.two_sided(image, trace, separation=5, width=4, sigma=3.0)
+
+  # Disable sigma clipping
+  bg = Background.two_sided(image, trace, separation=5, width=4, sigma=None)
+
+Uncertainty propagation
+-----------------------
+
+The `~specreduce.background.Background` class propagates uncertainties through
+background subtraction. When the input image is an `~astropy.nddata.NDData` object
+with ``image.uncertainty`` provided, the uncertainties are propagated using variance
+formulas appropriate for the chosen statistic (``average`` or ``median``). When no
+uncertainty is provided, it is estimated from the variance of flux values in the
+background region.
+
+The background image, background spectrum, and background-subtracted outputs all
+include proper uncertainties:
+
+.. code-block:: python
+
+  bg = Background.two_sided(image, trace, separation=5, width=4)
+
+  # Access background with uncertainty
+  bkg_spec = bg.bkg_spectrum()
+  print(bkg_spec.uncertainty)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -207,7 +207,8 @@ intersphinx_mapping.update(
 # ArrayLike from numpy.typing is not properly resolved by intersphinx
 nitpick_ignore = [
     ("py:class", "ArrayLike"),
-    ("py:class", "numpy._typing.ArrayLike")
+    ("py:class", "numpy._typing.ArrayLike"),
+    ("py:class", "specutils.spectra.spectrum1d.Spectrum1D"),
 ]
 
 # -- Options for linkcheck output -------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -207,6 +207,7 @@ intersphinx_mapping.update(
 # ArrayLike from numpy.typing is not properly resolved by intersphinx
 nitpick_ignore = [
     ("py:class", "ArrayLike"),
+    ("py:class", "numpy._typing.ArrayLike")
 ]
 
 # -- Options for linkcheck output -------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -211,6 +211,15 @@ nitpick_ignore = [
     ("py:class", "specutils.spectra.spectrum1d.Spectrum1D"),
 ]
 
+# Ignore complex type annotations that can't be cross-referenced
+# These come from autodoc processing dataclass fields with Literal, Union, and generic types
+nitpick_ignore_regex = [
+    (r"py:obj", r"typing\.Literal\[.*"),      # Literal types with string values
+    (r"py:class", r"tuple\[.*"),               # Generic tuple types
+    (r"py:class", r"None \| dict\[.*"),        # Union types with dict
+    (r"py:class", r"dict\[.*"),                # Generic dict types
+]
+
 # -- Options for linkcheck output -------------------------------------------
 linkcheck_retry = 5
 linkcheck_ignore = [

--- a/docs/extraction.rst
+++ b/docs/extraction.rst
@@ -44,6 +44,33 @@ flux is scaled according to the effective number of unmasked pixels. When using 
 options (``filter`` or ``omit``), the non-finite values may be propagated or treated
 differently as documented in the API.
 
+Uncertainty propagation
+-----------------------
+
+Both `~specreduce.extract.BoxcarExtract` and `~specreduce.extract.HorneExtract`
+propagate uncertainties from the input image to the extracted 1D spectrum.
+
+For the input image, uncertainties can be provided in two ways:
+
+1. As part of an `~astropy.nddata.NDData` object via ``image.uncertainty``
+2. Via the ``variance`` parameter (for HorneExtract)
+
+The extracted spectrum includes the propagated uncertainty, which can be accessed via
+the ``uncertainty`` attribute:
+
+.. code-block:: python
+
+  extract = BoxcarExtract(image, trace, width=5)
+  spectrum = extract.spectrum
+  print(spectrum.uncertainty)
+
+For `~specreduce.extract.BoxcarExtract`, the uncertainty is propagated through the
+weighted sum over the extraction aperture. For `~specreduce.extract.HorneExtract`,
+the optimal extraction algorithm naturally produces properly weighted uncertainties.
+
+Calling the extraction methods
+------------------------------
+
 The previous examples in this section show how to initialize the BoxcarExtract
 or HorneExtract objects with their required parameters. To extract the 1D
 spectrum

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -12,4 +12,8 @@ dependencies:
   - photutils
   - tox
   - sphinx-astropy
+  - sphinx-copybutton
+  - sphinx-design
+  - nbsphinx
+  - pydata-sphinx-theme
   - synphot

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -80,7 +80,7 @@ class Background(_ImageParser):
     disp_axis: int = 1
     crossdisp_axis: int = 0
     mask_treatment: MaskingOption = "apply"
-    sigma: float | None = 5.0
+    sigma: None | float = 5.0
     _valid_mask_treatment_methods = (
         "apply",
         "ignore",

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -32,7 +32,7 @@ class Background(_ImageParser):
     ----------
     image
         Image with 2-D spectral image data
-    traces : List, `specreduce.tracing.Trace`, int, float
+    traces
         Individual or list of trace object(s) (or integers/floats to define
         FlatTraces) to extract the background. If None, a ``FlatTrace`` at the
         center of the image (according to ``disp_axis``) will be used.
@@ -286,7 +286,6 @@ class Background(_ImageParser):
         Determine the background from an image for subtraction centered around
         an input trace.
 
-
         Example: ::
 
             trace = FitTrace(image, guess=trace_pos)
@@ -294,43 +293,24 @@ class Background(_ImageParser):
 
         Parameters
         ----------
-        image : `~astropy.nddata.NDData`-like or array-like
+        image
             Image with 2-D spectral image data. Assumes cross-dispersion
             (spatial) direction is axis 0 and dispersion (wavelength)
             direction is axis 1.
-        trace_object : `~specreduce.tracing.Trace`
-            estimated trace of the spectrum to center the background traces
-        separation : float
-            separation from ``trace_object`` for the background regions
-        width : float
-            width of each background aperture in pixels
-        statistic : string
-            statistic to use when computing the background.  'average' will
-            account for partial pixel weights, 'median' will include all partial
-            pixels.
-        disp_axis
-            dispersion axis
-        crossdisp_axis
-            cross-dispersion axis
-        mask_treatment
-            Specifies how to handle masked or non-finite values in the input image.
-            The accepted values are:
+        trace_object
+            Estimated trace of the spectrum to center the background traces.
+        separation
+            Separation from ``trace_object`` for the background regions.
+        **kwargs
+            Additional keyword arguments passed to the `Background` constructor.
+            See `Background` for available options including ``width``, ``statistic``,
+            ``disp_axis``, ``crossdisp_axis``, ``mask_treatment``, and ``sigma``.
 
-            - ``apply``: The image remains unchanged, and any existing mask is combined\
-                with a mask derived from non-finite values.
-            - ``ignore``: The image remains unchanged, and any existing mask is dropped.
-            - ``propagate``: The image remains unchanged, and any masked or non-finite pixel\
-                causes the mask to extend across the entire cross-dispersion axis.
-            - ``zero_fill``: Pixels that are either masked or non-finite are replaced with 0.0,\
-                and the mask is dropped.
-            - ``nan_fill``:  Pixels that are either masked or non-finite are replaced with nan,\
-                and the mask is dropped.
-            - ``apply_mask_only``: The  image and mask are left unmodified.
-            - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a\
-                new mask is created based on non-finite values.
-
+        Returns
+        -------
+        `Background`
+            A Background object with two-sided background regions.
         """
-
         image = _ImageParser._get_data_from_image(image) if image is not None else cls.image
         kwargs["traces"] = [trace_object - separation, trace_object + separation]
         return cls(image=image, **kwargs)
@@ -348,42 +328,24 @@ class Background(_ImageParser):
 
         Parameters
         ----------
-        image : `~astropy.nddata.NDData`-like or array-like
+        image
             Image with 2-D spectral image data. Assumes cross-dispersion
             (spatial) direction is axis 0 and dispersion (wavelength)
             direction is axis 1.
-        trace_object : `~specreduce.tracing.Trace`
-            Estimated trace of the spectrum to center the background traces
-        separation : float
-            Separation from ``trace_object`` for the background, positive will be
+        trace_object
+            Estimated trace of the spectrum to center the background trace.
+        separation
+            Separation from ``trace_object`` for the background. Positive will be
             above the trace, negative below.
-        width : float
-            Width of each background aperture in pixels
-        statistic : string
-            Statistic to use when computing the background.  'average' will
-            account for partial pixel weights, 'median' will include all partial
-            pixels.
-        disp_axis : int
-            Dispersion axis
-        crossdisp_axis : int
-            Cross-dispersion axis
-        mask_treatment
-            Specifies how to handle masked or non-finite values in the input image.
-            The accepted values are:
+        **kwargs
+            Additional keyword arguments passed to the `Background` constructor.
+            See `Background` for available options including ``width``, ``statistic``,
+            ``disp_axis``, ``crossdisp_axis``, ``mask_treatment``, and ``sigma``.
 
-            - ``apply``: The image remains unchanged, and any existing mask is combined\
-                with a mask derived from non-finite values.
-            - ``ignore``: The image remains unchanged, and any existing mask is dropped.
-            - ``propagate``: The image remains unchanged, and any masked or non-finite pixel\
-                causes the mask to extend across the entire cross-dispersion axis.
-            - ``zero_fill``: Pixels that are either masked or non-finite are replaced with 0.0,\
-                and the mask is dropped.
-            - ``nan_fill``:  Pixels that are either masked or non-finite are replaced with nan,\
-                and the mask is dropped.
-            - ``apply_mask_only``: The  image and mask are left unmodified.
-            - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a\
-                new mask is created based on non-finite values.
-
+        Returns
+        -------
+        `Background`
+            A Background object with a one-sided background region.
         """
         image = _ImageParser._get_data_from_image(image) if image is not None else cls.image
         kwargs["traces"] = [trace_object + separation]
@@ -427,15 +389,18 @@ class Background(_ImageParser):
 
         Parameters
         ----------
-        image : `~astropy.nddata.NDData`-like or array-like, optional
+        image
             Image with 2D spectral image data. Assumes cross-dispersion
             (spatial) direction is axis 0 and dispersion (wavelength)
             direction is axis 1. If None, will extract the background
-            from ``image`` used to initialize the class. [default: None]
+            from ``image`` used to initialize the class.
+        bkg_statistic
+            Deprecated. Use ``statistic`` parameter in the `Background`
+            constructor instead.
 
         Returns
         -------
-        spec : `~specutils.Spectrum`
+        `~specutils.Spectrum1D`
             The background 1D spectrum, with flux and uncertainty expressed
             in the same units as the input image (or DN if none were provided).
         """
@@ -459,14 +424,16 @@ class Background(_ImageParser):
 
         Parameters
         ----------
-        image : nddata-compatible image or None
-            image with 2D spectral image data.  If None, will extract
-            the background from ``image`` used to initialize the class.
+        image
+            `~astropy.nddata.NDData`-like or array-like 2D spectral image data.
+            If None, will extract the background from ``image`` used to
+            initialize the class.
 
         Returns
         -------
-        spec : `~specutils.Spectrum`
-            Spectrum object with same shape as ``image``.
+        `~specutils.Spectrum`
+            Spectrum object with same shape as ``image``, including propagated
+            uncertainty.
         """
         image = self._parse_image(image)
 
@@ -524,5 +491,15 @@ class Background(_ImageParser):
     def __rsub__(self, image):
         """
         Subtract the background from an image.
+
+        Parameters
+        ----------
+        image
+            `~astropy.nddata.NDData`-like or array-like 2D spectral image data.
+
+        Returns
+        -------
+        `~specutils.Spectrum`
+            Background-subtracted image with propagated uncertainty.
         """
         return self.sub_image(image)

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -177,7 +177,7 @@ class Background(_ImageParser):
 
         if self.traces == []:
             # assume a flat trace at the image center if nothing is passed in.
-            trace_pos = self.image.shape[self.disp_axis] / 2.0
+            trace_pos = self.image.shape[self.crossdisp_axis] / 2.0
             self.traces = [FlatTrace(self.image, trace_pos)]
 
         if isinstance(self.traces, Trace):

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -284,16 +284,21 @@ class Background(_ImageParser):
         crossdisp_axis : int
             cross-dispersion axis
         mask_treatment : string
-            The method for handling masked or non-finite data. Choice of ``filter``,
-            ``omit`, or ``zero_fill``. If `filter` is chosen, masked/non-finite data
-            will be filtered during the fit to each bin/column (along disp. axis) to
-            find the peak. If ``omit`` is chosen, columns along disp_axis with any
-            masked/non-finite data values will be fully masked (i.e, 2D mask is
-            collapsed to 1D and applied). If ``zero_fill`` is chosen, masked/non-finite
-            data will be replaced with 0.0 in the input image, and the mask will then
-            be dropped. For all three options, the input mask (optional on input
-            NDData object) will be combined with a mask generated from any non-finite
-            values in the image data.
+            Specifies how to handle masked or non-finite values in the input image.
+            The accepted values are:
+
+            - ``apply``: The image remains unchanged, and any existing mask is combined\
+                with a mask derived from non-finite values.
+            - ``ignore``: The image remains unchanged, and any existing mask is dropped.
+            - ``propagate``: The image remains unchanged, and any masked or non-finite pixel\
+                causes the mask to extend across the entire cross-dispersion axis.
+            - ``zero_fill``: Pixels that are either masked or non-finite are replaced with 0.0,\
+                and the mask is dropped.
+            - ``nan_fill``:  Pixels that are either masked or non-finite are replaced with nan,\
+                and the mask is dropped.
+            - ``apply_mask_only``: The  image and mask are left unmodified.
+            - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a\
+                new mask is created based on non-finite values.
         """
 
         image = _ImageParser._get_data_from_image(image) if image is not None else cls.image
@@ -333,16 +338,21 @@ class Background(_ImageParser):
         crossdisp_axis : int
             Cross-dispersion axis
         mask_treatment : string
-            The method for handling masked or non-finite data. Choice of ``filter``,
-            ``omit``, or ``zero_fill``. If `filter` is chosen, masked/non-finite data
-            will be filtered during the fit to each bin/column (along disp. axis) to
-            find the peak. If ``omit`` is chosen, columns along disp_axis with any
-            masked/non-finite data values will be fully masked (i.e, 2D mask is
-            collapsed to 1D and applied). If ``zero_fill`` is chosen, masked/non-finite
-            data will be replaced with 0.0 in the input image, and the mask will then
-            be dropped. For all three options, the input mask (optional on input
-            NDData object) will be combined with a mask generated from any non-finite
-            values in the image data.
+            Specifies how to handle masked or non-finite values in the input image.
+            The accepted values are:
+
+            - ``apply``: The image remains unchanged, and any existing mask is combined\
+                with a mask derived from non-finite values.
+            - ``ignore``: The image remains unchanged, and any existing mask is dropped.
+            - ``propagate``: The image remains unchanged, and any masked or non-finite pixel\
+                causes the mask to extend across the entire cross-dispersion axis.
+            - ``zero_fill``: Pixels that are either masked or non-finite are replaced with 0.0,\
+                and the mask is dropped.
+            - ``nan_fill``:  Pixels that are either masked or non-finite are replaced with nan,\
+                and the mask is dropped.
+            - ``apply_mask_only``: The  image and mask are left unmodified.
+            - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a\
+                new mask is created based on non-finite values.
         """
         image = _ImageParser._get_data_from_image(image) if image is not None else cls.image
         kwargs["traces"] = [trace_object + separation]

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -308,11 +308,11 @@ class Background(_ImageParser):
             statistic to use when computing the background.  'average' will
             account for partial pixel weights, 'median' will include all partial
             pixels.
-        disp_axis : int
+        disp_axis
             dispersion axis
-        crossdisp_axis : int
+        crossdisp_axis
             cross-dispersion axis
-        mask_treatment : string
+        mask_treatment
             Specifies how to handle masked or non-finite values in the input image.
             The accepted values are:
 
@@ -328,6 +328,7 @@ class Background(_ImageParser):
             - ``apply_mask_only``: The  image and mask are left unmodified.
             - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a\
                 new mask is created based on non-finite values.
+
         """
 
         image = _ImageParser._get_data_from_image(image) if image is not None else cls.image
@@ -366,7 +367,7 @@ class Background(_ImageParser):
             Dispersion axis
         crossdisp_axis : int
             Cross-dispersion axis
-        mask_treatment : string
+        mask_treatment
             Specifies how to handle masked or non-finite values in the input image.
             The accepted values are:
 
@@ -382,6 +383,7 @@ class Background(_ImageParser):
             - ``apply_mask_only``: The  image and mask are left unmodified.
             - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a\
                 new mask is created based on non-finite values.
+
         """
         image = _ImageParser._get_data_from_image(image) if image is not None else cls.image
         kwargs["traces"] = [trace_object + separation]

--- a/specreduce/tests/test_background.py
+++ b/specreduce/tests/test_background.py
@@ -131,7 +131,7 @@ def test_trace_inputs(mk_test_img_raw):
     # When `Background` object is created with no Trace object passed in it should
     # create a FlatTrace in the middle of the image (according to disp. axis)
     background = Background(image, width=5)
-    assert np.all(background.traces[0].trace.data == image.shape[1] / 2.0)
+    assert np.all(background.traces[0].trace.data == image.shape[0] / 2.0)
 
     # FlatTrace(s) should be created if number or list of numbers is passed in for `traces`
     background = Background(image, 10.0, width=5)


### PR DESCRIPTION
This PR adds uncertainty propagation to the `Background` class and introduces sigma clipping for outlier rejection in background estimation. It also adds tests for the functionality and updates the documentation.

## New Features

### Uncertainty Propagation

The `Background` class now computes and propagates uncertainties through all background operations:

- **`bkg_image()`** - Returns background image with uncertainty
- **`bkg_spectrum()`** - Returns 1D background spectrum with uncertainty
- **`sub_image()`** - Returns background-subtracted image with propagated uncertainty
- **`sub_spectrum()`** - Returns background-subtracted 1D spectrum with propagated uncertainty

#### Variance Calculation

For the `average` statistic:
```
Var(weighted_mean) = Σ(w² × σ²) / (Σw)²
```

For the `median` statistic:
```
Var(median) ≈ (π/2) × σ² / n
```

#### Automatic Variance Estimation

When input image has no uncertainty provided, variance is automatically estimated from the sample variance of flux values in the background region.

#### Uncertainty Type Preservation

The output uncertainty type matches the input:
- `VarianceUncertainty` → `VarianceUncertainty`
- `StdDevUncertainty` → `StdDevUncertainty`
- `InverseVariance` → `InverseVariance`

### Sigma Clipping for Outlier Rejection

Added optional `sigma` parameter for sigma clipping to reject cosmic rays and other outliers in the background region:

```python
# Default: sigma=5.0
bg = Background.two_sided(image, trace, separation=5, width=4)

# Tighter clipping for aggressive outlier rejection
bg = Background.two_sided(image, trace, separation=5, width=4, sigma=3.0)

# Disable sigma clipping
bg = Background.two_sided(image, trace, separation=5, width=4, sigma=None)
```

The outlier mask is stored separately in `_outlier_mask` and does not modify the original image mask.

## Bug Fixes

- Fixed incorrect axis reference in trace position calculation: now correctly uses `crossdisp_axis` instead of `disp_axis` when computing default trace position.

## Documentation

- Updated `docs/background.rst` with new sections on outlier rejection and uncertainty propagation
- Updated `docs/extraction.rst` with uncertainty propagation documentation
- Updated `CHANGES.rst` changelog
