### PR TITLE
Image parsing refactor

### DIFF
--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -10,7 +10,7 @@ from astropy.stats import sigma_clip
 from astropy.utils.decorators import deprecated_attribute
 
 from specutils import Spectrum
-from specreduce.core import _ImageParser, MaskingOption, ImageLike
+from specreduce.core import parse_image, MaskingOption, ImageLike
 from specreduce.extract import _ap_weight_image
 from specreduce.tracing import Trace, FlatTrace
 
@@ -18,7 +18,7 @@ __all__ = ["Background"]
 
 
 @dataclass
-class Background(_ImageParser):
+class Background:
     """
     Determine the background from an image for subtraction.
 
@@ -95,7 +95,7 @@ class Background(_ImageParser):
     bkg_array = deprecated_attribute("bkg_array", "1.3")
 
     def __post_init__(self):
-        self.image = self._parse_image(
+        self.image = parse_image(
             self.image, disp_axis=self.disp_axis, mask_treatment=self.mask_treatment
         )
 
@@ -311,7 +311,7 @@ class Background(_ImageParser):
         `Background`
             A Background object with two-sided background regions.
         """
-        image = _ImageParser._get_data_from_image(image) if image is not None else cls.image
+        image = parse_image(image) if image is not None else cls.image
         kwargs["traces"] = [trace_object - separation, trace_object + separation]
         return cls(image=image, **kwargs)
 
@@ -347,7 +347,7 @@ class Background(_ImageParser):
         `Background`
             A Background object with a one-sided background region.
         """
-        image = _ImageParser._get_data_from_image(image) if image is not None else cls.image
+        image = parse_image(image) if image is not None else cls.image
         kwargs["traces"] = [trace_object + separation]
         return cls(image=image, **kwargs)
 
@@ -368,7 +368,7 @@ class Background(_ImageParser):
         spec : `~specutils.Spectrum`
             Spectrum object with same shape as ``image``, including uncertainty.
         """
-        image = self._parse_image(image)
+        image = parse_image(image) if image is not None else self.image
         arr = np.tile(self._bkg_array, (image.shape[0], 1))
         var_arr = np.tile(self._bkg_variance, (image.shape[0], 1))
         uncertainty = VarianceUncertainty(var_arr * self._variance_unit).represent_as(
@@ -432,7 +432,7 @@ class Background(_ImageParser):
             Spectrum object with same shape as ``image``, including propagated
             uncertainty.
         """
-        image = self._parse_image(image)
+        image = parse_image(image) if image is not None else self.image
         return image - self.bkg_image(image)
 
     def sub_spectrum(self, image=None) -> Spectrum:

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -11,7 +11,7 @@ from astropy.nddata import VarianceUncertainty, NDData
 
 from specutils import Spectrum
 
-__all__ = ["SpecreduceOperation"]
+__all__ = ["SpecreduceOperation", "parse_image"]
 
 MaskingOption = Literal[
     "apply", "ignore", "propagate", "zero_fill", "nan_fill", "apply_mask_only", "apply_nan_only"
@@ -19,210 +19,158 @@ MaskingOption = Literal[
 
 ImageLike = np.ndarray | NDData | u.Quantity
 
+# The '_valid_mask_treatment_methods' tuples in the Background, Trace, and
+# Extract classes are subsets of these implemented methods.
+_IMPLEMENTED_MASK_TREATMENTS = (
+    "apply",
+    "ignore",
+    "propagate",
+    "zero_fill",
+    "nan_fill",
+    "apply_mask_only",
+    "apply_nan_only",
+)
 
-class _ImageParser:
+
+def parse_image(
+    image: ImageLike, disp_axis: int = 1, mask_treatment: MaskingOption = "apply"
+) -> Spectrum:
     """
-    Coerces images from accepted formats to Spectrum objects for
-    internal use in specreduce's operation classes.
+    Convert all accepted image types to a consistently formatted Spectrum object.
 
-    Fills any and all of uncertainty, mask, units, and spectral axis
-    that are missing in the provided image with generic values.
-    Accepted image types are:
+    Fills any and all of uncertainty, mask, units, and spectral axis that are
+    missing in the provided image with generic values. Accepted image types are:
 
         - `~specutils.Spectrum` (preferred)
         - `~astropy.nddata.ccddata.CCDData`
         - `~astropy.nddata.ndddata.NDDData`
         - `~astropy.units.quantity.Quantity`
         - `~numpy.ndarray`
-    """
 
-    # The '_valid_mask_treatment_methods' in the Background, Trace, and Extract
-    # classes is a subset of implemented methods.
-    implemented_mask_treatment_methods = (
-        "apply",
-        "ignore",
-        "propagate",
-        "zero_fill",
-        "nan_fill",
-        "apply_mask_only",
-        "apply_nan_only",
+    Parameters
+    ----------
+    image
+        Input image from which data is extracted. This can be a 2D numpy
+        array, Quantity, or an NDData object.
+    disp_axis
+        The index of the image's dispersion axis. Should not be changed until
+        operations can handle variable image orientations.
+    mask_treatment
+        Specifies how to handle masked or non-finite values in the input image.
+        The accepted values are:
+
+        - ``apply``: The image remains unchanged, and any existing mask is combined\
+            with a mask derived from non-finite values.
+        - ``ignore``: The image remains unchanged, and any existing mask is dropped.
+        - ``propagate``: The image remains unchanged, and any masked or non-finite pixel\
+            causes the mask to extend across the entire cross-dispersion axis.
+        - ``zero_fill``: Pixels that are either masked or non-finite are replaced with 0.0,\
+            and the mask is dropped.
+        - ``nan_fill``:  Pixels that are either masked or non-finite are replaced with nan,\
+            and the mask is dropped.
+        - ``apply_mask_only``: The  image and mask are left unmodified.
+        - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a\
+            new mask is created based on non-finite values.
+
+    Returns
+    -------
+    Spectrum
+    """
+    if isinstance(image, u.quantity.Quantity):
+        img = image.value
+    elif isinstance(image, np.ndarray):
+        img = image
+    else:  # NDData, including CCDData and Spectrum
+        img = image.data
+
+    mask = getattr(image, "mask", None)
+    crossdisp_axis = (disp_axis + 1) % 2
+
+    # A mask is built from any non-finite image data, combined with any existing
+    # mask. If a fill value is chosen the image data is also modified. The
+    # returned Spectrum always carries a mask, even if everything is finite.
+    img, mask = _apply_mask_treatment(
+        image=img, mask=mask, mask_treatment=mask_treatment, crossdisp_axis=crossdisp_axis
     )
 
-    def _parse_image(
-        self, image: ImageLike, disp_axis: int = 1, mask_treatment: MaskingOption = "apply"
-    ) -> Spectrum:
-        """
-        Convert all accepted image types to a consistently formatted Spectrum object.
+    # mask and uncertainty default to None on a Spectrum, so test for both
+    # absence of the attribute and presence-with-None.
+    if hasattr(image, "uncertainty"):
+        uncertainty = image.uncertainty
+    else:
+        uncertainty = VarianceUncertainty(np.ones(img.shape))
 
-        Parameters
-        ----------
-        image : `~astropy.nddata.NDData`-like or array-like
-            The image to be parsed. If None, defaults to class' own
-            image attribute.
-        disp_axis
-            The index of the image's dispersion axis. Should not be
-            changed until operations can handle variable image
-            orientations.
-        mask_treatment
-            Specifies how to handle masked or non-finite values in the input image.
-            The accepted values are:
+    unit = getattr(image, "unit", u.Unit("DN"))
 
-            - ``apply``: The image remains unchanged, and any existing mask is combined\
-                with a mask derived from non-finite values.
-            - ``ignore``: The image remains unchanged, and any existing mask is dropped.
-            - ``propagate``: The image remains unchanged, and any masked or non-finite pixel\
-                causes the mask to extend across the entire cross-dispersion axis.
-            - ``zero_fill``: Pixels that are either masked or non-finite are replaced with 0.0,\
-                and the mask is dropped.
-            - ``nan_fill``:  Pixels that are either masked or non-finite are replaced with nan,\
-                and the mask is dropped.
-            - ``apply_mask_only``: The  image and mask are left unmodified.
-            - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a\
-                new mask is created based on non-finite values.
+    spectral_axis = getattr(image, "spectral_axis", np.arange(img.shape[disp_axis]) * u.pix)
 
-        Returns
-        -------
-        Spectrum
-        """
-        # would be nice to handle (cross)disp_axis consistently across
-        # operations (public attribute? private attribute? argument only?) so
-        # it can be called from self instead of via kwargs...
+    return Spectrum(
+        img * unit, spectral_axis=spectral_axis, uncertainty=uncertainty, mask=mask,
+        spectral_axis_index=img.ndim - 1
+    )
 
-        if image is None:
-            # useful for Background's instance methods
-            return self.image
 
-        return self._get_data_from_image(image, disp_axis=disp_axis, mask_treatment=mask_treatment)
+def _apply_mask_treatment(
+    image: np.ndarray,
+    mask: np.ndarray | None = None,
+    mask_treatment: MaskingOption = "apply",
+    crossdisp_axis: int = 1,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Handle the treatment of masked and non-finite data.
 
-    @staticmethod
-    def _get_data_from_image(
-        image: ImageLike, disp_axis: int = 1, mask_treatment: MaskingOption = "apply"
-    ) -> Spectrum:
-        """
-        Extract data array from various input types for `image`.
-
-        Parameters
-        ----------
-        image
-            Input image from which data is extracted. This can be a 2D numpy
-            array, Quantity, or an NDData object.
-        disp_axis
-            The dispersion axis of the image.
-        mask_treatment
-            Specifies how to handle masked or non-finite values in the input image.
-
-        Returns
-        -------
-        Spectrum
-        """
-        if isinstance(image, u.quantity.Quantity):
-            img = image.value
-        elif isinstance(image, np.ndarray):
-            img = image
-        else:  # NDData, including CCDData and Spectrum
-            img = image.data
-
-        mask = getattr(image, "mask", None)
-        crossdisp_axis = (disp_axis + 1) % 2
-
-        # next, handle masked and non-finite data in image.
-        # A mask will be created from any non-finite image data, and combined
-        # with any additional 'mask' passed in. If image is being parsed within
-        # a specreduce operation that has 'mask_treatment' options, this will be
-        # handled as well. Note that input data may be modified if a fill value
-        # is chosen to handle masked data. The returned image will always have
-        # `image.mask` even if there are no non-finite or masked values.
-        img, mask = _ImageParser._mask_and_nonfinite_data_handling(
-            image=img, mask=mask, mask_treatment=mask_treatment, crossdisp_axis=crossdisp_axis
+    Parameters
+    ----------
+    image
+        The input image data array that may contain non-finite values.
+    mask
+        An optional Boolean mask array. Non-finite values in the image will be
+        added to this mask.
+    mask_treatment
+        Specifies how to handle masked or non-finite values in the input image.
+    crossdisp_axis
+        Cross-dispersion axis, used for the ``propagate`` treatment.
+    """
+    if mask_treatment not in _IMPLEMENTED_MASK_TREATMENTS:
+        raise ValueError(
+            f"'mask_treatment' must be one of {_IMPLEMENTED_MASK_TREATMENTS}"
         )
 
-        # mask (handled above) and uncertainty are set as None when they aren't
-        # specified upon creating a Spectrum object, so we must check whether
-        # these attributes are absent *and* whether they are present but set as None
-        if hasattr(image, "uncertainty"):
-            uncertainty = image.uncertainty
-        else:
-            uncertainty = VarianceUncertainty(np.ones(img.shape))
+    if mask is not None and (mask.dtype not in (bool, int)):
+        raise ValueError("'mask' must be a boolean or integer array.")
 
-        unit = getattr(image, "unit", u.Unit("DN"))
-
-        spectral_axis = getattr(image, "spectral_axis", np.arange(img.shape[disp_axis]) * u.pix)
-
-        img = Spectrum(
-            img * unit, spectral_axis=spectral_axis, uncertainty=uncertainty, mask=mask,
-            spectral_axis_index=img.ndim - 1
-        )
-        return img
-
-    @staticmethod
-    def _mask_and_nonfinite_data_handling(
-        image: ImageLike,
-        mask: ImageLike | None = None,
-        mask_treatment: str = "apply",
-        crossdisp_axis: int = 1,
-    ) -> tuple[np.ndarray, np.ndarray]:
-        """
-        Handle the treatment of masked and non-finite data.
-
-        All operations in Specreduce can take in a mask for the data as
-        part of the input NDData.
-
-        There are five options currently implemented for the treatment
-        of masked and non-finite data - apply, ignore, zero_fill, nan_fill,
-        apply_mask_only, and apply_nan_only. Depending on the routine,
-        all or a subset of these three options are valid.
-
-        Parameters
-        ----------
-        image : array-like
-            The input image data array that may contain non-finite values.
-        mask : array-like of bool or None
-            An optional Boolean mask array. Non-finite values in the image will be added
-            to this mask.
-        mask_treatment
-            Specifies how to handle masked or non-finite values in the input image.
-        """
-        if mask_treatment not in _ImageParser.implemented_mask_treatment_methods:
-            raise ValueError(
-                "'mask_treatment' must be one of "
-                f"{_ImageParser.implemented_mask_treatment_methods}"
-            )
-
-        if mask is not None and (mask.dtype not in (bool, int)):
-            raise ValueError("'mask' must be a boolean or integer array.")
-
-        match mask_treatment:
-            case "apply":
-                mask = mask | (~np.isfinite(image)) if mask is not None else ~np.isfinite(image)
-            case "ignore":
-                mask = np.zeros(image.shape, dtype=bool)
-            case "propagate":
-                if mask is None:
-                    mask = ~np.isfinite(image)
-                else:
-                    mask = mask | (~np.isfinite(image))
-                mask[:] = mask.any(axis=crossdisp_axis, keepdims=True)
-            case "zero_fill" | "nan_fill":
-                mask = mask | (~np.isfinite(image)) if mask is not None else ~np.isfinite(image)
-                image = deepcopy(image)
-                if mask_treatment == "zero_fill":
-                    image[mask] = 0.0
-                else:
-                    image[mask] = np.nan
-                mask[:] = False
-            case "apply_nan_only":
+    match mask_treatment:
+        case "apply":
+            mask = mask | (~np.isfinite(image)) if mask is not None else ~np.isfinite(image)
+        case "ignore":
+            mask = np.zeros(image.shape, dtype=bool)
+        case "propagate":
+            if mask is None:
                 mask = ~np.isfinite(image)
-            case "apply_mask_only":
-                mask = mask.copy() if mask is not None else np.zeros(image.shape, dtype=bool)
+            else:
+                mask = mask | (~np.isfinite(image))
+            mask[:] = mask.any(axis=crossdisp_axis, keepdims=True)
+        case "zero_fill" | "nan_fill":
+            mask = mask | (~np.isfinite(image)) if mask is not None else ~np.isfinite(image)
+            image = deepcopy(image)
+            if mask_treatment == "zero_fill":
+                image[mask] = 0.0
+            else:
+                image[mask] = np.nan
+            mask[:] = False
+        case "apply_nan_only":
+            mask = ~np.isfinite(image)
+        case "apply_mask_only":
+            mask = mask.copy() if mask is not None else np.zeros(image.shape, dtype=bool)
 
-        if mask.all():
-            raise ValueError("Image is fully masked. Check for invalid values.")
+    if mask.all():
+        raise ValueError("Image is fully masked. Check for invalid values.")
 
-        return image, mask
+    return image, mask
 
 
 @dataclass
-class SpecreduceOperation(_ImageParser):
+class SpecreduceOperation:
     """
     An operation to perform as part of a spectroscopic reduction pipeline.
 

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -43,7 +43,7 @@ def parse_image(
 
         - `~specutils.Spectrum` (preferred)
         - `~astropy.nddata.CCDData`
-        - `~astropy.nddata.NDDData`
+        - `~astropy.nddata.NDData`
         - `~astropy.units.quantity.Quantity`
         - `~numpy.ndarray`
 
@@ -66,10 +66,10 @@ def parse_image(
             causes the mask to extend across the entire cross-dispersion axis.
         - ``zero_fill``: Pixels that are either masked or non-finite are replaced with 0.0,\
             and the mask is dropped.
-        - ``nan_fill``:  Pixels that are either masked or non-finite are replaced with nan,\
+        - ``nan_fill``: Pixels that are either masked or non-finite are replaced with nan,\
             and the mask is dropped.
-        - ``apply_mask_only``: The  image and mask are left unmodified.
-        - ``apply_nan_only``: The  image is left unmodified, the old mask is dropped, and a\
+        - ``apply_mask_only``: The image and mask are left unmodified.
+        - ``apply_nan_only``: The image is left unmodified, the old mask is dropped, and a\
             new mask is created based on non-finite values.
 
     Returns

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -19,7 +19,7 @@ MaskingOption = Literal[
 
 ImageLike = np.ndarray | NDData | u.Quantity
 
-# The '_valid_mask_treatment_methods' tuples in the Background, Trace, and
+# The '_valid_mask_treatment_methods' tuples in the Background, Trace, and nddata
 # Extract classes are subsets of these implemented methods.
 _IMPLEMENTED_MASK_TREATMENTS = (
     "apply",
@@ -42,8 +42,8 @@ def parse_image(
     missing in the provided image with generic values. Accepted image types are:
 
         - `~specutils.Spectrum` (preferred)
-        - `~astropy.nddata.ccddata.CCDData`
-        - `~astropy.nddata.ndddata.NDDData`
+        - `~astropy.nddata.CCDData`
+        - `~astropy.nddata.NDDData`
         - `~astropy.units.quantity.Quantity`
         - `~numpy.ndarray`
 

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -12,7 +12,7 @@ from scipy.integrate import trapezoid
 from scipy.interpolate import RectBivariateSpline
 
 from specutils import Spectrum
-from specreduce.core import SpecreduceOperation, ImageLike, MaskingOption
+from specreduce.core import SpecreduceOperation, ImageLike, MaskingOption, parse_image
 from specreduce.tracing import Trace, FlatTrace
 
 __all__ = ["BoxcarExtract", "HorneExtract", "OptimalExtract"]
@@ -232,7 +232,7 @@ class BoxcarExtract(SpecreduceOperation):
         if width <= 0:
             raise ValueError("The window width must be positive")
 
-        self.image = self._parse_image(
+        self.image = parse_image(
             image, disp_axis=disp_axis, mask_treatment=self.mask_treatment
         )
 

--- a/specreduce/tests/test_image_parsing.py
+++ b/specreduce/tests/test_image_parsing.py
@@ -2,7 +2,7 @@ import numpy as np
 from astropy import units as u
 
 from specutils import Spectrum
-from specreduce.core import _ImageParser
+from specreduce.core import parse_image
 from specreduce.extract import HorneExtract
 from specreduce.tracing import FlatTrace
 
@@ -50,7 +50,7 @@ def compare_images(all_images, key, collection, compare='s1d'):
 # test consistency of general image parser results
 def test_parse_general(all_images):
 
-    all_images_parsed = {k: _ImageParser()._parse_image(im)
+    all_images_parsed = {k: parse_image(im)
                          for k, im in all_images.items()}
     for key in all_images_parsed.keys():
         compare_images(all_images, key, all_images_parsed)
@@ -68,7 +68,7 @@ def test_parse_horne(all_images):
 
     for key, col in images_collection.items():
         img = all_images[key]
-        col['general'] = _ImageParser()._parse_image(img)
+        col['general'] = parse_image(img)
 
         if hasattr(all_images[key], 'uncertainty'):
             defaults = {}

--- a/specreduce/tests/test_mask_treatment.py
+++ b/specreduce/tests/test_mask_treatment.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from astropy.units import DN
 from astropy.nddata import NDData
-from specreduce.core import _ImageParser
+from specreduce.core import parse_image
 
 
 def mk_image():
@@ -19,26 +19,26 @@ def mk_image():
 def test_bad_option():
     image = mk_image()
     with pytest.raises(ValueError, match="'mask_treatment' must be one of"):
-        _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="bad")
+        parse_image(image, disp_axis=1, mask_treatment="bad")
 
 
 def test_bad_mask_type():
     image = mk_image()
     image.mask = image.mask.astype(float)
     with pytest.raises(ValueError, match="'mask' must be a boolean or integer array."):
-        _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="apply")
+        parse_image(image, disp_axis=1, mask_treatment="apply")
 
 
 def test_apply():
     image = mk_image()
-    parsed_image = _ImageParser()._parse_image(deepcopy(image), disp_axis=1, mask_treatment="apply")
+    parsed_image = parse_image(deepcopy(image), disp_axis=1, mask_treatment="apply")
     np.testing.assert_array_equal(parsed_image.data, image.data)
     mask_true = np.zeros(image.data.shape, dtype=bool)
     mask_true[[0, 1, 1], [1, 0, 3]] = 1
     np.testing.assert_array_equal(parsed_image.mask, mask_true)
 
     image.mask = None
-    parsed_image = _ImageParser()._parse_image(deepcopy(image), disp_axis=1, mask_treatment="apply")
+    parsed_image = parse_image(deepcopy(image), disp_axis=1, mask_treatment="apply")
     np.testing.assert_array_equal(parsed_image.data, image.data)
     mask_true = np.zeros(image.data.shape, dtype=bool)
     mask_true[1, 3] = 1
@@ -47,13 +47,13 @@ def test_apply():
 
 def test_ignore():
     image = mk_image()
-    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="ignore")
+    parsed_image = parse_image(image, disp_axis=1, mask_treatment="ignore")
     np.testing.assert_array_equal(parsed_image.data, image.data)
     mask_true = np.zeros(image.data.shape, dtype=bool)
     np.testing.assert_array_equal(parsed_image.mask, mask_true)
 
     image.mask = None
-    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="ignore")
+    parsed_image = parse_image(image, disp_axis=1, mask_treatment="ignore")
     np.testing.assert_array_equal(parsed_image.data, image.data)
     mask_true = np.zeros(image.data.shape, dtype=bool)
     np.testing.assert_array_equal(parsed_image.mask, mask_true)
@@ -61,14 +61,14 @@ def test_ignore():
 
 def test_propagate():
     image = mk_image()
-    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="propagate")
+    parsed_image = parse_image(image, disp_axis=1, mask_treatment="propagate")
     np.testing.assert_array_equal(parsed_image.data, image.data)
     mask_true = np.zeros(image.data.shape, dtype=bool)
     mask_true[:, [0, 1, 3]] = 1
     np.testing.assert_array_equal(parsed_image.mask, mask_true)
 
     image.mask = None
-    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="propagate")
+    parsed_image = parse_image(image, disp_axis=1, mask_treatment="propagate")
     np.testing.assert_array_equal(parsed_image.data, image.data)
     mask_true = np.zeros(image.data.shape, dtype=bool)
     mask_true[:, 3] = 1
@@ -77,7 +77,7 @@ def test_propagate():
 
 def test_zero_fill():
     image = mk_image()
-    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="zero_fill")
+    parsed_image = parse_image(image, disp_axis=1, mask_treatment="zero_fill")
     image_true = np.ones(image.data.shape)
     image_true[[0, 1, 1], [1, 0, 3]] = 0
     np.testing.assert_array_equal(parsed_image.data, image_true)
@@ -85,7 +85,7 @@ def test_zero_fill():
     np.testing.assert_array_equal(parsed_image.mask, mask_true)
 
     image.mask = None
-    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="zero_fill")
+    parsed_image = parse_image(image, disp_axis=1, mask_treatment="zero_fill")
     image_true = np.ones(image.data.shape)
     image_true[1, 3] = 0
     np.testing.assert_array_equal(parsed_image.data, image_true)
@@ -95,7 +95,7 @@ def test_zero_fill():
 
 def test_nan_fill():
     image = mk_image()
-    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="nan_fill")
+    parsed_image = parse_image(image, disp_axis=1, mask_treatment="nan_fill")
     image_true = np.ones(image.data.shape)
     image_true[[0, 1, 1], [1, 0, 3]] = np.nan
     np.testing.assert_array_equal(parsed_image.data, image_true)
@@ -103,7 +103,7 @@ def test_nan_fill():
     np.testing.assert_array_equal(parsed_image.mask, mask_true)
 
     image.mask = None
-    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="nan_fill")
+    parsed_image = parse_image(image, disp_axis=1, mask_treatment="nan_fill")
     image_true = np.ones(image.data.shape)
     image_true[1, 3] = np.nan
     np.testing.assert_array_equal(parsed_image.data, image_true)
@@ -113,14 +113,14 @@ def test_nan_fill():
 
 def test_apply_nan_only():
     image = mk_image()
-    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="apply_nan_only")
+    parsed_image = parse_image(image, disp_axis=1, mask_treatment="apply_nan_only")
     np.testing.assert_array_equal(parsed_image.data, image.data)
     mask_true = np.zeros(image.data.shape, dtype=bool)
     mask_true[1, 3] = 1
     np.testing.assert_array_equal(parsed_image.mask, mask_true)
 
     image.mask = None
-    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="apply_nan_only")
+    parsed_image = parse_image(image, disp_axis=1, mask_treatment="apply_nan_only")
     np.testing.assert_array_equal(parsed_image.data, image.data)
     mask_true = np.zeros(image.data.shape, dtype=bool)
     mask_true[1, 3] = 1
@@ -129,14 +129,14 @@ def test_apply_nan_only():
 
 def test_apply_mask_only():
     image = mk_image()
-    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="apply_mask_only")
+    parsed_image = parse_image(image, disp_axis=1, mask_treatment="apply_mask_only")
     np.testing.assert_array_equal(parsed_image.data, image.data)
     mask_true = np.zeros(image.data.shape, dtype=bool)
     mask_true[[0, 1], [1, 0]] = 1
     np.testing.assert_array_equal(parsed_image.mask, mask_true)
 
     image.mask = None
-    parsed_image = _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="apply_mask_only")
+    parsed_image = parse_image(image, disp_axis=1, mask_treatment="apply_mask_only")
     np.testing.assert_array_equal(parsed_image.data, image.data)
     mask_true = np.zeros(image.data.shape, dtype=bool)
     np.testing.assert_array_equal(parsed_image.mask, mask_true)
@@ -146,4 +146,4 @@ def test_fully_masked():
     image = mk_image()
     image.mask[:] = 1
     with pytest.raises(ValueError, match="Image is fully masked."):
-        _ImageParser()._parse_image(image, disp_axis=1, mask_treatment="apply")
+        parse_image(image, disp_axis=1, mask_treatment="apply")

--- a/specreduce/tilt_correction.py
+++ b/specreduce/tilt_correction.py
@@ -10,7 +10,7 @@ from scipy.optimize import minimize
 from scipy.spatial import KDTree
 from specutils import Spectrum
 
-from specreduce.core import _ImageParser
+from specreduce.core import parse_image
 from specreduce.line_matching import find_arc_lines
 from specreduce.tilt_solution import TiltSolution
 from specreduce.tracing import Trace
@@ -101,11 +101,9 @@ class TiltCorrection:
         if not isinstance(arc_frames, Sequence):
             arc_frames = [arc_frames]
 
-        # An ugly hack that should be changed after the refactoring of image parsing.
-        ip = _ImageParser()
         self.arc_frames = []
         for f in arc_frames:
-            im = ip._parse_image(f, disp_axis=disp_axis, mask_treatment=mask_treatment)
+            im = parse_image(f, disp_axis=disp_axis, mask_treatment=mask_treatment)
             self.arc_frames.append(NDData(im.flux, uncertainty=im.uncertainty, mask=im.mask))
         self.nframes = len(arc_frames)
         self._ny, self._nx = self.arc_frames[0].data.shape

--- a/specreduce/tilt_solution.py
+++ b/specreduce/tilt_solution.py
@@ -12,7 +12,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from gwcs import coordinate_frames
 from numpy import ndarray
 
-from specreduce.core import _ImageParser
+from specreduce.core import parse_image
 
 __all__ = ["TiltSolution"]
 
@@ -302,8 +302,7 @@ class TiltSolution:
 
         # TODO: In the future, we want to make sure that we don't copy the data unless absolutely
         # necessary.
-        ip = _ImageParser()
-        im = ip._parse_image(flux, disp_axis=self.disp_axis, mask_treatment=mask_treatment)
+        im = parse_image(flux, disp_axis=self.disp_axis, mask_treatment=mask_treatment)
         flux = im.flux.value
 
         ny, nx = flux.data.shape

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -11,7 +11,7 @@ from astropy.nddata import NDData
 from astropy.stats import gaussian_sigma_to_fwhm
 from astropy.utils.decorators import deprecated
 
-from specreduce.core import _ImageParser
+from specreduce.core import parse_image
 
 __all__ = ["Trace", "FlatTrace", "ArrayTrace", "FitTrace"]
 
@@ -105,7 +105,7 @@ class Trace:
 
 
 @dataclass
-class FlatTrace(Trace, _ImageParser):
+class FlatTrace(Trace):
     """
     Trace that is constant along the axis being traced.
 
@@ -122,7 +122,7 @@ class FlatTrace(Trace, _ImageParser):
     trace_pos: float
 
     def __post_init__(self):
-        self.image = self._parse_image(self.image)
+        self.image = parse_image(self.image)
 
         self.set_position(self.trace_pos)
 
@@ -147,7 +147,7 @@ class FlatTrace(Trace, _ImageParser):
 
 
 @dataclass
-class ArrayTrace(Trace, _ImageParser):
+class ArrayTrace(Trace):
     """
     Define a trace given an array of trace positions.
 
@@ -181,7 +181,7 @@ class ArrayTrace(Trace, _ImageParser):
         # dropped at the end and a regular array will be returned.
         self.trace = np.ma.MaskedArray(trace_data, total_mask)
 
-        self.image = self._parse_image(self.image)
+        self.image = parse_image(self.image)
 
         nx = self.image.shape[1]
         nt = len(self.trace)
@@ -207,7 +207,7 @@ class ArrayTrace(Trace, _ImageParser):
 
 
 @dataclass
-class FitTrace(Trace, _ImageParser):
+class FitTrace(Trace):
     """
     Trace the spectrum aperture in an image.
 
@@ -294,17 +294,17 @@ class FitTrace(Trace, _ImageParser):
     def __post_init__(self):
 
         # Parse image, including masked/nonfinite data handling based on
-        # choice of `mask_treatment`. returns a Spectrum1D
+        # choice of `mask_treatment`. returns a Spectrum
         if self.mask_treatment not in self._valid_mask_treatment_methods:
             raise ValueError(
                 "`mask_treatment` must be one of " f"{self._valid_mask_treatment_methods}"
             )
 
-        self.image = self._parse_image(
+        self.image = parse_image(
             self.image, disp_axis=self._disp_axis, mask_treatment=self.mask_treatment
         )
 
-        # _parse_image returns a Spectrum1D. convert this to a masked array
+        # parse_image returns a Spectrum. convert this to a masked array
         # for ease of calculations here (even if there is no masked data).
         # Note: uncertainties are dropped, this should also be addressed at
         # some point probably across the package.

--- a/specreduce/utils/utils.py
+++ b/specreduce/utils/utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from specreduce.core import _ImageParser
+from specreduce.core import parse_image
 from specreduce.tracing import Trace, FlatTrace
 from specreduce.extract import _ap_weight_image, _align_along_trace
 
@@ -86,10 +86,9 @@ def measure_cross_dispersion_profile(image, trace=None, crossdisp_axis=0,
 
     unit = getattr(image, 'unit', None)
 
-    # parse image, which will return a spectrum1D (note: this is not ideal,
+    # parse image, which will return a Spectrum (note: this is not ideal,
     # but will be addressed at some point)
-    parser = _ImageParser()
-    image = parser._parse_image(image, disp_axis=disp_axis)
+    image = parse_image(image, disp_axis=disp_axis)
 
     # which we then need to make back into a masked array
     # again this way of parsing the image is not ideal but


### PR DESCRIPTION
This small PR replaces the `_ImageParser` mixin class with a `parse_image` function that does the same thing with a clearer structure. There are no user-visible changes, and the internal changes are quite minimal as well. The main motivation is to simplify how the code works and make it more approachable for new developers. This is one step in a larger refactoring of the codebase.