### PR TITLE
Add missing pytest.mark.remote_data

### DIFF
--- a/specreduce/tests/test_tilt_correction.py
+++ b/specreduce/tests/test_tilt_correction.py
@@ -6,6 +6,7 @@ from specreduce.tilt_correction import TiltCorrection
 from specreduce.tracing import FlatTrace
 
 
+@pytest.mark.remote_data
 def test_init_trace(mk_arc_frames):
     arcs = mk_arc_frames
     trace = FlatTrace(arcs[0], arcs[0].shape[0] // 2)
@@ -13,6 +14,7 @@ def test_init_trace(mk_arc_frames):
     assert tc.ref_pixel == (arcs[0].shape[0] // 2, arcs[0].shape[1] // 2)
 
 
+@pytest.mark.remote_data
 def test_init_default_params(mk_arc_frames):
     arcs = mk_arc_frames
     tc = TiltCorrection(arcs, cdisp_ref_pixel=64, disp_ref_pixel=256)
@@ -34,18 +36,21 @@ def test_init_default_params(mk_arc_frames):
     np.testing.assert_array_equal(tc.cd_samples, np.array([10, 20, 30, 40, 50]))
 
 
+@pytest.mark.remote_data
 def test_find_lines(mk_default_tc):
     tc = mk_default_tc
     tc.find_arc_lines(3.0, 5.0)
     np.testing.assert_array_equal(tc.cd_samples, np.array([14, 28, 43, 57, 71, 85, 100, 114]))
 
 
+@pytest.mark.remote_data
 def test_fit(mk_default_tc):
     tc = mk_default_tc
     tc.find_arc_lines(3.0, 5.0)
     tc.fit(4)
 
 
+@pytest.mark.remote_data
 def test_plot_fit_quality(mk_default_tc):
     tc = mk_default_tc
     tc.find_arc_lines(3.0, 5.0)
@@ -53,6 +58,7 @@ def test_plot_fit_quality(mk_default_tc):
     tc.plot_fit_quality()
 
 
+@pytest.mark.remote_data
 def test_plot_wavelength_contours(mk_default_tc):
     tc = mk_default_tc
     tc.find_arc_lines(3.0, 5.0)
@@ -60,6 +66,7 @@ def test_plot_wavelength_contours(mk_default_tc):
     tc.plot_wavelength_contours()
 
 
+@pytest.mark.remote_data
 def test_refine_fit_before_fit(mk_default_tc):
     tc = mk_default_tc
     tc.find_arc_lines(3.0, 5.0)
@@ -67,6 +74,7 @@ def test_refine_fit_before_fit(mk_default_tc):
         tc.refine_fit()
 
 
+@pytest.mark.remote_data
 def test_match_lines_before_fit(mk_default_tc):
     tc = mk_default_tc
     tc.find_arc_lines(3.0, 5.0)
@@ -74,6 +82,7 @@ def test_match_lines_before_fit(mk_default_tc):
         tc.match_lines()
 
 
+@pytest.mark.remote_data
 def test_plot_wavelength_contours_options(mk_default_tc):
     tc = mk_default_tc
     tc.find_arc_lines(3.0, 5.0)
@@ -89,6 +98,7 @@ def test_plot_wavelength_contours_options(mk_default_tc):
     plt.close("all")
 
 
+@pytest.mark.remote_data
 def test_plot_fit_quality_with_rlim(mk_default_tc):
     tc = mk_default_tc
     tc.find_arc_lines(3.0, 5.0)

--- a/specreduce/tests/test_tilt_solution.py
+++ b/specreduce/tests/test_tilt_solution.py
@@ -14,6 +14,7 @@ def test_diff_poly2d_x_valid_derivative():
     assert derivative.c0_1 == 5
 
 
+@pytest.mark.remote_data
 def test_tilt_solution_gwcs(mk_default_tc):
     tc = mk_default_tc
     tc.find_arc_lines(3.0, 5.0)
@@ -37,6 +38,7 @@ def test_tilt_solution_gwcs(mk_default_tc):
     np.testing.assert_allclose(det_y_gwcs, cdisp_arr)
 
 
+@pytest.mark.remote_data
 def test_tilt_solution_gwcs_cache_invalidation(mk_default_tc):
     tc = mk_default_tc
     tc.find_arc_lines(3.0, 5.0)
@@ -52,6 +54,7 @@ def test_tilt_solution_gwcs_cache_invalidation(mk_default_tc):
     assert "gwcs" not in ts.__dict__
 
 
+@pytest.mark.remote_data
 def test_det_to_corr_round_trip(mk_default_tc):
     tc = mk_default_tc
     tc.find_arc_lines(3.0, 5.0)
@@ -69,6 +72,7 @@ def test_det_to_corr_round_trip(mk_default_tc):
     np.testing.assert_allclose(cdisp_out2, cdisp)
 
 
+@pytest.mark.remote_data
 def test_d2c_cache_invalidation(mk_default_tc):
     tc = mk_default_tc
     tc.find_arc_lines(3.0, 5.0)
@@ -84,6 +88,7 @@ def test_d2c_cache_invalidation(mk_default_tc):
     assert "d2c" not in ts.__dict__
 
 
+@pytest.mark.remote_data
 def test_gwcs_inverse(mk_default_tc):
     tc = mk_default_tc
     tc.find_arc_lines(3.0, 5.0)
@@ -105,6 +110,7 @@ def test_gwcs_inverse(mk_default_tc):
     np.testing.assert_allclose(cdisp_cor_inv, cdisp_direct)
 
 
+@pytest.mark.remote_data
 def test_resample(mk_default_tc, mk_arc_frames):
     arcs = mk_arc_frames
     tc = mk_default_tc
@@ -113,6 +119,7 @@ def test_resample(mk_default_tc, mk_arc_frames):
     tc.solution.resample(arcs[0])
 
 
+@pytest.mark.remote_data
 def test_c2d_derivative_cache_invalidation(mk_default_tc):
     tc = mk_default_tc
     tc.find_arc_lines(3.0, 5.0)
@@ -128,6 +135,7 @@ def test_c2d_derivative_cache_invalidation(mk_default_tc):
     assert "c2d_derivative" not in ts.__dict__
 
 
+@pytest.mark.remote_data
 def test_inverse_without_image_shape(mk_default_tc):
     tc = mk_default_tc
     tc.find_arc_lines(3.0, 5.0)
@@ -140,6 +148,7 @@ def test_inverse_without_image_shape(mk_default_tc):
         _ = ts_no_shape.d2c
 
 
+@pytest.mark.remote_data
 def test_from_gwcs(mk_default_tc):
     tc = mk_default_tc
     tc.find_arc_lines(3.0, 5.0)
@@ -178,6 +187,7 @@ def test_from_gwcs_invalid():
         TiltSolution.from_gwcs(wcs)
 
 
+@pytest.mark.remote_data
 def test_resample_disp_axis_0(mk_default_tc, mk_arc_frames):
     arcs = mk_arc_frames
     tc = mk_default_tc


### PR DESCRIPTION
These were missing in 1.8.0; I discovered them when packaging the new version for Debian.