### PR TITLE
RTD annotation fix + tox action v2 -> v3 fix + linkcheck fix

### DIFF
--- a/.github/workflows/cron-tests.yml
+++ b/.github/workflows/cron-tests.yml
@@ -29,6 +29,10 @@ jobs:
       envs: |
         - name: Check URLs in docs
           linux: linkcheck
+          libraries:
+            apt:
+              - pandoc
+              - graphviz
 
         - name: Python 3.14 on Linux with pre-releases
           linux: py314-test-alldeps-predeps

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -210,6 +210,7 @@ nitpick_ignore_regex = [
     (r"py:class", r"tuple\[.*"),               # Generic tuple types
     (r"py:class", r"None \| dict\[.*"),        # Union types with dict
     (r"py:class", r"dict\[.*"),                # Generic dict types
+    (r"py:class", r"numpy\._typing\..*"),
 ]
 
 # -- Options for linkcheck output -------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ test = [
     "tox",
 ]
 docs = [
+    "numpy<=2.5",
     "sphinx-astropy[confv3]>=1.11",
     "sphinx-copybutton",
     "sphinx-design",

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ passenv = HOME,WINDIR,CI
 
 setenv =
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    cov: COVERAGE_FILE = {toxinidir}/.coverage
 
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree
@@ -63,7 +64,6 @@ commands =
     pip freeze
     !cov: pytest --pyargs specreduce {toxinidir}/docs {posargs}
     cov: pytest --pyargs specreduce {toxinidir}/docs --cov specreduce --cov-config={toxinidir}/pyproject.toml {posargs}
-    cov: coverage xml -o {toxinidir}/coverage.xml
 
 pip_pre =
     predeps: true


### PR DESCRIPTION
This small PR fixes the RDT build broken by the introduction of NumPy 2.5, the coverage tests broken by the transition from the tox v2 action to v3, and the weekly linkcheck action that was missing dependencies.