### PR TITLE
Spectral FITS WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ New Features
   be written with the specutils 'wcs1d-fits' format. The fitted WCS is now cached
   per air/vacuum axis type and invalidated when the pixel-to-wavelength
   transformation changes, so one solution can be applied to many spectra without
-  refitting the grism dispersion function. [#NNN]
+  refitting the grism dispersion function. [#316]
 
 - Added ``WavelengthSolution1D.to_asdf()`` and ``WavelengthSolution1D.from_asdf()``
   for serializing a wavelength solution losslessly into an ASDF file. Only the
@@ -23,12 +23,12 @@ New Features
   to the solution. The reference pixel keywords (CRPIX, CRVAL, CDELT) are
   set exactly from the solution model and only the grating PV terms are
   fitted, and a warning is emitted if the approximation deviates from the
-  exact solution by more than a given number of pixels. [#NNN]
+  exact solution by more than a given number of pixels. [#316]
 
 - The ``wave_air`` flag given to ``WavelengthCalibration1D`` is now stored
   in the resulting ``WavelengthSolution1D``, where it selects between air
   (``AWAV-GRA``) and vacuum (``WAVE-GRI``) spectral axis types in FITS WCS
-  export. [#NNN]
+  export. [#316]
 
 API Changes
 ^^^^^^^^^^^
@@ -36,7 +36,7 @@ API Changes
 - The legacy ``specreduce.wavelength_calibration.WavelengthCalibration1D``
   class (deprecated since v1.7.0) now emits an ``AstropyDeprecationWarning``
   on instantiation, and its removal has been rescheduled from v2.0 to v1.11.
-  Use ``specreduce.wavecal1d.WavelengthCalibration1D`` instead. [#NNN]
+  Use ``specreduce.wavecal1d.WavelengthCalibration1D`` instead. [#316]
 
 1.9.0 (2026-05-06)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,12 @@ API Changes
   on instantiation, and its removal has been rescheduled from v2.0 to v1.11.
   Use ``specreduce.wavecal1d.WavelengthCalibration1D`` instead. [#316]
 
+Other changes
+^^^^^^^^^^^^^
+
+- Dropped support for Python 3.11. The minimum supported Python version is
+  now 3.12.
+
 1.9.0 (2026-05-06)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,9 +13,10 @@ New Features
 - Added a ``WavelengthSolution1D.wcs()`` method that exports the wavelength
   solution as a standard FITS ``astropy.wcs.WCS`` object by fitting the
   WCS Paper III grating dispersion function (``WAVE-GRA`` or ``AWAV-GRA``)
-  to the solution. The fit is deterministic given a seed, and a warning is
-  emitted if the approximation deviates from the exact solution by more
-  than a given number of pixels. [#NNN]
+  to the solution. The reference pixel keywords (CRPIX, CRVAL, CDELT) are
+  set exactly from the solution model and only the grating PV terms are
+  fitted, and a warning is emitted if the approximation deviates from the
+  exact solution by more than a given number of pixels. [#NNN]
 
 - The ``wave_air`` flag given to ``WavelengthCalibration1D`` is now stored
   in the resulting ``WavelengthSolution1D``, where it selects between air

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ New Features
 
 - Added a ``WavelengthSolution1D.wcs()`` method that exports the wavelength
   solution as a standard FITS ``astropy.wcs.WCS`` object by fitting the
-  WCS Paper III grating dispersion function (``WAVE-GRI`` or ``AWAV-GRA``)
+  WCS Paper III grism dispersion function (``WAVE-GRI`` or ``AWAV-GRA``)
   to the solution. The reference pixel keywords (CRPIX, CRVAL, CDELT) are
   set exactly from the solution model and only the grating PV terms are
   fitted, and a warning is emitted if the approximation deviates from the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ New Features
 
 - Added a ``WavelengthSolution1D.wcs()`` method that exports the wavelength
   solution as a standard FITS ``astropy.wcs.WCS`` object by fitting the
-  WCS Paper III grating dispersion function (``WAVE-GRA`` or ``AWAV-GRA``)
+  WCS Paper III grating dispersion function (``WAVE-GRI`` or ``AWAV-GRA``)
   to the solution. The reference pixel keywords (CRPIX, CRVAL, CDELT) are
   set exactly from the solution model and only the grating PV terms are
   fitted, and a warning is emitted if the approximation deviates from the
@@ -20,7 +20,7 @@ New Features
 
 - The ``wave_air`` flag given to ``WavelengthCalibration1D`` is now stored
   in the resulting ``WavelengthSolution1D``, where it selects between air
-  (``AWAV-GRA``) and vacuum (``WAVE-GRA``) spectral axis types in FITS WCS
+  (``AWAV-GRA``) and vacuum (``WAVE-GRI``) spectral axis types in FITS WCS
   export. [#NNN]
 
 1.9.0 (2026-05-06)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,14 @@ New Features
   (``AWAV-GRA``) and vacuum (``WAVE-GRI``) spectral axis types in FITS WCS
   export. [#NNN]
 
+API Changes
+^^^^^^^^^^^
+
+- The legacy ``specreduce.wavelength_calibration.WavelengthCalibration1D``
+  class (deprecated since v1.7.0) now emits an ``AstropyDeprecationWarning``
+  on instantiation, and its removal has been rescheduled from v2.0 to v1.11.
+  Use ``specreduce.wavecal1d.WavelengthCalibration1D`` instead. [#NNN]
+
 1.9.0 (2026-05-06)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,18 @@ New Features
   coordinate transformation is stored, as a GWCS object whose bounding box carries
   the pixel bounds, so the restored solution reproduces the original exactly. [#317]
 
+- Added a ``WavelengthSolution1D.wcs()`` method that exports the wavelength
+  solution as a standard FITS ``astropy.wcs.WCS`` object by fitting the
+  WCS Paper III grating dispersion function (``WAVE-GRA`` or ``AWAV-GRA``)
+  to the solution. The fit is deterministic given a seed, and a warning is
+  emitted if the approximation deviates from the exact solution by more
+  than a given number of pixels. [#NNN]
+
+- The ``wave_air`` flag given to ``WavelengthCalibration1D`` is now stored
+  in the resulting ``WavelengthSolution1D``, where it selects between air
+  (``AWAV-GRA``) and vacuum (``WAVE-GRA``) spectral axis types in FITS WCS
+  export. [#NNN]
+
 1.9.0 (2026-05-06)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,14 @@
 New Features
 ^^^^^^^^^^^^
 
+- Added a ``WavelengthSolution1D.wcs()`` method that exports the wavelength
+  solution as a standard FITS ``astropy.wcs.WCS`` object by fitting the
+  WCS Paper III grism dispersion function (``WAVE-GRI`` or ``AWAV-GRA``)
+  to the solution. The reference pixel keywords (CRPIX, CRVAL, CDELT) are
+  set exactly from the solution model and only the grating PV terms are
+  fitted, and a warning is emitted if the approximation deviates from the
+  exact solution by more than a given number of pixels. [#316]
+
 - Added a ``WavelengthSolution1D.attach_wcs()`` method that returns a copy of a
   pixel-space spectrum carrying the fitted FITS WCS as its spectral axis, ready to
   be written with the specutils 'wcs1d-fits' format. The fitted WCS is now cached
@@ -16,14 +24,6 @@ New Features
   for serializing a wavelength solution losslessly into an ASDF file. Only the
   coordinate transformation is stored, as a GWCS object whose bounding box carries
   the pixel bounds, so the restored solution reproduces the original exactly. [#317]
-
-- Added a ``WavelengthSolution1D.wcs()`` method that exports the wavelength
-  solution as a standard FITS ``astropy.wcs.WCS`` object by fitting the
-  WCS Paper III grism dispersion function (``WAVE-GRI`` or ``AWAV-GRA``)
-  to the solution. The reference pixel keywords (CRPIX, CRVAL, CDELT) are
-  set exactly from the solution model and only the grating PV terms are
-  fitted, and a warning is emitted if the approximation deviates from the
-  exact solution by more than a given number of pixels. [#316]
 
 - The ``wave_air`` flag given to ``WavelengthCalibration1D`` is now stored
   in the resulting ``WavelengthSolution1D``, where it selects between air

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,13 @@
 New Features
 ^^^^^^^^^^^^
 
+- Added a ``WavelengthSolution1D.attach_wcs()`` method that returns a copy of a
+  pixel-space spectrum carrying the fitted FITS WCS as its spectral axis, ready to
+  be written with the specutils 'wcs1d-fits' format. The fitted WCS is now cached
+  per air/vacuum axis type and invalidated when the pixel-to-wavelength
+  transformation changes, so one solution can be applied to many spectra without
+  refitting the grism dispersion function. [#NNN]
+
 - Added ``WavelengthSolution1D.to_asdf()`` and ``WavelengthSolution1D.from_asdf()``
   for serializing a wavelength solution losslessly into an ASDF file. Only the
   coordinate transformation is stored, as a GWCS object whose bounding box carries

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ The reduction workflow follows a modular pipeline: **Trace → Background → Ex
 
 - **wavecal1d.py**: Current wavelength calibration implementation using `WavelengthCalibration1D`. Supports automated line matching, template matching, and produces GWCS-based WCS objects.
 
-- **wavesol1d.py**: `WavelengthSolution1D` — manages the pixel↔wavelength polynomial mapping underlying the calibration. Exports the solution as a lossless GWCS (`gwcs` property) or as a standard FITS WCS fitted with the Paper III grating dispersion function (`wcs()` method, `WAVE-GRI`/`AWAV-GRA`).
+- **wavesol1d.py**: `WavelengthSolution1D` — manages the pixel↔wavelength polynomial mapping underlying the calibration. Exports the solution as a lossless GWCS (`gwcs` property) or as a standard FITS WCS fitted with the Paper III grism dispersion function (`wcs()` method, `WAVE-GRI`/`AWAV-GRA`).
 
 - **line_matching.py**: Helpers for matching detected lines to reference line lists.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ The reduction workflow follows a modular pipeline: **Trace → Background → Ex
 
 - **table_utils.py**: Shared helpers for the QTable structures used across modules.
 
-- **wavelength_calibration.py**: Legacy wavelength calibration (deprecated in v1.7.0, removal in v2.0)
+- **wavelength_calibration.py**: Legacy wavelength calibration (deprecated in v1.7.0, removal in v1.11)
 
 - **fluxcal.py**: `FluxCalibration` class for flux calibration with magnitude-to-flux conversion and airmass extinction correction
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ The reduction workflow follows a modular pipeline: **Trace → Background → Ex
 
 - **wavecal1d.py**: Current wavelength calibration implementation using `WavelengthCalibration1D`. Supports automated line matching, template matching, and produces GWCS-based WCS objects.
 
-- **wavesol1d.py**: `WavelengthSolution1D` — manages the pixel↔wavelength polynomial mapping underlying the calibration. Exports the solution as a lossless GWCS (`gwcs` property) or as a standard FITS WCS fitted with the Paper III grating dispersion function (`wcs()` method, `WAVE-GRA`/`AWAV-GRA`).
+- **wavesol1d.py**: `WavelengthSolution1D` — manages the pixel↔wavelength polynomial mapping underlying the calibration. Exports the solution as a lossless GWCS (`gwcs` property) or as a standard FITS WCS fitted with the Paper III grating dispersion function (`wcs()` method, `WAVE-GRI`/`AWAV-GRA`).
 
 - **line_matching.py**: Helpers for matching detected lines to reference line lists.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ The reduction workflow follows a modular pipeline: **Trace → Background → Ex
 
 - **wavecal1d.py**: Current wavelength calibration implementation using `WavelengthCalibration1D`. Supports automated line matching, template matching, and produces GWCS-based WCS objects.
 
-- **wavesol1d.py**: `WavelengthSolution1D` — manages the pixel↔wavelength polynomial mapping underlying the calibration.
+- **wavesol1d.py**: `WavelengthSolution1D` — manages the pixel↔wavelength polynomial mapping underlying the calibration. Exports the solution as a lossless GWCS (`gwcs` property) or as a standard FITS WCS fitted with the Paper III grating dispersion function (`wcs()` method, `WAVE-GRA`/`AWAV-GRA`).
 
 - **line_matching.py**: Helpers for matching detected lines to reference line lists.
 

--- a/docs/wavelength_calibration/wavelength_calibration.rst
+++ b/docs/wavelength_calibration/wavelength_calibration.rst
@@ -214,9 +214,9 @@ Several tools help assess the quality of the wavelength solution:
 ********************************
 
 The fitted polynomial wavelength solution is stored as a
-:class:`~specreduce.wavesol1d .WavelengthSolution1D` instance that you can use to transform and
-resample spectra. The fitting methods return the solution, but it is also stored in
-`WavelengthCalibration1D.solution`.
+:class:`~specreduce.wavesol1d.WavelengthSolution1D` instance that you can use to transform and
+resample spectra. The fitting methods return the solution, but it is also stored in the
+``solution`` attribute of :class:`~specreduce.wavecal1d.WavelengthCalibration1D`.
 
 *   **Convert Coordinates**: Use :meth:`~specreduce.wavesol1d.WavelengthSolution1D.pix_to_wav` and
     :meth:`~specreduce.wavesol1d.WavelengthSolution1D.wav_to_pix` to convert between pixel and

--- a/docs/wavelength_calibration/wavelength_calibration.rst
+++ b/docs/wavelength_calibration/wavelength_calibration.rst
@@ -213,9 +213,10 @@ Several tools help assess the quality of the wavelength solution:
 5. Using the Wavelength Solution
 ********************************
 
-The fitted wavelength solution is stored as a :class:`~specreduce.wavesol1d.WavelengthSolution1D`
-instance that you can use to transform and resample spectra. The fitting methods return the
-solution, but it is also stored in ``WavelengthCalibration1D.solution``.
+The fitted polynomial wavelength solution is stored as a
+:class:`~specreduce.wavesol1d .WavelengthSolution1D` instance that you can use to transform and
+resample spectra. The fitting methods return the solution, but it is also stored in
+`WavelengthCalibration1D.solution`.
 
 *   **Convert Coordinates**: Use :meth:`~specreduce.wavesol1d.WavelengthSolution1D.pix_to_wav` and
     :meth:`~specreduce.wavesol1d.WavelengthSolution1D.wav_to_pix` to convert between pixel and
@@ -227,23 +228,23 @@ solution, but it is also stored in ``WavelengthCalibration1D.solution``.
         wavelengths = ws.pix_to_wav(pixels)
         print(wavelengths)
 
-*   **Get WCS Object**: Access the `~gwcs.wcs.WCS` object representing the solution via the
-    :attr:`~specreduce.wavesol1d.WavelengthSolution1D.gwcs` attribute. This is particularly
-    useful for attaching the calibration to a :class:`~specutils.Spectrum` object.
-
 *   **Export a FITS WCS**: Use :meth:`~specreduce.wavesol1d.WavelengthSolution1D.wcs` to get a
-    standard `~astropy.wcs.WCS` object that approximates the solution with the FITS WCS Paper III
-    grating dispersion function (``WAVE-GRA`` for vacuum or ``AWAV-GRA`` for air wavelengths,
-    selected by the ``wave_air`` flag). Unlike the lossless
-    :attr:`~specreduce.wavesol1d.WavelengthSolution1D.gwcs` representation, the returned WCS is a
-    numerical fit to the polynomial solution and can be serialized into a FITS header readable by
-    any FITS-compliant software; a warning is emitted if the fit deviates from the exact solution
-    by more than ``max_residual`` pixels.
+    standard `~astropy.wcs.WCS` object that approximates the polynomial solution with the FITS WCS
+    Paper III grating dispersion function. The returned WCS is a numerical fit to the
+    polynomial solution and can be serialized into a FITS header readable by any FITS-compliant
+    software, or attached to a :class:`~specutils.Spectrum` object. A warning
+    is emitted if the fit deviates from the polynomial solution by more than ``max_residual``
+    pixels.
 
     .. code-block:: python
 
         header = ws.wcs().to_header()
         print(header)
+
+*   **Export a GWCS Object**: Access the `~gwcs.wcs.WCS` object representing the polynomial
+    wavelength solution via the :attr:`~specreduce.wavesol1d.WavelengthSolution1D.gwcs` attribute.
+    This is particularly useful for attaching the calibration to a :class:`~specutils.Spectrum`
+    object.
 
 *   **Rebin Spectrum**: Resample a spectrum onto a new wavelength grid using
     :meth:`~specreduce.wavesol1d.WavelengthSolution1D.resample`. The rebinning is

--- a/docs/wavelength_calibration/wavelength_calibration.rst
+++ b/docs/wavelength_calibration/wavelength_calibration.rst
@@ -244,7 +244,9 @@ resample spectra. The fitting methods return the solution, but it is also stored
 *   **Export a GWCS Object**: Access the `~gwcs.wcs.WCS` object representing the polynomial
     wavelength solution via the :attr:`~specreduce.wavesol1d.WavelengthSolution1D.gwcs` attribute.
     This is particularly useful for attaching the calibration to a :class:`~specutils.Spectrum`
-    object.
+    object. Unlike `~specreduce.wavesol1d.WavelengthSolution1D.wcs`, which returns a grism
+    dispersion function fitted to the polynomial solution, the GWCS object carries the
+    exact polynomial model.
 
 *   **Rebin Spectrum**: Resample a spectrum onto a new wavelength grid using
     :meth:`~specreduce.wavesol1d.WavelengthSolution1D.resample`. The rebinning is

--- a/docs/wavelength_calibration/wavelength_calibration.rst
+++ b/docs/wavelength_calibration/wavelength_calibration.rst
@@ -230,7 +230,7 @@ resample spectra. The fitting methods return the solution, but it is also stored
 
 *   **Export a FITS WCS**: Use :meth:`~specreduce.wavesol1d.WavelengthSolution1D.wcs` to get a
     standard `~astropy.wcs.WCS` object that approximates the polynomial solution with the FITS WCS
-    Paper III grating dispersion function. The returned WCS is a numerical fit to the
+    Paper III grism dispersion function. The returned WCS is a numerical fit to the
     polynomial solution and can be serialized into a FITS header readable by any FITS-compliant
     software, or attached to a :class:`~specutils.Spectrum` object. A warning
     is emitted if the fit deviates from the polynomial solution by more than ``max_residual``

--- a/docs/wavelength_calibration/wavelength_calibration.rst
+++ b/docs/wavelength_calibration/wavelength_calibration.rst
@@ -231,6 +231,20 @@ solution, but it is also stored in ``WavelengthCalibration1D.solution``.
     :attr:`~specreduce.wavesol1d.WavelengthSolution1D.gwcs` attribute. This is particularly
     useful for attaching the calibration to a :class:`~specutils.Spectrum` object.
 
+*   **Export a FITS WCS**: Use :meth:`~specreduce.wavesol1d.WavelengthSolution1D.wcs` to get a
+    standard `~astropy.wcs.WCS` object that approximates the solution with the FITS WCS Paper III
+    grating dispersion function (``WAVE-GRA`` for vacuum or ``AWAV-GRA`` for air wavelengths,
+    selected by the ``wave_air`` flag). Unlike the lossless
+    :attr:`~specreduce.wavesol1d.WavelengthSolution1D.gwcs` representation, the returned WCS is a
+    numerical fit to the polynomial solution and can be serialized into a FITS header readable by
+    any FITS-compliant software; a warning is emitted if the fit deviates from the exact solution
+    by more than ``max_residual`` pixels.
+
+    .. code-block:: python
+
+        header = ws.wcs().to_header()
+        print(header)
+
 *   **Rebin Spectrum**: Resample a spectrum onto a new wavelength grid using
     :meth:`~specreduce.wavesol1d.WavelengthSolution1D.resample`. The rebinning is
     flux-conserving, meaning the integrated flux in the output spectrum matches the integrated flux

--- a/specreduce/tests/test_wavecal1d.py
+++ b/specreduce/tests/test_wavecal1d.py
@@ -66,7 +66,12 @@ def mk_arc():
 def test_init(mk_arc, mk_lines):
     arc = mk_arc
     obs_lines, cat_lines = mk_lines
-    WavelengthCalibration1D(arc_spectra=arc, line_lists=cat_lines, ref_pixel=ref_pixel)
+    wc = WavelengthCalibration1D(arc_spectra=arc, line_lists=cat_lines, ref_pixel=ref_pixel)
+    assert wc.solution.wave_air is False
+    wc = WavelengthCalibration1D(
+        arc_spectra=arc, line_lists=cat_lines, ref_pixel=ref_pixel, wave_air=True
+    )
+    assert wc.solution.wave_air is True
     WavelengthCalibration1D(
         obs_lines=obs_lines,
         line_lists=cat_lines,

--- a/specreduce/tests/test_wavelength_calibration.py
+++ b/specreduce/tests/test_wavelength_calibration.py
@@ -9,6 +9,22 @@ from numpy.testing import assert_allclose
 
 from specreduce import WavelengthCalibration1D
 
+# The legacy WavelengthCalibration1D emits an AstropyDeprecationWarning on instantiation;
+# ignore it module-wide so the functional tests keep running until the class is removed.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:The WavelengthCalibration1D class is deprecated:"
+    "astropy.utils.exceptions.AstropyDeprecationWarning"
+)
+
+
+def test_deprecation_warning(spec1d):
+    from astropy.utils.exceptions import AstropyDeprecationWarning
+
+    centers = [0, 10, 20, 30]
+    w = [5000, 5100, 5198, 5305] * u.AA
+    with pytest.warns(AstropyDeprecationWarning, match="v1.11"):
+        WavelengthCalibration1D(spec1d, line_pixels=centers, line_wavelengths=w)
+
 
 def test_linear_from_list(spec1d):
     centers = [0, 10, 20, 30]

--- a/specreduce/tests/test_wavesol1d.py
+++ b/specreduce/tests/test_wavesol1d.py
@@ -52,7 +52,7 @@ def gra_solution():
 
 @pytest.fixture(scope="module")
 def gra_fitted_wcs(gra_solution):
-    return gra_solution.wcs(seed=1)
+    return gra_solution.wcs()
 
 
 @pytest.fixture
@@ -172,33 +172,37 @@ def test_wcs_gra_round_trip(gra_solution, gra_fitted_wcs):
     assert w.wcs.ctype[0] == "AWAV-GRA"
     x = np.arange(*ws.bounds_pix)
     res_pix = (w.wcs_pix2world(x[:, None] + 1.0, 1)[:, 0] * 1e10 - ws.p2w(x)) / ws.p2w_dldx(x)
-    assert np.max(np.abs(res_pix)) < 0.1
+    assert np.max(np.abs(res_pix)) < 0.5
+
+
+def test_wcs_pinned_keywords(gra_solution, gra_fitted_wcs):
+    ws, w = gra_solution, gra_fitted_wcs
+    # wcslib normalizes crval/cdelt/cunit to metres in place when WCS.set() first runs,
+    # so the comparison must go through the current cunit.
+    scale = (1.0 * u.Unit(w.wcs.cunit[0])).to_value(u.angstrom)
+    assert w.wcs.crpix[0] == -ws._p2w[0].offset.value + 1.0
+    assert w.wcs.crval[0] * scale == pytest.approx(ws._p2w[1].c0.value, rel=1e-12)
+    assert w.wcs.cdelt[0] * scale == pytest.approx(ws._p2w[1].c1.value, rel=1e-12)
+    pv = dict((i, v) for _, i, v in w.wcs.get_pv())
+    assert pv[1] == 1.0  # diffraction order
+    assert pv[3] == 1.0  # refractive index, absorbed by the fitted grating density
+    assert pv[5] == 0.0  # grating rotation
 
 
 def test_wcs_ctype_air_vacuum():
     ws_air = _make_gra_solution(128, wave_air=True)
     ws_vac = _make_gra_solution(128, wave_air=False)
-    assert ws_air.wcs(npix_subsample=32, seed=2).wcs.ctype[0] == "AWAV-GRA"
-    assert ws_vac.wcs(npix_subsample=32, seed=2).wcs.ctype[0] == "WAVE-GRA"
-    assert ws_air.wcs(wave_air=False, npix_subsample=32, seed=2).wcs.ctype[0] == "WAVE-GRA"
-    assert ws_vac.wcs(wave_air=True, npix_subsample=32, seed=2).wcs.ctype[0] == "AWAV-GRA"
+    assert ws_air.wcs().wcs.ctype[0] == "AWAV-GRA"
+    assert ws_vac.wcs().wcs.ctype[0] == "WAVE-GRA"
+    assert ws_air.wcs(wave_air=False).wcs.ctype[0] == "WAVE-GRA"
+    assert ws_vac.wcs(wave_air=True).wcs.ctype[0] == "AWAV-GRA"
 
 
 def test_wcs_warning_on_poor_fit():
     ws = _make_gra_solution(128)
     with pytest.warns(AstropyUserWarning, match="lossless"):
-        w = ws.wcs(max_residual=0.0, npix_subsample=32, seed=2)
+        w = ws.wcs(max_residual=0.0)
     assert isinstance(w, astropy_WCS)
-
-
-def test_wcs_deterministic():
-    ws = _make_gra_solution(128)
-    w1 = ws.wcs(npix_subsample=32, seed=7)
-    w2 = ws.wcs(npix_subsample=32, seed=7)
-    np.testing.assert_array_equal(w1.wcs.crpix, w2.wcs.crpix)
-    np.testing.assert_array_equal(w1.wcs.crval, w2.wcs.crval)
-    np.testing.assert_array_equal(w1.wcs.cdelt, w2.wcs.cdelt)
-    assert w1.wcs.get_pv() == w2.wcs.get_pv()
 
 
 def test_wcs_header_round_trip(gra_solution, gra_fitted_wcs):

--- a/specreduce/tests/test_wavesol1d.py
+++ b/specreduce/tests/test_wavesol1d.py
@@ -29,7 +29,7 @@ def mk_ws_with_transform():
 
 
 def _make_gra_solution(npix: int, wave_air: bool = False) -> WavelengthSolution1D:
-    """Create a solution whose polynomial closely follows a true grating dispersion curve."""
+    """Create a solution whose polynomial closely follows a true grism dispersion curve."""
     wt = astropy_WCS(naxis=1)
     wt.wcs.ctype = ["AWAV-GRA"]
     wt.wcs.cunit = ["Angstrom"]
@@ -184,9 +184,9 @@ def test_wcs_pinned_keywords(gra_solution, gra_fitted_wcs):
     assert w.wcs.crval[0] * scale == pytest.approx(ws._p2w[1].c0.value, rel=1e-12)
     assert w.wcs.cdelt[0] * scale == pytest.approx(ws._p2w[1].c1.value, rel=1e-12)
     pv = dict((i, v) for _, i, v in w.wcs.get_pv())
-    assert pv[1] == 1.0  # diffraction order
-    assert pv[3] == 1.0  # refractive index, absorbed by the fitted grating density
-    assert pv[5] == 0.0  # grating rotation
+    assert pv[1] == 1.0  # interference order, absorbed by the fitted ruling density
+    assert pv[3] == 1.0  # prism refractive index, absorbed by the fitted incidence angle
+    assert pv[5] == 0.0  # grating tilt, absorbed by the fitted ruling density
 
 
 def test_wcs_ctype_air_vacuum():
@@ -274,7 +274,7 @@ def test_wcs_raises_when_fit_degenerate():
     # this, so every residual evaluation is unphysical and the fit must fail loudly.
     poly = Polynomial1D(1, c0=1e10, c1=2.4)
     ws = WavelengthSolution1D(models.Shift(-255) | poly, (0, 512), u.angstrom)
-    with pytest.raises(RuntimeError, match="grating dispersion"):
+    with pytest.raises(RuntimeError, match="grism dispersion"):
         ws.wcs()
 
 

--- a/specreduce/tests/test_wavesol1d.py
+++ b/specreduce/tests/test_wavesol1d.py
@@ -2,6 +2,7 @@ import asdf
 import astropy.units as u
 import numpy as np
 import pytest
+from astropy.io import fits
 from astropy.modeling import models, fitting
 from astropy.modeling.polynomial import Polynomial1D
 from astropy.nddata import StdDevUncertainty
@@ -58,7 +59,7 @@ def gra_fitted_wcs(gra_solution):
 @pytest.fixture
 def mk_spectrum():
     return Spectrum(
-        flux=np.ones(pix_bounds[1]) * u.DN,
+        flux=np.ones(pix_bounds[1]) * u.count,
         spectral_axis=np.arange(pix_bounds[1]) * u.pix,
         uncertainty=StdDevUncertainty(np.ones(pix_bounds[1])),
     )
@@ -111,7 +112,7 @@ def test_resample(mk_spectrum, mk_ws_with_transform, mk_ws_without_transform):
     resampled = ws.resample(spectrum, nbins=50)
     assert resampled is not None
     assert len(resampled.flux) == 50
-    assert resampled.flux.unit == u.DN / u.angstrom
+    assert resampled.flux.unit == u.count / u.angstrom
 
     pix_edges = np.arange(spectrum.spectral_axis.size + 1) - 0.5
     f0 = (spectrum.flux.value * np.diff(ws._p2w(pix_edges))).sum()
@@ -276,6 +277,78 @@ def test_wcs_raises_when_fit_degenerate():
     ws = WavelengthSolution1D(models.Shift(-255) | poly, (0, 512), u.angstrom)
     with pytest.raises(RuntimeError, match="grism dispersion"):
         ws.wcs()
+
+
+def test_attach_wcs_attaches_fitted_wcs(gra_solution, gra_fitted_wcs):
+    ws = gra_solution
+    npix = ws.bounds_pix[1]
+    sp = Spectrum(
+        flux=np.arange(npix) * u.count,
+        spectral_axis=np.arange(npix) * u.pix,
+        uncertainty=StdDevUncertainty(np.full(npix, 0.5)),
+        mask=np.zeros(npix, dtype=bool),
+        meta={"OBJECT": "test"},
+    )
+    cal = ws.attach_wcs(sp)
+
+    assert isinstance(cal.wcs, astropy_WCS)
+    assert cal.wcs.wcs.ctype[0] == gra_fitted_wcs.wcs.ctype[0]
+    np.testing.assert_array_equal(cal.flux, sp.flux)
+    np.testing.assert_array_equal(cal.uncertainty.array, sp.uncertainty.array)
+    np.testing.assert_array_equal(cal.mask, sp.mask)
+    assert cal.meta == sp.meta
+
+    # The spectral axis must follow the solution to within the fitted residual.
+    x = np.arange(npix)
+    res_pix = (cal.spectral_axis.to_value(u.angstrom) - ws.p2w(x)) / ws.p2w_dldx(x)
+    assert np.max(np.abs(res_pix)) < 0.1
+
+
+def test_attach_wcs_result_writes_as_wcs1d_fits(gra_solution, tmp_path):
+    npix = gra_solution.bounds_pix[1]
+    sp = Spectrum(flux=np.arange(npix) * u.count, spectral_axis=np.arange(npix) * u.pix)
+    cal = gra_solution.attach_wcs(sp)
+
+    path = tmp_path / "calibrated.fits"
+    cal.write(path, format="wcs1d-fits")
+    back = Spectrum.read(path, format="wcs1d-fits")
+
+    assert fits.getheader(path)["CTYPE1"] == "AWAV-GRA"
+    np.testing.assert_allclose(back.spectral_axis.to_value(u.m), cal.spectral_axis.to_value(u.m))
+    np.testing.assert_allclose(back.flux.value, cal.flux.value)
+
+
+def test_wcs_is_cached_and_invalidated():
+    # A dedicated solution: the test clears the cache, which a shared fixture would carry
+    # into every test that follows.
+    ws = _make_gra_solution(128, wave_air=True)
+    assert ws.wcs() is not None
+    assert True in ws._wcs_cache
+
+    # A second call must reuse the fit but still hand out an independent object.
+    w1, w2 = ws.wcs(), ws.wcs()
+    assert w1 is not w2
+    np.testing.assert_array_equal(w1.wcs.get_pv(), w2.wcs.get_pv())
+
+    # Both axis types are cached separately.
+    ws.wcs(wave_air=False)
+    assert set(ws._wcs_cache) == {True, False}
+
+    ws.p2w = ws.p2w
+    assert ws._wcs_cache == {}
+
+
+def test_attach_wcs_raises_on_length_mismatch(gra_solution):
+    sp = Spectrum(flux=np.ones(13) * u.count, spectral_axis=np.arange(13) * u.pix)
+    with pytest.raises(ValueError, match="13 pixels"):
+        gra_solution.attach_wcs(sp)
+
+
+def test_attach_wcs_raises_on_multidimensional_flux(gra_solution):
+    npix = gra_solution.bounds_pix[1]
+    sp = Spectrum(flux=np.ones((3, npix)) * u.count, spectral_axis=np.arange(npix) * u.pix)
+    with pytest.raises(ValueError, match="one-dimensional"):
+        gra_solution.attach_wcs(sp)
 
 
 def test_asdf_round_trip_is_lossless(tmp_path):

--- a/specreduce/tests/test_wavesol1d.py
+++ b/specreduce/tests/test_wavesol1d.py
@@ -2,13 +2,15 @@ import asdf
 import astropy.units as u
 import numpy as np
 import pytest
-from astropy.modeling import models
+from astropy.modeling import models, fitting
 from astropy.modeling.polynomial import Polynomial1D
 from astropy.nddata import StdDevUncertainty
 from gwcs import coordinate_frames, wcs
-from specreduce.wavesol1d import _diff_poly1d, WavelengthSolution1D
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.wcs import WCS as astropy_WCS
 from specutils import Spectrum
 
+from specreduce.wavesol1d import _diff_poly1d, WavelengthSolution1D
 
 ref_pixel = 250.0
 p2w = models.Shift(ref_pixel) | models.Polynomial1D(degree=3, c0=1, c1=0.2, c2=0.001)
@@ -24,6 +26,33 @@ def mk_ws_without_transform():
 @pytest.fixture
 def mk_ws_with_transform():
     return WavelengthSolution1D(p2w, pix_bounds, u.angstrom)
+
+
+def _make_gra_solution(npix: int, wave_air: bool = False) -> WavelengthSolution1D:
+    """Create a solution whose polynomial closely follows a true grating dispersion curve."""
+    wt = astropy_WCS(naxis=1)
+    wt.wcs.ctype = ["AWAV-GRA"]
+    wt.wcs.cunit = ["Angstrom"]
+    wt.wcs.crpix = [npix // 2]
+    wt.wcs.crval = [5410.0]
+    wt.wcs.cdelt = [2.4]
+    wt.wcs.set_pv([(1, 0, 5.0e5), (1, 1, 1.0), (1, 2, 8.05)])
+    x = np.arange(npix)
+    ref_pixel = npix // 2 - 1
+    lam = wt.wcs_pix2world(x[:, None] + 1.0, 1)[:, 0] * 1e10
+    poly = fitting.LinearLSQFitter()(Polynomial1D(3), x - ref_pixel, lam)
+    m = models.Shift(-ref_pixel) | poly
+    return WavelengthSolution1D(m, (0, npix), u.angstrom, wave_air=wave_air)
+
+
+@pytest.fixture(scope="module")
+def gra_solution():
+    return _make_gra_solution(512, wave_air=True)
+
+
+@pytest.fixture(scope="module")
+def gra_fitted_wcs(gra_solution):
+    return gra_solution.wcs(seed=1)
 
 
 @pytest.fixture
@@ -68,6 +97,10 @@ def test_init():
 
     ws = WavelengthSolution1D(None, pix_bounds, u.angstrom)
     assert ws._p2w is None
+
+    assert ws.wave_air is False
+    ws = WavelengthSolution1D(p2w, pix_bounds, u.angstrom, wave_air=True)
+    assert ws.wave_air is True
 
 
 def test_resample(mk_spectrum, mk_ws_with_transform, mk_ws_without_transform):
@@ -131,6 +164,59 @@ def test_wcs_creates_valid_gwcs_object(mk_ws_with_transform):
     assert wcs_obj is not None
     assert isinstance(wcs_obj, wcs.WCS)
     assert wcs_obj.output_frame.unit[0] == u.angstrom
+
+
+def test_wcs_gra_round_trip(gra_solution, gra_fitted_wcs):
+    ws, w = gra_solution, gra_fitted_wcs
+    assert isinstance(w, astropy_WCS)
+    assert w.wcs.ctype[0] == "AWAV-GRA"
+    x = np.arange(*ws.bounds_pix)
+    res_pix = (w.wcs_pix2world(x[:, None] + 1.0, 1)[:, 0] * 1e10 - ws.p2w(x)) / ws.p2w_dldx(x)
+    assert np.max(np.abs(res_pix)) < 0.1
+
+
+def test_wcs_ctype_air_vacuum():
+    ws_air = _make_gra_solution(128, wave_air=True)
+    ws_vac = _make_gra_solution(128, wave_air=False)
+    assert ws_air.wcs(npix_subsample=32, seed=2).wcs.ctype[0] == "AWAV-GRA"
+    assert ws_vac.wcs(npix_subsample=32, seed=2).wcs.ctype[0] == "WAVE-GRA"
+    assert ws_air.wcs(wave_air=False, npix_subsample=32, seed=2).wcs.ctype[0] == "WAVE-GRA"
+    assert ws_vac.wcs(wave_air=True, npix_subsample=32, seed=2).wcs.ctype[0] == "AWAV-GRA"
+
+
+def test_wcs_warning_on_poor_fit():
+    ws = _make_gra_solution(128)
+    with pytest.warns(AstropyUserWarning, match="lossless"):
+        w = ws.wcs(max_residual=0.0, npix_subsample=32, seed=2)
+    assert isinstance(w, astropy_WCS)
+
+
+def test_wcs_deterministic():
+    ws = _make_gra_solution(128)
+    w1 = ws.wcs(npix_subsample=32, seed=7)
+    w2 = ws.wcs(npix_subsample=32, seed=7)
+    np.testing.assert_array_equal(w1.wcs.crpix, w2.wcs.crpix)
+    np.testing.assert_array_equal(w1.wcs.crval, w2.wcs.crval)
+    np.testing.assert_array_equal(w1.wcs.cdelt, w2.wcs.cdelt)
+    assert w1.wcs.get_pv() == w2.wcs.get_pv()
+
+
+def test_wcs_header_round_trip(gra_solution, gra_fitted_wcs):
+    w = gra_fitted_wcs
+    w2 = astropy_WCS(w.to_header())
+    x = np.arange(*gra_solution.bounds_pix)[:, None] + 1.0
+    np.testing.assert_allclose(w2.wcs_pix2world(x, 1), w.wcs_pix2world(x, 1), rtol=1e-12)
+
+
+def test_wcs_raises_without_transform(mk_ws_without_transform):
+    with pytest.raises(ValueError, match="Wavelength solution not set."):
+        mk_ws_without_transform.wcs()
+
+
+def test_wcs_raises_for_non_length_unit():
+    ws = WavelengthSolution1D(p2w, pix_bounds, u.Hz)
+    with pytest.raises(ValueError, match="length unit"):
+        ws.wcs()
 
 
 def test_asdf_round_trip_is_lossless(tmp_path):

--- a/specreduce/tests/test_wavesol1d.py
+++ b/specreduce/tests/test_wavesol1d.py
@@ -172,7 +172,7 @@ def test_wcs_gra_round_trip(gra_solution, gra_fitted_wcs):
     assert w.wcs.ctype[0] == "AWAV-GRA"
     x = np.arange(*ws.bounds_pix)
     res_pix = (w.wcs_pix2world(x[:, None] + 1.0, 1)[:, 0] * 1e10 - ws.p2w(x)) / ws.p2w_dldx(x)
-    assert np.max(np.abs(res_pix)) < 0.5
+    assert np.max(np.abs(res_pix)) < 0.1
 
 
 def test_wcs_pinned_keywords(gra_solution, gra_fitted_wcs):
@@ -193,8 +193,8 @@ def test_wcs_ctype_air_vacuum():
     ws_air = _make_gra_solution(128, wave_air=True)
     ws_vac = _make_gra_solution(128, wave_air=False)
     assert ws_air.wcs().wcs.ctype[0] == "AWAV-GRA"
-    assert ws_vac.wcs().wcs.ctype[0] == "WAVE-GRA"
-    assert ws_air.wcs(wave_air=False).wcs.ctype[0] == "WAVE-GRA"
+    assert ws_vac.wcs().wcs.ctype[0] == "WAVE-GRI"
+    assert ws_air.wcs(wave_air=False).wcs.ctype[0] == "WAVE-GRI"
     assert ws_vac.wcs(wave_air=True).wcs.ctype[0] == "AWAV-GRA"
 
 
@@ -220,6 +220,61 @@ def test_wcs_raises_without_transform(mk_ws_without_transform):
 def test_wcs_raises_for_non_length_unit():
     ws = WavelengthSolution1D(p2w, pix_bounds, u.Hz)
     with pytest.raises(ValueError, match="length unit"):
+        ws.wcs()
+
+
+def _assert_wcs_matches_solution(ws, scale, npix=512, limit=0.5):
+    w = ws.wcs()
+    x = np.arange(0, npix)
+    lam_fit = w.wcs_pix2world(x[:, None] + 1.0, 1)[:, 0] * scale
+    assert np.all(np.isfinite(lam_fit))
+    res_pix = (lam_fit - ws.p2w(x)) / ws.p2w_dldx(x)
+    assert np.max(np.abs(res_pix)) < limit
+
+
+def test_wcs_red_ir_solution():
+    # A K-band solution: the grating fit must converge far from the optical regime.
+    poly = Polynomial1D(3, c0=24000.0, c1=2.4, c2=5e-5, c3=-2e-8)
+    ws = WavelengthSolution1D(models.Shift(-255) | poly, (0, 512), u.angstrom)
+    _assert_wcs_matches_solution(ws, 1e10)
+
+
+def test_wcs_micron_unit():
+    # 'micron' has no FITS unit string of its own; export must use the FITS format ('um').
+    poly = Polynomial1D(3, c0=2.4, c1=2.4e-4, c2=5e-9, c3=-2e-12)
+    ws = WavelengthSolution1D(models.Shift(-255) | poly, (0, 512), u.micron)
+    _assert_wcs_matches_solution(ws, 1e6)
+
+
+def test_wcs_uv_vacuum_solution():
+    # A vacuum axis exported as 'WAVE-GRA' would pass through wcslib's air-refraction
+    # model, which is invalid below ~2000 A; vacuum solutions must use 'WAVE-GRI'.
+    poly = Polynomial1D(3, c0=1600.0, c1=0.6, c2=1e-5, c3=-5e-9)
+    ws = WavelengthSolution1D(models.Shift(-255) | poly, (0, 512), u.angstrom)
+    assert ws.wcs().wcs.ctype[0] == "WAVE-GRI"
+    _assert_wcs_matches_solution(ws, 1e10, limit=0.1)
+
+
+def test_wcs_raises_on_nonfinite_solution():
+    poly = Polynomial1D(3, c0=5410.0, c1=2.4, c2=np.nan, c3=0.0)
+    ws = WavelengthSolution1D(models.Shift(-255) | poly, (0, 512), u.angstrom)
+    with pytest.raises(ValueError, match="non-finite"):
+        ws.wcs()
+
+
+def test_wcs_raises_for_non_power_series_model():
+    cheb = models.Chebyshev1D(3, c0=5410.0, c1=600.0, c2=5.0, c3=-1.0)
+    ws = WavelengthSolution1D(models.Shift(-255) | cheb, (0, 512), u.angstrom)
+    with pytest.raises(TypeError, match="Polynomial1D"):
+        ws.wcs()
+
+
+def test_wcs_raises_when_fit_degenerate():
+    # Metre-scale "wavelengths": no grating within the parameter bounds can reproduce
+    # this, so every residual evaluation is unphysical and the fit must fail loudly.
+    poly = Polynomial1D(1, c0=1e10, c1=2.4)
+    ws = WavelengthSolution1D(models.Shift(-255) | poly, (0, 512), u.angstrom)
+    with pytest.raises(RuntimeError, match="grating dispersion"):
         ws.wcs()
 
 

--- a/specreduce/wavecal1d.py
+++ b/specreduce/wavecal1d.py
@@ -146,7 +146,7 @@ class WavelengthCalibration1D:
         wave_air
             Boolean indicating whether the input wavelengths correspond to air rather than vacuum;
             by default `False`, meaning vacuum wavelengths. The flag is also stored in the
-            wavelength solution, where it selects between the 'AWAV-GRA' and 'WAVE-GRA' axis
+            wavelength solution, where it selects between the 'AWAV-GRA' and 'WAVE-GRI' axis
             types in FITS WCS export.
         """
         self.unit = unit

--- a/specreduce/wavecal1d.py
+++ b/specreduce/wavecal1d.py
@@ -145,7 +145,9 @@ class WavelengthCalibration1D:
 
         wave_air
             Boolean indicating whether the input wavelengths correspond to air rather than vacuum;
-            by default `False`, meaning vacuum wavelengths.
+            by default `False`, meaning vacuum wavelengths. The flag is also stored in the
+            wavelength solution, where it selects between the 'AWAV-GRA' and 'WAVE-GRA' axis
+            types in FITS WCS export.
         """
         self.unit = unit
         self._unit_str = unit.to_string("latex")
@@ -164,7 +166,7 @@ class WavelengthCalibration1D:
         self._trees: list[KDTree] | None = None
 
         self._fit: optimize.OptimizeResult | None = None
-        self.solution = WavelengthSolution1D(None, pix_bounds, unit)
+        self.solution = WavelengthSolution1D(None, pix_bounds, unit, wave_air=wave_air)
 
         # Read and store the observational data if given. The user can provide either a list of arc
         # spectra as Spectrum objects or a list of line pixel position arrays. An attempt to give

--- a/specreduce/wavelength_calibration.py
+++ b/specreduce/wavelength_calibration.py
@@ -5,6 +5,7 @@ from astropy import units as u
 from astropy.modeling.fitting import LMLSQFitter, LinearLSQFitter
 from astropy.modeling.models import Linear1D
 from astropy.table import QTable, hstack
+from astropy.utils.decorators import deprecated
 from gwcs import coordinate_frames as cf
 from gwcs import wcs
 
@@ -24,6 +25,13 @@ def _check_arr_monotonic(arr):
     return sorted_increasing or sorted_decreasing
 
 
+@deprecated(
+    since="1.7",
+    message=(
+        "The {name} {obj_type} is deprecated and will be removed in specreduce v1.11. "
+        "Use `specreduce.wavecal1d.WavelengthCalibration1D` instead."
+    ),
+)
 class WavelengthCalibration1D():
 
     def __init__(self, input_spectrum, matched_line_list=None, line_pixels=None,

--- a/specreduce/wavesol1d.py
+++ b/specreduce/wavesol1d.py
@@ -310,9 +310,17 @@ class WavelengthSolution1D:
 
         Fits the FITS WCS Paper III grism dispersion function (Greisen et al. 2006,
         A&A 446, 747, Sect. 5.1) to the exact pixel-to-wavelength model and returns the
-        result as a standard `~astropy.wcs.WCS` object with an 'AWAV-GRA' (air) or
-        'WAVE-GRI' (vacuum) spectral axis that can be serialized into a FITS header and
-        evaluated by any FITS-compliant reader.
+        result as a standard `~astropy.wcs.WCS` object that can be serialized into a FITS
+        header and evaluated by any FITS-compliant reader. The spectral axis type is
+        'AWAV-GRA' for air wavelengths or 'WAVE-GRI' for vacuum wavelengths.
+
+        Note on the naming: despite appearances, neither algorithm code refers to a
+        grating versus a grism. Both 'GRA' and 'GRI' denote the same Paper III grism
+        dispersion algorithm, and the trailing letter only identifies the medium the
+        wavelengths are measured in: 'GRA' is the grism dispersion relation for air
+        wavelengths and 'GRI' the one for vacuum wavelengths. The algorithm code is
+        therefore always paired with the matching coordinate type: 'AWAV' (air
+        wavelength) with 'GRA', and 'WAVE' (vacuum wavelength) with 'GRI'.
 
         The fit is cached per air/vacuum axis type and invalidated whenever the
         pixel-to-wavelength transformation changes. Each call returns an independent copy
@@ -374,10 +382,11 @@ class WavelengthSolution1D:
         far from any grism dispersion curve, and the lossless :attr:`gwcs` property
         should be used instead.
 
-        Vacuum solutions use 'WAVE-GRI' (grism in vacuum, Sect. 5.1.2 of the paper)
-        rather than 'WAVE-GRA' because the GRA algorithm (Sect. 5.1.4) is native to air
-        wavelengths: pairing it with a vacuum axis would route every evaluation through
-        wcslib's air-refraction model, which is not valid below ~200 nm.
+        Vacuum solutions use 'WAVE-GRI' (the grism-in-vacuum form of the algorithm,
+        Sect. 5.1.2 of the paper) rather than 'WAVE-GRA' because the 'GRA' form
+        (Sect. 5.1.4) is native to air wavelengths: pairing it with a vacuum axis would
+        route every evaluation through wcslib's air-refraction model, which is not valid
+        below ~200 nm.
 
         Note also that wcslib normalizes spectral axes to SI units, so evaluating the
         returned WCS yields wavelengths in metres regardless of the CUNIT, and serializing

--- a/specreduce/wavesol1d.py
+++ b/specreduce/wavesol1d.py
@@ -11,7 +11,7 @@ import numpy as np
 from astropy.modeling import models, CompoundModel
 from astropy.nddata import VarianceUncertainty
 from astropy.utils.exceptions import AstropyUserWarning
-from astropy.wcs import WCS
+from astropy.wcs import WCS, InvalidTransformError
 from gwcs import coordinate_frames
 from numpy.ma import MaskedArray
 from numpy.typing import ArrayLike, NDArray
@@ -63,7 +63,7 @@ def _make_gra_wcs(
     cdelt
         Linear dispersion at the reference pixel.
     ctype
-        Spectral axis type, either 'AWAV-GRA' (air) or 'WAVE-GRA' (vacuum).
+        Spectral axis type, either 'AWAV-GRA' (air) or 'WAVE-GRI' (vacuum).
     cunit
         Wavelength unit string.
 
@@ -92,60 +92,31 @@ def _make_gra_wcs(
     return w
 
 
-def _gra_residuals(
-    p: ArrayLike, crpix: float, crval: float, cdelt: float, x_fits: NDArray, lam: NDArray,
-    ctype: str, cunit: str, m_to_unit: float,
-) -> NDArray:
-    """Compute the residuals between a grating dispersion WCS and the exact solution.
-
-    Parameters
-    ----------
-    p
-        Grating parameters as in `_make_gra_wcs`.
-    crpix
-        Reference pixel in the one-based FITS convention.
-    crval
-        Wavelength at the reference pixel.
-    cdelt
-        Linear dispersion at the reference pixel.
-    x_fits
-        Pixel coordinates as a (npt, 1) array in the one-based FITS convention.
-    lam
-        Exact wavelengths at ``x_fits`` in the solution unit.
-    ctype
-        Spectral axis type, either 'AWAV-GRA' (air) or 'WAVE-GRA' (vacuum).
-    cunit
-        Wavelength unit string.
-    m_to_unit
-        Conversion factor from metres to the solution unit, needed because wcslib returns
-        metres for a spectral axis regardless of the CUNIT.
-
-    Returns
-    -------
-    Residual wavelengths in the solution unit. Unphysical parameter combinations, for which
-    wcslib raises or returns non-finite values, yield large finite residuals to keep the
-    optimizer within the valid parameter space.
-    """
-    try:
-        w = _make_gra_wcs(p, crpix, crval, cdelt, ctype, cunit)
-        res = w.wcs_pix2world(x_fits, 1)[:, 0] * m_to_unit - lam
-    except Exception:
-        return np.full(lam.size, 1e8)
-    return np.where(np.isfinite(res), res, 1e8)
+GRA_SENTINEL = 1e8
+"""Residual value standing in for unphysical grating parameter combinations."""
 
 
 def _fit_gra_dispersion(
-    x_fits: NDArray, lam: NDArray, crpix: float, crval: float, cdelt: float, ctype: str,
-    cunit: str, m_to_unit: float,
-) -> NDArray:
+    x_fits: NDArray,
+    lam: NDArray,
+    crpix: float,
+    crval: float,
+    cdelt: float,
+    ctype: str,
+    cunit: str,
+    m_to_unit: float,
+) -> optimize.OptimizeResult:
     """Fit the WCS Paper III grating dispersion function to an exact wavelength solution.
 
     Fits the four free grating parameters (g, alpha, nrp, theta) with a single bounded
     least-squares run. The reference pixel keywords (CRPIX, CRVAL, CDELT) are exact
     statements about the wavelength solution and pin the value and slope of the dispersion
     function at the reference pixel, which makes the problem unimodal enough for a local
-    optimizer started from a fixed initial guess. The bounds fence off the region where
-    the grating equation goes out of the arcsin domain.
+    optimizer. The initial grating density is the Littrow-configuration value at the
+    reference wavelength, which places the starting point inside the arcsin domain of the
+    grating equation for any reference wavelength, and pixels for which wcslib returns
+    non-finite values yield large finite residuals that keep the optimizer within the
+    valid parameter space.
 
     Parameters
     ----------
@@ -160,23 +131,56 @@ def _fit_gra_dispersion(
     cdelt
         Fixed linear dispersion at the reference pixel.
     ctype
-        Spectral axis type, either 'AWAV-GRA' (air) or 'WAVE-GRA' (vacuum).
+        Spectral axis type, either 'AWAV-GRA' (air) or 'WAVE-GRI' (vacuum).
     cunit
-        Wavelength unit string.
+        Wavelength unit string in the FITS format.
     m_to_unit
-        Conversion factor from metres to the solution unit.
+        Conversion factor from metres to the solution unit, needed because wcslib returns
+        metres for a spectral axis regardless of the CUNIT.
 
     Returns
     -------
-    The optimized grating parameters as in `_make_gra_wcs`.
+    The `~scipy.optimize.OptimizeResult` of the fit, where ``x`` holds the optimized
+    grating parameters as in `_make_gra_wcs` and ``fun`` the residual wavelengths in the
+    solution unit.
+
+    Raises
+    ------
+    RuntimeError
+        If the grating dispersion function cannot be evaluated anywhere along the
+        spectral axis at the fitted parameters.
     """
-    p0 = [5e5, 10.0, 0.0, 0.0]  # g, alpha, nrp, theta
+
+    def residuals(p: NDArray) -> NDArray:
+        try:
+            w = _make_gra_wcs(p, crpix, crval, cdelt, ctype, cunit)
+            res = w.wcs_pix2world(x_fits, 1)[:, 0] * m_to_unit - lam
+        except InvalidTransformError:
+            return np.full(lam.size, GRA_SENTINEL)
+        return np.where(np.isfinite(res), res, GRA_SENTINEL)
+
+    lam_ref_m = crval / m_to_unit
+    g0 = float(np.clip(2.0 * np.sin(np.radians(10.0)) / lam_ref_m, 1e3, 1e7))
+    p0 = [g0, 10.0, 0.0, 0.0]  # g, alpha, nrp, theta
+
+    # Set the WCS once outside the fit so that parameter-independent configuration errors
+    # (such as an invalid CUNIT) propagate instead of being fenced off as unphysical
+    # parameter combinations. Out-of-domain grating parameters do not raise here: wcslib
+    # signals them with non-finite coordinates handled in `residuals`.
+    _make_gra_wcs(p0, crpix, crval, cdelt, ctype, cunit).wcs.set()
+
     bounds = ([1e3, -89.9, -1e7, -89.9], [1e7, 89.9, 1e7, 89.9])
     fit = optimize.least_squares(
-        _gra_residuals, p0, args=(crpix, crval, cdelt, x_fits, lam, ctype, cunit, m_to_unit),
-        bounds=bounds, method="trf", x_scale=[1e5, 10.0, 1e4, 10.0],
+        residuals, p0, bounds=bounds, method="trf", x_scale=[g0, 10.0, 1e4, 10.0]
     )
-    return fit.x
+    if np.all(fit.fun == GRA_SENTINEL):
+        raise RuntimeError(
+            "The grating dispersion function could not be evaluated anywhere along the "
+            "spectral axis: the wavelength solution is outside the parameter space "
+            "reachable by the 'WAVE-GRI'/'AWAV-GRA' dispersion model. The 'gwcs' property "
+            "provides a lossless representation."
+        )
+    return fit
 
 
 class WavelengthSolution1D:
@@ -300,15 +304,18 @@ class WavelengthSolution1D:
 
         Fits the FITS WCS Paper III grating dispersion function to the exact
         pixel-to-wavelength model and returns the result as a standard `~astropy.wcs.WCS`
-        object with a 'AWAV-GRA' (air) or 'WAVE-GRA' (vacuum) spectral axis that can be
+        object with an 'AWAV-GRA' (air) or 'WAVE-GRI' (vacuum) spectral axis that can be
         serialized into a FITS header and evaluated by any FITS-compliant reader.
 
         Parameters
         ----------
         wave_air
             Whether the spectral axis represents air rather than vacuum wavelengths,
-            selecting between the 'AWAV-GRA' and 'WAVE-GRA' axis types. If `None`, the
-            value given in the initialization is used.
+            selecting between the 'AWAV-GRA' and 'WAVE-GRI' axis types. If `None`, the
+            value given in the initialization is used. The flag only declares what the
+            solution's wavelengths mean: no air-vacuum conversion is applied to the
+            wavelength values, so overriding it relabels the axis without changing the
+            numbers.
         max_residual
             Maximum allowed absolute deviation between the fitted dispersion function and
             the exact solution in pixels. A fit exceeding this limit emits an
@@ -317,6 +324,19 @@ class WavelengthSolution1D:
         Returns
         -------
         A 1D `~astropy.wcs.WCS` using the Paper III grating dispersion function.
+
+        Raises
+        ------
+        ValueError
+            If the wavelength solution is not set, its unit is not a length unit, or it
+            produces non-finite values within the pixel bounds.
+        TypeError
+            If the wavelength solution does not use a power-series
+            `~astropy.modeling.polynomial.Polynomial1D` model.
+        RuntimeError
+            If the grating dispersion function cannot be evaluated anywhere along the
+            spectral axis, meaning the solution is outside the parameter space reachable
+            by the dispersion model.
 
         Notes
         -----
@@ -339,15 +359,26 @@ class WavelengthSolution1D:
         from any grating dispersion curve, and the lossless :attr:`gwcs` property should
         be used instead.
 
+        Vacuum solutions use 'WAVE-GRI' (grating in vacuo) rather than 'WAVE-GRA' because
+        the GRA algorithm is native to air wavelengths: pairing it with a vacuum axis
+        would route every evaluation through wcslib's air-refraction model, which is not
+        valid below ~200 nm.
+
         Note also that wcslib normalizes spectral axes to SI units, so evaluating the
-        returned WCS yields wavelengths in metres regardless of the CUNIT.
+        returned WCS yields wavelengths in metres regardless of the CUNIT, and serializing
+        it with ``to_header()`` likewise writes CRVAL and CDELT in metres with CUNIT 'm'.
         """
         if self._p2w is None:
             raise ValueError("Wavelength solution not set.")
+        if not isinstance(self._p2w[1], models.Polynomial1D):
+            raise TypeError(
+                "FITS WCS export requires the wavelength solution to use a power-series "
+                f"Polynomial1D model, got {type(self._p2w[1]).__name__}."
+            )
 
         air = self.wave_air if wave_air is None else wave_air
-        ctype = "AWAV-GRA" if air else "WAVE-GRA"
-        cunit = self.unit.to_string()
+        ctype = "AWAV-GRA" if air else "WAVE-GRI"
+        cunit = self.unit.to_string("fits")
 
         try:
             m_to_unit = (1.0 * u.m).to_value(self.unit)
@@ -360,12 +391,18 @@ class WavelengthSolution1D:
         x_model = np.arange(self.bounds_pix[0], self.bounds_pix[1])
         x_fits = x_model[:, None] + 1.0
         lam = self.p2w(x_model)
+        if not np.all(np.isfinite(lam)):
+            raise ValueError(
+                "The wavelength solution produces non-finite values within the pixel "
+                "bounds and cannot be exported as a FITS WCS."
+            )
 
-        popt = _fit_gra_dispersion(x_fits, lam, crpix, crval, cdelt, ctype, cunit, m_to_unit)
-        w = _make_gra_wcs(popt, crpix, crval, cdelt, ctype, cunit)
+        fit = _fit_gra_dispersion(x_fits, lam, crpix, crval, cdelt, ctype, cunit, m_to_unit)
+        w = _make_gra_wcs(fit.x, crpix, crval, cdelt, ctype, cunit)
 
-        res_wav = _gra_residuals(popt, crpix, crval, cdelt, x_fits, lam, ctype, cunit, m_to_unit)
-        max_res = float(np.max(np.abs(res_wav / self.p2w_dldx(x_model))))
+        with np.errstate(divide="ignore", invalid="ignore"):
+            res_pix = np.abs(fit.fun / self.p2w_dldx(x_model))
+        max_res = float(np.nanmax(res_pix)) if np.any(np.isfinite(res_pix)) else np.inf
         if max_res > max_residual:
             warnings.warn(
                 f"The fitted FITS WCS deviates from the wavelength solution by up to "

--- a/specreduce/wavesol1d.py
+++ b/specreduce/wavesol1d.py
@@ -223,6 +223,7 @@ class WavelengthSolution1D:
         self._unit_str = unit.to_string("latex")
         self.bounds_pix: tuple[int, int] = bounds_pix
         self.bounds_wav: tuple[float, float] | None = None
+        self._wcs_cache: dict[bool, tuple[tuple, float]] = {}
         self._p2w: None | CompoundModel = None
         self.p2w = p2w
 
@@ -242,6 +243,7 @@ class WavelengthSolution1D:
             del self.w2p
         if "gwcs" in self.__dict__:
             del self.gwcs
+        self._wcs_cache.clear()
 
     @cached_property
     def p2w_dldx(self) -> CompoundModel:
@@ -312,6 +314,10 @@ class WavelengthSolution1D:
         'WAVE-GRI' (vacuum) spectral axis that can be serialized into a FITS header and
         evaluated by any FITS-compliant reader.
 
+        The fit is cached per air/vacuum axis type and invalidated whenever the
+        pixel-to-wavelength transformation changes. Each call returns an independent copy
+        of the cached WCS, so the caller is free to modify the result.
+
         Parameters
         ----------
         wave_air
@@ -377,6 +383,39 @@ class WavelengthSolution1D:
         returned WCS yields wavelengths in metres regardless of the CUNIT, and serializing
         it with ``to_header()`` likewise writes CRVAL and CDELT in metres with CUNIT 'm'.
         """
+        air = self.wave_air if wave_air is None else wave_air
+        if air not in self._wcs_cache:
+            self._wcs_cache[air] = self._fit_wcs(air)
+        args, max_res = self._wcs_cache[air]
+
+        if max_res > max_residual:
+            warnings.warn(
+                f"The fitted FITS WCS deviates from the wavelength solution by up to "
+                f"{max_res:.2f} pixels, exceeding the given limit of {max_residual} pixels. "
+                f"The 'gwcs' property provides a lossless representation.",
+                AstropyUserWarning,
+            )
+        return _make_grism_wcs(*args)
+
+    def _fit_wcs(self, air: bool) -> tuple[tuple, float]:
+        """Fit the grism dispersion function to the wavelength solution.
+
+        Caching the arguments of `_make_grism_wcs` rather than the fitted WCS itself keeps
+        every call to :meth:`wcs` returning a pristine object: wcslib normalizes a WCS to SI
+        units in place the first time it is evaluated, so a shared or copied instance would
+        hand out metres where a freshly built one still carries the solution unit. Rebuilding
+        costs microseconds against the milliseconds of the fit.
+
+        Parameters
+        ----------
+        air
+            Whether the spectral axis represents air rather than vacuum wavelengths.
+
+        Returns
+        -------
+        The arguments needed to rebuild the fitted `~astropy.wcs.WCS` and the largest
+        deviation from the exact solution within the pixel bounds in pixels.
+        """
         if self._p2w is None:
             raise ValueError("Wavelength solution not set.")
         if not isinstance(self._p2w[1], models.Polynomial1D):
@@ -385,7 +424,6 @@ class WavelengthSolution1D:
                 f"Polynomial1D model, got {type(self._p2w[1]).__name__}."
             )
 
-        air = self.wave_air if wave_air is None else wave_air
         ctype = "AWAV-GRA" if air else "WAVE-GRI"
         cunit = self.unit.to_string("fits")
 
@@ -407,19 +445,81 @@ class WavelengthSolution1D:
             )
 
         fit = _fit_grism_dispersion(x_fits, lam, crpix, crval, cdelt, ctype, cunit, m_to_unit)
-        w = _make_grism_wcs(fit.x, crpix, crval, cdelt, ctype, cunit)
 
         with np.errstate(divide="ignore", invalid="ignore"):
             res_pix = np.abs(fit.fun / self.p2w_dldx(x_model))
         max_res = float(np.nanmax(res_pix)) if np.any(np.isfinite(res_pix)) else np.inf
-        if max_res > max_residual:
-            warnings.warn(
-                f"The fitted FITS WCS deviates from the wavelength solution by up to "
-                f"{max_res:.2f} pixels, exceeding the given limit of {max_residual} pixels. "
-                f"The 'gwcs' property provides a lossless representation.",
-                AstropyUserWarning,
+        return (fit.x, crpix, crval, cdelt, ctype, cunit), max_res
+
+    def attach_wcs(
+        self, spectrum: Spectrum, wave_air: bool | None = None, max_residual: float = 1.0
+    ) -> Spectrum:
+        """Attach the fitted FITS WCS to a copy of a pixel-space spectrum.
+
+        Returns a new `~specutils.Spectrum` holding the flux, uncertainty, mask, and metadata
+        of the given spectrum with the FITS WCS returned by :meth:`wcs` as its world
+        coordinate system. The samples are left where they are and only their spectral
+        coordinates change, so the result can be written with the specutils 'wcs1d-fits'
+        format, which stores the flux as an image and the wavelength solution as WCS header
+        keywords. Use :meth:`resample` instead to rebin the flux onto a wavelength grid.
+
+        The fitted WCS is cached per air/vacuum axis type and reused, so applying one
+        solution to many spectra runs the grism fit only once. The cache is cleared whenever
+        the pixel-to-wavelength transformation changes.
+
+        Parameters
+        ----------
+        spectrum
+            A pixel-space spectrum sampled on the pixel grid the solution was fitted on.
+        wave_air
+            Whether the spectral axis represents air rather than vacuum wavelengths. If
+            `None`, the value given in the initialization is used.
+        max_residual
+            Maximum allowed absolute deviation between the fitted dispersion function and
+            the exact solution in pixels. A fit exceeding this limit emits an
+            `~astropy.utils.exceptions.AstropyUserWarning`.
+
+        Returns
+        -------
+        A spectrum with the same flux as the input and a FITS WCS spectral axis.
+
+        Raises
+        ------
+        ValueError
+            If the spectrum is not one-dimensional, or if its length does not match the
+            pixel range the solution was fitted over.
+
+        Notes
+        -----
+        The spectrum is assumed to be sampled one flux value per pixel over the solution's
+        pixel bounds, which is what the calibration produces: the WCS maps array index i to
+        the solution's pixel i, and a length mismatch means the spectrum does not share the
+        pixel grid the solution was derived on.
+
+        Because wcslib normalizes spectral axes to SI units, the spectral axis of the
+        returned spectrum is in metres regardless of the solution unit.
+        """
+        if spectrum.flux.ndim != 1:
+            raise ValueError(
+                f"Applying a wavelength solution requires a one-dimensional spectrum, got "
+                f"{spectrum.flux.ndim} dimensions."
             )
-        return w
+
+        npix = spectrum.flux.shape[0]
+        npix_solution = self.bounds_pix[1] - self.bounds_pix[0]
+        if npix != npix_solution:
+            raise ValueError(
+                f"The spectrum has {npix} pixels but the wavelength solution was fitted "
+                f"over {npix_solution}."
+            )
+
+        return Spectrum(
+            flux=spectrum.flux,
+            wcs=self.wcs(wave_air=wave_air, max_residual=max_residual),
+            uncertainty=spectrum.uncertainty,
+            mask=spectrum.mask,
+            meta=spectrum.meta,
+        )
 
     def to_asdf(self, path: str | Path, **kwargs) -> None:
         """Serialize the wavelength solution into an ASDF file.

--- a/specreduce/wavesol1d.py
+++ b/specreduce/wavesol1d.py
@@ -45,17 +45,21 @@ def _diff_poly1d(m: models.Polynomial1D) -> models.Polynomial1D:
     return models.Polynomial1D(m.degree - 1, **coeffs)
 
 
-def _make_gra_wcs(
+def _make_grism_wcs(
     p: ArrayLike, crpix: float, crval: float, cdelt: float, ctype: str, cunit: str
 ) -> WCS:
-    """Create a 1D FITS WCS using the WCS Paper III grating dispersion function.
+    """Create a 1D FITS WCS using the WCS Paper III grism dispersion function.
+
+    The grism dispersion function and its PV parameters are defined in Greisen et al.
+    (2006, A&A 446, 747), Sect. 5.1 and Table 6.
 
     Parameters
     ----------
     p
-        Fitted grating parameters (g, alpha, nrp, theta): the effective grating density
-        [1/m], the incidence angle [deg], the derivative of the refractive index with
-        respect to wavelength at the reference wavelength [1/m], and the camera angle [deg].
+        Fitted grism parameters (g, alpha, nrp, theta): the effective grating ruling
+        density [1/m], the incidence angle [deg], the derivative of the prism refractive
+        index with respect to wavelength at the reference wavelength [1/m], and the
+        camera angle [deg].
     crpix
         Reference pixel in the one-based FITS convention.
     crval
@@ -69,7 +73,7 @@ def _make_gra_wcs(
 
     Returns
     -------
-    A 1D `~astropy.wcs.WCS` with a grating dispersion spectral axis.
+    A 1D `~astropy.wcs.WCS` with a grism dispersion spectral axis.
     """
     g, alpha, nrp, theta = p
     w = WCS(naxis=1)
@@ -80,23 +84,23 @@ def _make_gra_wcs(
     w.wcs.cdelt = [cdelt]
     w.wcs.set_pv(
         [
-            (1, 0, g),  # effective grating density [1/m], absorbs the refractive index
-            (1, 1, 1.0),  # diffraction order, fixed (enters only as a product with g)
-            (1, 2, alpha),  # incidence angle [deg]
-            (1, 3, 1.0),  # refractive index, fixed (enters only as a product with g)
-            (1, 4, nrp),  # dn/dlambda at the reference wavelength [1/m]
-            (1, 5, 0.0),  # grating rotation, fixed (degenerate with the grating density)
-            (1, 6, theta),  # camera angle [deg]
+            (1, 0, g),  # G: effective ruling density [1/m], absorbs m and cos(eps)
+            (1, 1, 1.0),  # m: interference order, fixed (enters only in the product G*m)
+            (1, 2, alpha),  # alpha: incidence angle [deg], absorbs n_r
+            (1, 3, 1.0),  # n_r: prism refractive index, fixed (enters only via n_r*sin(alpha))
+            (1, 4, nrp),  # n'_r: dn/dlambda at the reference wavelength [1/m]
+            (1, 5, 0.0),  # eps: grating tilt, fixed (enters only via G*m/cos(eps))
+            (1, 6, theta),  # theta: camera angle [deg]
         ]
     )
     return w
 
 
-GRA_SENTINEL = 1e8
-"""Residual value standing in for unphysical grating parameter combinations."""
+GRISM_SENTINEL = 1e8
+"""Residual value standing in for unphysical grism parameter combinations."""
 
 
-def _fit_gra_dispersion(
+def _fit_grism_dispersion(
     x_fits: NDArray,
     lam: NDArray,
     crpix: float,
@@ -106,17 +110,17 @@ def _fit_gra_dispersion(
     cunit: str,
     m_to_unit: float,
 ) -> optimize.OptimizeResult:
-    """Fit the WCS Paper III grating dispersion function to an exact wavelength solution.
+    """Fit the WCS Paper III grism dispersion function to an exact wavelength solution.
 
-    Fits the four free grating parameters (g, alpha, nrp, theta) with a single bounded
+    Fits the four free grism parameters (g, alpha, nrp, theta) with a single bounded
     least-squares run. The reference pixel keywords (CRPIX, CRVAL, CDELT) are exact
     statements about the wavelength solution and pin the value and slope of the dispersion
     function at the reference pixel, which makes the problem unimodal enough for a local
-    optimizer. The initial grating density is the Littrow-configuration value at the
+    optimizer. The initial ruling density is the Littrow-configuration value at the
     reference wavelength, which places the starting point inside the arcsin domain of the
-    grating equation for any reference wavelength, and pixels for which wcslib returns
-    non-finite values yield large finite residuals that keep the optimizer within the
-    valid parameter space.
+    grism equation (Greisen et al. 2006, Eq. 68) for any reference wavelength, and pixels
+    for which wcslib returns non-finite values yield large finite residuals that keep the
+    optimizer within the valid parameter space.
 
     Parameters
     ----------
@@ -141,23 +145,23 @@ def _fit_gra_dispersion(
     Returns
     -------
     The `~scipy.optimize.OptimizeResult` of the fit, where ``x`` holds the optimized
-    grating parameters as in `_make_gra_wcs` and ``fun`` the residual wavelengths in the
+    grism parameters as in `_make_grism_wcs` and ``fun`` the residual wavelengths in the
     solution unit.
 
     Raises
     ------
     RuntimeError
-        If the grating dispersion function cannot be evaluated anywhere along the
+        If the grism dispersion function cannot be evaluated anywhere along the
         spectral axis at the fitted parameters.
     """
 
     def residuals(p: NDArray) -> NDArray:
         try:
-            w = _make_gra_wcs(p, crpix, crval, cdelt, ctype, cunit)
+            w = _make_grism_wcs(p, crpix, crval, cdelt, ctype, cunit)
             res = w.wcs_pix2world(x_fits, 1)[:, 0] * m_to_unit - lam
         except InvalidTransformError:
-            return np.full(lam.size, GRA_SENTINEL)
-        return np.where(np.isfinite(res), res, GRA_SENTINEL)
+            return np.full(lam.size, GRISM_SENTINEL)
+        return np.where(np.isfinite(res), res, GRISM_SENTINEL)
 
     lam_ref_m = crval / m_to_unit
     g0 = float(np.clip(2.0 * np.sin(np.radians(10.0)) / lam_ref_m, 1e3, 1e7))
@@ -165,17 +169,17 @@ def _fit_gra_dispersion(
 
     # Set the WCS once outside the fit so that parameter-independent configuration errors
     # (such as an invalid CUNIT) propagate instead of being fenced off as unphysical
-    # parameter combinations. Out-of-domain grating parameters do not raise here: wcslib
+    # parameter combinations. Out-of-domain grism parameters do not raise here: wcslib
     # signals them with non-finite coordinates handled in `residuals`.
-    _make_gra_wcs(p0, crpix, crval, cdelt, ctype, cunit).wcs.set()
+    _make_grism_wcs(p0, crpix, crval, cdelt, ctype, cunit).wcs.set()
 
     bounds = ([1e3, -89.9, -1e7, -89.9], [1e7, 89.9, 1e7, 89.9])
     fit = optimize.least_squares(
         residuals, p0, bounds=bounds, method="trf", x_scale=[g0, 10.0, 1e4, 10.0]
     )
-    if np.all(fit.fun == GRA_SENTINEL):
+    if np.all(fit.fun == GRISM_SENTINEL):
         raise RuntimeError(
-            "The grating dispersion function could not be evaluated anywhere along the "
+            "The grism dispersion function could not be evaluated anywhere along the "
             "spectral axis: the wavelength solution is outside the parameter space "
             "reachable by the 'WAVE-GRI'/'AWAV-GRA' dispersion model. The 'gwcs' property "
             "provides a lossless representation."
@@ -302,10 +306,11 @@ class WavelengthSolution1D:
     def wcs(self, wave_air: bool | None = None, max_residual: float = 1.0) -> WCS:
         """Fit and return a FITS WCS approximating the wavelength solution.
 
-        Fits the FITS WCS Paper III grating dispersion function to the exact
-        pixel-to-wavelength model and returns the result as a standard `~astropy.wcs.WCS`
-        object with an 'AWAV-GRA' (air) or 'WAVE-GRI' (vacuum) spectral axis that can be
-        serialized into a FITS header and evaluated by any FITS-compliant reader.
+        Fits the FITS WCS Paper III grism dispersion function (Greisen et al. 2006,
+        A&A 446, 747, Sect. 5.1) to the exact pixel-to-wavelength model and returns the
+        result as a standard `~astropy.wcs.WCS` object with an 'AWAV-GRA' (air) or
+        'WAVE-GRI' (vacuum) spectral axis that can be serialized into a FITS header and
+        evaluated by any FITS-compliant reader.
 
         Parameters
         ----------
@@ -323,7 +328,7 @@ class WavelengthSolution1D:
 
         Returns
         -------
-        A 1D `~astropy.wcs.WCS` using the Paper III grating dispersion function.
+        A 1D `~astropy.wcs.WCS` using the Paper III grism dispersion function.
 
         Raises
         ------
@@ -334,7 +339,7 @@ class WavelengthSolution1D:
             If the wavelength solution does not use a power-series
             `~astropy.modeling.polynomial.Polynomial1D` model.
         RuntimeError
-            If the grating dispersion function cannot be evaluated anywhere along the
+            If the grism dispersion function cannot be evaluated anywhere along the
             spectral axis, meaning the solution is outside the parameter space reachable
             by the dispersion model.
 
@@ -343,26 +348,30 @@ class WavelengthSolution1D:
         The reference pixel keywords are exact statements about the wavelength solution
         rather than fit parameters: CRPIX is the solution's reference pixel, and CRVAL and
         CDELT are the value and derivative of the solution polynomial at that pixel. Only
-        the four grating terms (the grating density PV1_0, the incidence angle PV1_2, the
-        refractive index derivative PV1_4, and the camera angle PV1_6) are fitted, so all
-        approximation error lives in the PV terms, and the residual is zero in both value
-        and slope at the reference pixel and grows towards the chip edges.
+        four grism terms (the grating ruling density PV1_0, the incidence angle PV1_2,
+        the refractive index derivative PV1_4, and the camera angle PV1_6; see Greisen
+        et al. 2006, Table 6) are fitted, so all approximation error lives in the PV
+        terms, and the residual is zero in both value and slope at the reference pixel
+        and grows towards the chip edges.
 
-        The grating dispersion function cannot represent an arbitrary polynomial exactly,
+        The grism dispersion function cannot represent an arbitrary polynomial exactly,
         so the returned WCS is a numerical approximation of the wavelength solution and
-        the fitted PV values are effective rather than physical: the refractive index
-        PV1_3 is fixed at 1 because it enters the dispersion function only through its
-        product with the grating density, making the fitted PV1_0 an effective density
-        that absorbs the refractive index, and PV1_4 acts as a curvature absorber rather
-        than a measure of air dispersion. No spectrograph physics should be read from the
-        fitted PV values. If the fit fails to reach ``max_residual``, the solution is far
-        from any grating dispersion curve, and the lossless :attr:`gwcs` property should
-        be used instead.
+        the fitted PV values are effective rather than physical. The remaining Table 6
+        parameters are fixed at values that make them redundant with the fitted ones: the
+        interference order PV1_1 and the grating tilt PV1_5 enter the grism equation only
+        through the combination G*m/cos(eps), so they are absorbed by the fitted ruling
+        density, and the prism refractive index PV1_3 is fixed at 1 (the paper's plain
+        grating case) because it enters only through the product n_r*sin(alpha) and is
+        absorbed by the fitted incidence angle; PV1_4 acts as a curvature absorber rather
+        than a measure of glass dispersion. No spectrograph physics should be read from
+        the fitted PV values. If the fit fails to reach ``max_residual``, the solution is
+        far from any grism dispersion curve, and the lossless :attr:`gwcs` property
+        should be used instead.
 
-        Vacuum solutions use 'WAVE-GRI' (grating in vacuo) rather than 'WAVE-GRA' because
-        the GRA algorithm is native to air wavelengths: pairing it with a vacuum axis
-        would route every evaluation through wcslib's air-refraction model, which is not
-        valid below ~200 nm.
+        Vacuum solutions use 'WAVE-GRI' (grism in vacuum, Sect. 5.1.2 of the paper)
+        rather than 'WAVE-GRA' because the GRA algorithm (Sect. 5.1.4) is native to air
+        wavelengths: pairing it with a vacuum axis would route every evaluation through
+        wcslib's air-refraction model, which is not valid below ~200 nm.
 
         Note also that wcslib normalizes spectral axes to SI units, so evaluating the
         returned WCS yields wavelengths in metres regardless of the CUNIT, and serializing
@@ -397,8 +406,8 @@ class WavelengthSolution1D:
                 "bounds and cannot be exported as a FITS WCS."
             )
 
-        fit = _fit_gra_dispersion(x_fits, lam, crpix, crval, cdelt, ctype, cunit, m_to_unit)
-        w = _make_gra_wcs(fit.x, crpix, crval, cdelt, ctype, cunit)
+        fit = _fit_grism_dispersion(x_fits, lam, crpix, crval, cdelt, ctype, cunit, m_to_unit)
+        w = _make_grism_wcs(fit.x, crpix, crval, cdelt, ctype, cunit)
 
         with np.errstate(divide="ignore", invalid="ignore"):
             res_pix = np.abs(fit.fun / self.p2w_dldx(x_model))

--- a/specreduce/wavesol1d.py
+++ b/specreduce/wavesol1d.py
@@ -1,3 +1,4 @@
+import warnings
 from functools import cached_property
 from pathlib import Path
 from typing import Callable
@@ -9,9 +10,12 @@ import gwcs
 import numpy as np
 from astropy.modeling import models, CompoundModel
 from astropy.nddata import VarianceUncertainty
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.wcs import WCS
 from gwcs import coordinate_frames
 from numpy.ma import MaskedArray
 from numpy.typing import ArrayLike, NDArray
+from scipy import optimize
 from scipy.interpolate import interp1d
 
 from specutils import Spectrum
@@ -39,6 +43,152 @@ def _diff_poly1d(m: models.Polynomial1D) -> models.Polynomial1D:
     """
     coeffs = {f"c{i-1}": i * getattr(m, f"c{i}").value for i in range(1, m.degree + 1)}
     return models.Polynomial1D(m.degree - 1, **coeffs)
+
+
+def _make_gra_wcs(p: ArrayLike, crpix: float, ctype: str, cunit: str) -> WCS:
+    """Create a 1D FITS WCS using the WCS Paper III grating dispersion function.
+
+    Parameters
+    ----------
+    p
+        Dispersion parameters (crval, cdelt, log10_g, alpha, theta, nr, nrp): the reference
+        wavelength, the linear dispersion, the base-10 logarithm of the grating density [1/m],
+        the incidence angle [deg], the camera angle [deg], the refractive index at the
+        reference wavelength, and its derivative with respect to wavelength [1/m].
+    crpix
+        Reference pixel in the one-based FITS convention.
+    ctype
+        Spectral axis type, either 'AWAV-GRA' (air) or 'WAVE-GRA' (vacuum).
+    cunit
+        Wavelength unit string.
+
+    Returns
+    -------
+    A 1D `~astropy.wcs.WCS` with a grating dispersion spectral axis.
+    """
+    crval, cdelt, log10_g, alpha, theta, nr, nrp = p
+    w = WCS(naxis=1)
+    w.wcs.ctype = [ctype]
+    w.wcs.cunit = [cunit]
+    w.wcs.crpix = [crpix]
+    w.wcs.crval = [crval]
+    w.wcs.cdelt = [cdelt]
+    w.wcs.set_pv(
+        [
+            (1, 0, 10.0**log10_g),  # grating density [1/m]
+            (1, 1, 1.0),  # diffraction order, fixed
+            (1, 2, alpha),  # incidence angle [deg]
+            (1, 3, nr),  # refractive index at the reference wavelength
+            (1, 4, nrp),  # dn/dlambda at the reference wavelength [1/m]
+            (1, 5, 0.0),  # grating rotation, fixed (degenerate with the grating density)
+            (1, 6, theta),  # camera angle [deg]
+        ]
+    )
+    return w
+
+
+def _gra_residuals(
+    p: ArrayLike, crpix: float, x_fits: NDArray, lam: NDArray, ctype: str, cunit: str,
+    m_to_unit: float,
+) -> NDArray:
+    """Compute the residuals between a grating dispersion WCS and the exact solution.
+
+    Parameters
+    ----------
+    p
+        Dispersion parameters as in `_make_gra_wcs`.
+    crpix
+        Reference pixel in the one-based FITS convention.
+    x_fits
+        Pixel coordinates as a (npt, 1) array in the one-based FITS convention.
+    lam
+        Exact wavelengths at ``x_fits`` in the solution unit.
+    ctype
+        Spectral axis type, either 'AWAV-GRA' (air) or 'WAVE-GRA' (vacuum).
+    cunit
+        Wavelength unit string.
+    m_to_unit
+        Conversion factor from metres to the solution unit, needed because wcslib returns
+        metres for a spectral axis regardless of the CUNIT.
+
+    Returns
+    -------
+    Residual wavelengths in the solution unit. Unphysical parameter combinations, for which
+    wcslib raises or returns non-finite values, yield large finite residuals to keep the
+    optimizers within the valid parameter space.
+    """
+    try:
+        w = _make_gra_wcs(p, crpix, ctype, cunit)
+        res = w.wcs_pix2world(x_fits, 1)[:, 0] * m_to_unit - lam
+    except Exception:
+        return np.full(lam.size, 1e8)
+    return np.where(np.isfinite(res), res, 1e8)
+
+
+def _fit_gra_dispersion(
+    x_fits: NDArray, lam: NDArray, crpix: float, lam_ref: float, ctype: str, cunit: str,
+    m_to_unit: float, seed: int, npix_subsample: int,
+) -> NDArray:
+    """Fit the WCS Paper III grating dispersion function to an exact wavelength solution.
+
+    Runs a seeded global optimization (differential evolution) on a subsampled pixel grid
+    to locate the correct parameter-space basin, followed by a bounded least-squares polish
+    on the full grid. The reference pixel is fixed, so the fitted dispersion passes through
+    (crpix, crval) exactly and only seven parameters are free.
+
+    Parameters
+    ----------
+    x_fits
+        Pixel coordinates as a (npix, 1) array in the one-based FITS convention.
+    lam
+        Exact wavelengths at ``x_fits`` in the solution unit.
+    crpix
+        Fixed reference pixel in the one-based FITS convention.
+    lam_ref
+        Exact wavelength at the reference pixel in the solution unit.
+    ctype
+        Spectral axis type, either 'AWAV-GRA' (air) or 'WAVE-GRA' (vacuum).
+    cunit
+        Wavelength unit string.
+    m_to_unit
+        Conversion factor from metres to the solution unit.
+    seed
+        Seed for the differential evolution optimizer.
+    npix_subsample
+        Number of pixels used in the global optimization stage.
+
+    Returns
+    -------
+    The optimized dispersion parameters as in `_make_gra_wcs`.
+    """
+    d = (lam[-1] - lam[0]) / (x_fits[-1, 0] - x_fits[0, 0])
+    aspan = abs(lam[-1] - lam[0])
+    bounds = [
+        (max(lam_ref - 0.1 * aspan, 0.01 * abs(lam_ref)), lam_ref + 0.1 * aspan),  # crval
+        tuple(sorted((0.2 * d, 5.0 * d))),  # cdelt
+        (3.0, 7.0),  # log10 grating density
+        (-89.9, 89.9),  # incidence angle
+        (-89.9, 89.9),  # camera angle
+        (0.5, 2.0),  # refractive index
+        (-1e7, 1e7),  # refractive index derivative
+    ]
+
+    ix = np.unique(np.linspace(0, lam.size - 1, npix_subsample).astype(int))
+    x_sub, lam_sub = x_fits[ix], lam[ix]
+
+    def objective(p: NDArray) -> float:
+        res = _gra_residuals(p, crpix, x_sub, lam_sub, ctype, cunit, m_to_unit)
+        return float(np.sqrt(np.mean(res**2)))
+
+    de = optimize.differential_evolution(
+        objective, bounds=bounds, seed=seed, init="sobol",
+        popsize=24, maxiter=300, tol=0.01, polish=False,
+    )
+    fit = optimize.least_squares(
+        _gra_residuals, de.x, args=(crpix, x_fits, lam, ctype, cunit, m_to_unit),
+        bounds=tuple(zip(*bounds)), method="trf", x_scale="jac",
+    )
+    return fit.x
 
 
 class WavelengthSolution1D:
@@ -156,6 +306,90 @@ class WavelengthSolution1D:
         )
         pipeline = [(pixel_frame, self._p2w), (spectral_frame, None)]
         return gwcs.wcs.WCS(pipeline)
+
+    def wcs(
+        self,
+        wave_air: bool | None = None,
+        max_residual: float = 0.5,
+        npix_subsample: int = 128,
+        seed: int = 0,
+    ) -> WCS:
+        """Fit and return a FITS WCS approximating the wavelength solution.
+
+        Fits the FITS WCS Paper III grating dispersion function to the exact
+        pixel-to-wavelength model and returns the result as a standard `~astropy.wcs.WCS`
+        object with a 'AWAV-GRA' (air) or 'WAVE-GRA' (vacuum) spectral axis that can be
+        serialized into a FITS header and evaluated by any FITS-compliant reader.
+
+        Parameters
+        ----------
+        wave_air
+            Whether the spectral axis represents air rather than vacuum wavelengths,
+            selecting between the 'AWAV-GRA' and 'WAVE-GRA' axis types. If `None`, the
+            value given in the initialization is used.
+        max_residual
+            Maximum allowed absolute deviation between the fitted dispersion function and
+            the exact solution in pixels. A fit exceeding this limit emits an
+            `~astropy.utils.exceptions.AstropyUserWarning`.
+        npix_subsample
+            Number of pixels used in the global optimization stage.
+        seed
+            Seed for the differential evolution optimizer, making the fit deterministic.
+
+        Returns
+        -------
+        A 1D `~astropy.wcs.WCS` using the Paper III grating dispersion function.
+
+        Notes
+        -----
+        The grating dispersion function cannot represent an arbitrary polynomial exactly,
+        so the returned WCS is a numerical approximation of the wavelength solution and
+        the fitted parameters are effective rather than physical. The reference pixel is
+        fixed to the solution's reference pixel, and the remaining seven parameters
+        (CRVAL, CDELT, and the PV grating terms) are fitted with a seeded global optimizer
+        followed by a least-squares polish, which takes on the order of a second. If the
+        fit fails to reach ``max_residual``, retrying with a different ``seed`` may help;
+        solutions far from any grating dispersion curve have no accurate '-GRA'
+        representation, in which case the lossless :attr:`gwcs` property should be used
+        instead.
+
+        Note also that wcslib normalizes spectral axes to SI units, so evaluating the
+        returned WCS yields wavelengths in metres regardless of the CUNIT.
+        """
+        if self._p2w is None:
+            raise ValueError("Wavelength solution not set.")
+
+        air = self.wave_air if wave_air is None else wave_air
+        ctype = "AWAV-GRA" if air else "WAVE-GRA"
+        cunit = self.unit.to_string()
+
+        try:
+            m_to_unit = (1.0 * u.m).to_value(self.unit)
+        except u.UnitConversionError:
+            raise ValueError(f"FITS WCS export requires a length unit, got '{self.unit}'.")
+
+        ref_pixel = -self.ref_pixel
+        crpix = ref_pixel + 1.0
+        x_model = np.arange(self.bounds_pix[0], self.bounds_pix[1])
+        x_fits = x_model[:, None] + 1.0
+        lam = self.p2w(x_model)
+        lam_ref = float(self.p2w(ref_pixel))
+
+        popt = _fit_gra_dispersion(
+            x_fits, lam, crpix, lam_ref, ctype, cunit, m_to_unit, seed, npix_subsample
+        )
+        w = _make_gra_wcs(popt, crpix, ctype, cunit)
+
+        res_wav = _gra_residuals(popt, crpix, x_fits, lam, ctype, cunit, m_to_unit)
+        max_res = float(np.max(np.abs(res_wav / self.p2w_dldx(x_model))))
+        if max_res > max_residual:
+            warnings.warn(
+                f"The fitted FITS WCS deviates from the wavelength solution by up to "
+                f"{max_res:.2f} pixels, exceeding the given limit of {max_residual} pixels. "
+                f"The 'gwcs' property provides a lossless representation.",
+                AstropyUserWarning,
+            )
+        return w
 
     def to_asdf(self, path: str | Path, **kwargs) -> None:
         """Serialize the wavelength solution into an ASDF file.

--- a/specreduce/wavesol1d.py
+++ b/specreduce/wavesol1d.py
@@ -45,18 +45,23 @@ def _diff_poly1d(m: models.Polynomial1D) -> models.Polynomial1D:
     return models.Polynomial1D(m.degree - 1, **coeffs)
 
 
-def _make_gra_wcs(p: ArrayLike, crpix: float, ctype: str, cunit: str) -> WCS:
+def _make_gra_wcs(
+    p: ArrayLike, crpix: float, crval: float, cdelt: float, ctype: str, cunit: str
+) -> WCS:
     """Create a 1D FITS WCS using the WCS Paper III grating dispersion function.
 
     Parameters
     ----------
     p
-        Dispersion parameters (crval, cdelt, log10_g, alpha, theta, nr, nrp): the reference
-        wavelength, the linear dispersion, the base-10 logarithm of the grating density [1/m],
-        the incidence angle [deg], the camera angle [deg], the refractive index at the
-        reference wavelength, and its derivative with respect to wavelength [1/m].
+        Fitted grating parameters (g, alpha, nrp, theta): the effective grating density
+        [1/m], the incidence angle [deg], the derivative of the refractive index with
+        respect to wavelength at the reference wavelength [1/m], and the camera angle [deg].
     crpix
         Reference pixel in the one-based FITS convention.
+    crval
+        Wavelength at the reference pixel.
+    cdelt
+        Linear dispersion at the reference pixel.
     ctype
         Spectral axis type, either 'AWAV-GRA' (air) or 'WAVE-GRA' (vacuum).
     cunit
@@ -66,7 +71,7 @@ def _make_gra_wcs(p: ArrayLike, crpix: float, ctype: str, cunit: str) -> WCS:
     -------
     A 1D `~astropy.wcs.WCS` with a grating dispersion spectral axis.
     """
-    crval, cdelt, log10_g, alpha, theta, nr, nrp = p
+    g, alpha, nrp, theta = p
     w = WCS(naxis=1)
     w.wcs.ctype = [ctype]
     w.wcs.cunit = [cunit]
@@ -75,10 +80,10 @@ def _make_gra_wcs(p: ArrayLike, crpix: float, ctype: str, cunit: str) -> WCS:
     w.wcs.cdelt = [cdelt]
     w.wcs.set_pv(
         [
-            (1, 0, 10.0**log10_g),  # grating density [1/m]
-            (1, 1, 1.0),  # diffraction order, fixed
+            (1, 0, g),  # effective grating density [1/m], absorbs the refractive index
+            (1, 1, 1.0),  # diffraction order, fixed (enters only as a product with g)
             (1, 2, alpha),  # incidence angle [deg]
-            (1, 3, nr),  # refractive index at the reference wavelength
+            (1, 3, 1.0),  # refractive index, fixed (enters only as a product with g)
             (1, 4, nrp),  # dn/dlambda at the reference wavelength [1/m]
             (1, 5, 0.0),  # grating rotation, fixed (degenerate with the grating density)
             (1, 6, theta),  # camera angle [deg]
@@ -88,17 +93,21 @@ def _make_gra_wcs(p: ArrayLike, crpix: float, ctype: str, cunit: str) -> WCS:
 
 
 def _gra_residuals(
-    p: ArrayLike, crpix: float, x_fits: NDArray, lam: NDArray, ctype: str, cunit: str,
-    m_to_unit: float,
+    p: ArrayLike, crpix: float, crval: float, cdelt: float, x_fits: NDArray, lam: NDArray,
+    ctype: str, cunit: str, m_to_unit: float,
 ) -> NDArray:
     """Compute the residuals between a grating dispersion WCS and the exact solution.
 
     Parameters
     ----------
     p
-        Dispersion parameters as in `_make_gra_wcs`.
+        Grating parameters as in `_make_gra_wcs`.
     crpix
         Reference pixel in the one-based FITS convention.
+    crval
+        Wavelength at the reference pixel.
+    cdelt
+        Linear dispersion at the reference pixel.
     x_fits
         Pixel coordinates as a (npt, 1) array in the one-based FITS convention.
     lam
@@ -115,10 +124,10 @@ def _gra_residuals(
     -------
     Residual wavelengths in the solution unit. Unphysical parameter combinations, for which
     wcslib raises or returns non-finite values, yield large finite residuals to keep the
-    optimizers within the valid parameter space.
+    optimizer within the valid parameter space.
     """
     try:
-        w = _make_gra_wcs(p, crpix, ctype, cunit)
+        w = _make_gra_wcs(p, crpix, crval, cdelt, ctype, cunit)
         res = w.wcs_pix2world(x_fits, 1)[:, 0] * m_to_unit - lam
     except Exception:
         return np.full(lam.size, 1e8)
@@ -126,15 +135,17 @@ def _gra_residuals(
 
 
 def _fit_gra_dispersion(
-    x_fits: NDArray, lam: NDArray, crpix: float, lam_ref: float, ctype: str, cunit: str,
-    m_to_unit: float, seed: int, npix_subsample: int,
+    x_fits: NDArray, lam: NDArray, crpix: float, crval: float, cdelt: float, ctype: str,
+    cunit: str, m_to_unit: float,
 ) -> NDArray:
     """Fit the WCS Paper III grating dispersion function to an exact wavelength solution.
 
-    Runs a seeded global optimization (differential evolution) on a subsampled pixel grid
-    to locate the correct parameter-space basin, followed by a bounded least-squares polish
-    on the full grid. The reference pixel is fixed, so the fitted dispersion passes through
-    (crpix, crval) exactly and only seven parameters are free.
+    Fits the four free grating parameters (g, alpha, nrp, theta) with a single bounded
+    least-squares run. The reference pixel keywords (CRPIX, CRVAL, CDELT) are exact
+    statements about the wavelength solution and pin the value and slope of the dispersion
+    function at the reference pixel, which makes the problem unimodal enough for a local
+    optimizer started from a fixed initial guess. The bounds fence off the region where
+    the grating equation goes out of the arcsin domain.
 
     Parameters
     ----------
@@ -144,49 +155,26 @@ def _fit_gra_dispersion(
         Exact wavelengths at ``x_fits`` in the solution unit.
     crpix
         Fixed reference pixel in the one-based FITS convention.
-    lam_ref
-        Exact wavelength at the reference pixel in the solution unit.
+    crval
+        Fixed wavelength at the reference pixel.
+    cdelt
+        Fixed linear dispersion at the reference pixel.
     ctype
         Spectral axis type, either 'AWAV-GRA' (air) or 'WAVE-GRA' (vacuum).
     cunit
         Wavelength unit string.
     m_to_unit
         Conversion factor from metres to the solution unit.
-    seed
-        Seed for the differential evolution optimizer.
-    npix_subsample
-        Number of pixels used in the global optimization stage.
 
     Returns
     -------
-    The optimized dispersion parameters as in `_make_gra_wcs`.
+    The optimized grating parameters as in `_make_gra_wcs`.
     """
-    d = (lam[-1] - lam[0]) / (x_fits[-1, 0] - x_fits[0, 0])
-    aspan = abs(lam[-1] - lam[0])
-    bounds = [
-        (max(lam_ref - 0.1 * aspan, 0.01 * abs(lam_ref)), lam_ref + 0.1 * aspan),  # crval
-        tuple(sorted((0.2 * d, 5.0 * d))),  # cdelt
-        (3.0, 7.0),  # log10 grating density
-        (-89.9, 89.9),  # incidence angle
-        (-89.9, 89.9),  # camera angle
-        (0.5, 2.0),  # refractive index
-        (-1e7, 1e7),  # refractive index derivative
-    ]
-
-    ix = np.unique(np.linspace(0, lam.size - 1, npix_subsample).astype(int))
-    x_sub, lam_sub = x_fits[ix], lam[ix]
-
-    def objective(p: NDArray) -> float:
-        res = _gra_residuals(p, crpix, x_sub, lam_sub, ctype, cunit, m_to_unit)
-        return float(np.sqrt(np.mean(res**2)))
-
-    de = optimize.differential_evolution(
-        objective, bounds=bounds, seed=seed, init="sobol",
-        popsize=24, maxiter=300, tol=0.01, polish=False,
-    )
+    p0 = [5e5, 10.0, 0.0, 0.0]  # g, alpha, nrp, theta
+    bounds = ([1e3, -89.9, -1e7, -89.9], [1e7, 89.9, 1e7, 89.9])
     fit = optimize.least_squares(
-        _gra_residuals, de.x, args=(crpix, x_fits, lam, ctype, cunit, m_to_unit),
-        bounds=tuple(zip(*bounds)), method="trf", x_scale="jac",
+        _gra_residuals, p0, args=(crpix, crval, cdelt, x_fits, lam, ctype, cunit, m_to_unit),
+        bounds=bounds, method="trf", x_scale=[1e5, 10.0, 1e4, 10.0],
     )
     return fit.x
 
@@ -307,13 +295,7 @@ class WavelengthSolution1D:
         pipeline = [(pixel_frame, self._p2w), (spectral_frame, None)]
         return gwcs.wcs.WCS(pipeline)
 
-    def wcs(
-        self,
-        wave_air: bool | None = None,
-        max_residual: float = 0.5,
-        npix_subsample: int = 128,
-        seed: int = 0,
-    ) -> WCS:
+    def wcs(self, wave_air: bool | None = None, max_residual: float = 1.0) -> WCS:
         """Fit and return a FITS WCS approximating the wavelength solution.
 
         Fits the FITS WCS Paper III grating dispersion function to the exact
@@ -331,10 +313,6 @@ class WavelengthSolution1D:
             Maximum allowed absolute deviation between the fitted dispersion function and
             the exact solution in pixels. A fit exceeding this limit emits an
             `~astropy.utils.exceptions.AstropyUserWarning`.
-        npix_subsample
-            Number of pixels used in the global optimization stage.
-        seed
-            Seed for the differential evolution optimizer, making the fit deterministic.
 
         Returns
         -------
@@ -342,16 +320,24 @@ class WavelengthSolution1D:
 
         Notes
         -----
+        The reference pixel keywords are exact statements about the wavelength solution
+        rather than fit parameters: CRPIX is the solution's reference pixel, and CRVAL and
+        CDELT are the value and derivative of the solution polynomial at that pixel. Only
+        the four grating terms (the grating density PV1_0, the incidence angle PV1_2, the
+        refractive index derivative PV1_4, and the camera angle PV1_6) are fitted, so all
+        approximation error lives in the PV terms, and the residual is zero in both value
+        and slope at the reference pixel and grows towards the chip edges.
+
         The grating dispersion function cannot represent an arbitrary polynomial exactly,
         so the returned WCS is a numerical approximation of the wavelength solution and
-        the fitted parameters are effective rather than physical. The reference pixel is
-        fixed to the solution's reference pixel, and the remaining seven parameters
-        (CRVAL, CDELT, and the PV grating terms) are fitted with a seeded global optimizer
-        followed by a least-squares polish, which takes on the order of a second. If the
-        fit fails to reach ``max_residual``, retrying with a different ``seed`` may help;
-        solutions far from any grating dispersion curve have no accurate '-GRA'
-        representation, in which case the lossless :attr:`gwcs` property should be used
-        instead.
+        the fitted PV values are effective rather than physical: the refractive index
+        PV1_3 is fixed at 1 because it enters the dispersion function only through its
+        product with the grating density, making the fitted PV1_0 an effective density
+        that absorbs the refractive index, and PV1_4 acts as a curvature absorber rather
+        than a measure of air dispersion. No spectrograph physics should be read from the
+        fitted PV values. If the fit fails to reach ``max_residual``, the solution is far
+        from any grating dispersion curve, and the lossless :attr:`gwcs` property should
+        be used instead.
 
         Note also that wcslib normalizes spectral axes to SI units, so evaluating the
         returned WCS yields wavelengths in metres regardless of the CUNIT.
@@ -368,19 +354,17 @@ class WavelengthSolution1D:
         except u.UnitConversionError:
             raise ValueError(f"FITS WCS export requires a length unit, got '{self.unit}'.")
 
-        ref_pixel = -self.ref_pixel
-        crpix = ref_pixel + 1.0
+        crpix = -self.ref_pixel + 1.0
+        crval = float(self._p2w[1].c0.value)
+        cdelt = float(self._p2w[1].c1.value)
         x_model = np.arange(self.bounds_pix[0], self.bounds_pix[1])
         x_fits = x_model[:, None] + 1.0
         lam = self.p2w(x_model)
-        lam_ref = float(self.p2w(ref_pixel))
 
-        popt = _fit_gra_dispersion(
-            x_fits, lam, crpix, lam_ref, ctype, cunit, m_to_unit, seed, npix_subsample
-        )
-        w = _make_gra_wcs(popt, crpix, ctype, cunit)
+        popt = _fit_gra_dispersion(x_fits, lam, crpix, crval, cdelt, ctype, cunit, m_to_unit)
+        w = _make_gra_wcs(popt, crpix, crval, cdelt, ctype, cunit)
 
-        res_wav = _gra_residuals(popt, crpix, x_fits, lam, ctype, cunit, m_to_unit)
+        res_wav = _gra_residuals(popt, crpix, crval, cdelt, x_fits, lam, ctype, cunit, m_to_unit)
         max_res = float(np.max(np.abs(res_wav / self.p2w_dldx(x_model))))
         if max_res > max_residual:
             warnings.warn(


### PR DESCRIPTION
This PR adds:
- The `WavelengthSolution1D.wcs` method to calculate a spectral FITS WCS by fitting the grism dispersion function (Greisen et al. 2006) to the native polynomial solution. The WCS is returned as an `astropy.wcs.WCS` object that can be easily serialised to a FITS header.
- The `WavelengthSolution1D.attach_wcs` method to attach a (cached) FITS WCS to a `Spectrum` object, after which the spectrum can be saved/read using the  "wcs1d-fits" format.

AI/LLM disclaimer: I used Claude Opus 5 and Claude Fable quite extensively during development (including in agentic mode). That said, I am well familiar with the code and can explain what it does and why.