### PR TITLE
1D wavelength solution ASDF export/import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ New Features
 - Added ``WavelengthSolution1D.to_asdf()`` and ``WavelengthSolution1D.from_asdf()``
   for serializing a wavelength solution losslessly into an ASDF file. Only the
   coordinate transformation is stored, as a GWCS object whose bounding box carries
-  the pixel bounds, so the restored solution reproduces the original exactly. [#NNN]
+  the pixel bounds, so the restored solution reproduces the original exactly. [#317]
 
 1.9.0 (2026-05-06)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,15 @@
 
+1.10.0 (unreleased)
+-------------------
+
+New Features
+^^^^^^^^^^^^
+
+- Added ``WavelengthSolution1D.to_asdf()`` and ``WavelengthSolution1D.from_asdf()``
+  for serializing a wavelength solution losslessly into an ASDF file. Only the
+  coordinate transformation is stored, as a GWCS object whose bounding box carries
+  the pixel bounds, so the restored solution reproduces the original exactly. [#NNN]
+
 1.9.0 (2026-05-06)
 ------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,6 +172,7 @@ intersphinx_mapping.update(
         "ccdproc": ("https://ccdproc.readthedocs.io/en/stable/", None),
         "specutils": ("https://specutils.readthedocs.io/en/stable/", None),
         "gwcs": ("https://gwcs.readthedocs.io/en/stable/", None),
+        "asdf": ("https://www.asdf-format.org/projects/asdf/en/stable/", None),
     }
 )
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 license = {file = "licenses/LICENSE.rst"}
 description = "Astropy coordinated package for Spectroscopic Reductions"
 readme = "README.rst"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "numpy>=1.24",
     "astropy>=6.0",
@@ -65,7 +65,7 @@ build-backend = 'setuptools.build_meta'
 
 [tool.black]
 line-length = 100
-target-version = ['py311', 'py312', 'py313', 'py314']
+target-version = ['py312', 'py313', 'py314']
 
 [tool.pytest.ini_options]
 minversion = 7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "specutils>=2.0",
     "matplotlib>=3.10",
     "gwcs",
+    "asdf>=3.3",
 ]
 
 [project.optional-dependencies]

--- a/specreduce/tests/test_wavesol1d.py
+++ b/specreduce/tests/test_wavesol1d.py
@@ -1,10 +1,11 @@
+import asdf
 import astropy.units as u
 import numpy as np
 import pytest
 from astropy.modeling import models
 from astropy.modeling.polynomial import Polynomial1D
 from astropy.nddata import StdDevUncertainty
-from gwcs import wcs
+from gwcs import coordinate_frames, wcs
 from specreduce.wavesol1d import _diff_poly1d, WavelengthSolution1D
 from specutils import Spectrum
 
@@ -130,3 +131,73 @@ def test_wcs_creates_valid_gwcs_object(mk_ws_with_transform):
     assert wcs_obj is not None
     assert isinstance(wcs_obj, wcs.WCS)
     assert wcs_obj.output_frame.unit[0] == u.angstrom
+
+
+def test_asdf_round_trip_is_lossless(tmp_path):
+    ws = WavelengthSolution1D(p2w, pix_bounds, u.angstrom, wave_air=True)
+    path = tmp_path / "solution.asdf"
+    ws.to_asdf(path)
+    rs = WavelengthSolution1D.from_asdf(path)
+
+    assert rs.unit == ws.unit
+    assert rs.wave_air == ws.wave_air
+    assert rs.bounds_pix == ws.bounds_pix
+    assert rs.ref_pixel == ws.ref_pixel
+    assert isinstance(rs.p2w[1], Polynomial1D)
+    np.testing.assert_array_equal(rs.p2w.parameters, ws.p2w.parameters)
+
+    # The transform must be reproduced exactly, extrapolation outside the bounds included.
+    x = np.linspace(pix_bounds[0] - 50, pix_bounds[1] + 50, 137)
+    np.testing.assert_array_equal(rs.pix_to_wav(x), ws.pix_to_wav(x))
+    np.testing.assert_array_equal(rs.p2w_dldx(x), ws.p2w_dldx(x))
+
+
+def test_asdf_export_leaves_solution_unbounded(tmp_path, mk_ws_with_transform):
+    ws = mk_ws_with_transform
+    ws.to_asdf(tmp_path / "solution.asdf")
+
+    # The pixel bounds travel as the GWCS bounding box, which GWCS stores on the forward
+    # transform. Exporting must not bound the live solution, whose GWCS extrapolates.
+    assert ws.gwcs.bounding_box is None
+    with pytest.raises(NotImplementedError):
+        ws.p2w.bounding_box
+
+    rs = WavelengthSolution1D.from_asdf(tmp_path / "solution.asdf")
+    assert rs.gwcs.bounding_box is None
+    with pytest.raises(NotImplementedError):
+        rs.p2w.bounding_box
+
+
+def test_to_asdf_raises_without_transform(mk_ws_without_transform, tmp_path):
+    with pytest.raises(ValueError, match="not set"):
+        mk_ws_without_transform.to_asdf(tmp_path / "solution.asdf")
+
+
+def test_from_asdf_raises_on_foreign_file(tmp_path):
+    path = tmp_path / "foreign.asdf"
+    asdf.AsdfFile({"something_else": 1}).write_to(path)
+    with pytest.raises(ValueError, match="no wavelength solution"):
+        WavelengthSolution1D.from_asdf(path)
+
+
+def test_from_asdf_raises_without_bounding_box(tmp_path, mk_ws_with_transform):
+    ws = mk_ws_with_transform
+    path = tmp_path / "unbounded.asdf"
+    tree = {"wavelength_solution": {"gwcs": ws.gwcs, "wave_air": False}}
+    asdf.AsdfFile(tree).write_to(path)
+    with pytest.raises(ValueError, match="no bounding box"):
+        WavelengthSolution1D.from_asdf(path)
+
+
+def test_from_asdf_raises_on_unsupported_transform(tmp_path):
+    pixel_frame = coordinate_frames.CoordinateFrame(
+        1, "SPECTRAL", (0,), axes_names=["x"], unit=[u.pix]
+    )
+    spectral_frame = coordinate_frames.SpectralFrame(axes_names=("wavelength",), unit=[u.angstrom])
+    w = wcs.WCS([(pixel_frame, Polynomial1D(2, c0=1, c1=2)), (spectral_frame, None)])
+    w.bounding_box = (pix_bounds,)
+
+    path = tmp_path / "unsupported.asdf"
+    asdf.AsdfFile({"wavelength_solution": {"gwcs": w, "wave_air": False}}).write_to(path)
+    with pytest.raises(ValueError, match="shift followed by a polynomial"):
+        WavelengthSolution1D.from_asdf(path)

--- a/specreduce/wavesol1d.py
+++ b/specreduce/wavesol1d.py
@@ -1,6 +1,9 @@
 from functools import cached_property
+from pathlib import Path
 from typing import Callable
+from copy import deepcopy
 
+import asdf
 import astropy.units as u
 import gwcs
 import numpy as np
@@ -44,6 +47,7 @@ class WavelengthSolution1D:
         p2w: None | CompoundModel,
         bounds_pix: tuple[int, int],
         unit: u.Unit,
+        wave_air: bool = False,
     ) -> None:
         """Class defining a one-dimensional wavelength solution.
 
@@ -64,8 +68,12 @@ class WavelengthSolution1D:
             The lower and upper pixel bounds defining the range of the spectrum.
         unit
             The wavelength unit.
+        wave_air
+            Whether the solution maps pixels to air rather than vacuum wavelengths; by
+            default `False`, meaning vacuum wavelengths.
         """
         self.unit = unit
+        self.wave_air = wave_air
         self._unit_str = unit.to_string("latex")
         self.bounds_pix: tuple[int, int] = bounds_pix
         self.bounds_wav: tuple[float, float] | None = None
@@ -148,6 +156,104 @@ class WavelengthSolution1D:
         )
         pipeline = [(pixel_frame, self._p2w), (spectral_frame, None)]
         return gwcs.wcs.WCS(pipeline)
+
+    def to_asdf(self, path: str | Path, **kwargs) -> None:
+        """Serialize the wavelength solution into an ASDF file.
+
+        Stores the pixel-to-wavelength transformation as a GWCS object under the
+        'wavelength_solution' key of the ASDF tree. The transformation is written as an
+        analytic model rather than as a tabulated array, so the solution read back is
+        identical to the one written, and the file can be opened by any ASDF-aware tool
+        without specreduce. This is the lossless counterpart of :meth:`wcs`, which
+        approximates the solution closely enough to fit into a FITS header.
+
+        Only the coordinate transformation is stored: the line lists, matched-line tables,
+        and fit diagnostics held by the calibration that produced the solution are not
+        included.
+
+        Parameters
+        ----------
+        path
+            File to write to, given either as a path or as a writable file object.
+        **kwargs
+            Additional keyword arguments passed to `asdf.AsdfFile.write_to`.
+
+        Raises
+        ------
+        ValueError
+            If the wavelength solution is not set.
+
+        Notes
+        -----
+        The pixel bounds travel as the bounding box of the exported GWCS, which is the
+        idiomatic way to declare the domain over which a GWCS is valid. The bounding box is
+        set on the exported object only: the :attr:`gwcs` property is deliberately left
+        unbounded, because a bounded GWCS returns NaN outside its box instead of
+        extrapolating.
+
+        The air-wavelength flag is stored as a separate 'wave_air' entry because it states
+        what the wavelengths mean rather than how they are computed, and neither GWCS
+        spectral frames nor their physical types can express it.
+        """
+        if self._p2w is None:
+            raise ValueError("Wavelength solution not set.")
+
+        w = deepcopy(self.gwcs)
+        w.bounding_box = (self.bounds_pix,)
+        tree = {"wavelength_solution": {"gwcs": w, "wave_air": bool(self.wave_air)}}
+        asdf.AsdfFile(tree).write_to(path, **kwargs)
+
+    @classmethod
+    def from_asdf(cls, path: str | Path) -> "WavelengthSolution1D":
+        """Create a wavelength solution from an ASDF file written by :meth:`to_asdf`.
+
+        Parameters
+        ----------
+        path
+            File to read from, given either as a path or as a readable file object.
+
+        Returns
+        -------
+        The wavelength solution stored in the file.
+
+        Raises
+        ------
+        ValueError
+            If the file holds no wavelength solution written by :meth:`to_asdf`, if the
+            stored GWCS carries no bounding box giving the pixel bounds, or if its
+            transformation is not a shift followed by a polynomial.
+        """
+        with asdf.open(path, lazy_load=False) as af:
+            try:
+                node = af["wavelength_solution"]
+                w = node["gwcs"]
+                wave_air = node["wave_air"]
+            except (KeyError, TypeError):
+                raise ValueError(
+                    "The ASDF file contains no wavelength solution written by "
+                    "WavelengthSolution1D.to_asdf."
+                )
+
+            bbox = w.bounding_box
+            if bbox is None:
+                raise ValueError(
+                    "The stored GWCS carries no bounding box giving the pixel bounds of "
+                    "the wavelength solution."
+                )
+            bounds_pix = bbox.bounding_box()
+            unit = u.Unit(w.output_frame.unit[0])
+            p2w = w.forward_transform.copy()
+
+        # The bounding box lives on the forward transform, so drop it to keep the
+        # restored transformation extrapolating exactly like the one that was written.
+        del p2w.bounding_box
+
+        if not (isinstance(p2w, CompoundModel) and isinstance(p2w[0], models.Shift)):
+            raise ValueError(
+                "WavelengthSolution1D requires the stored transformation to be a shift "
+                f"followed by a polynomial, got {p2w.__class__.__name__}."
+            )
+        return cls(p2w, (int(bounds_pix[0]), int(bounds_pix[1])), unit, wave_air=bool(wave_air))
 
     def resample(
         self,

--- a/specreduce/wavesol1d.py
+++ b/specreduce/wavesol1d.py
@@ -164,8 +164,7 @@ class WavelengthSolution1D:
         'wavelength_solution' key of the ASDF tree. The transformation is written as an
         analytic model rather than as a tabulated array, so the solution read back is
         identical to the one written, and the file can be opened by any ASDF-aware tool
-        without specreduce. This is the lossless counterpart of :meth:`wcs`, which
-        approximates the solution closely enough to fit into a FITS header.
+        without specreduce.
 
         Only the coordinate transformation is stored: the line lists, matched-line tables,
         and fit diagnostics held by the calibration that produced the solution are not

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{311,312,313,314}-test{,-alldeps}{,-oldestdeps,-devdeps,-predeps}{,-cov}
+    py{312,313,314}-test{,-alldeps}{,-oldestdeps,-devdeps,-predeps}{,-cov}
     linkcheck
     codestyle
 


### PR DESCRIPTION
This PR adds the `WavelengthSolution1D.to_asdf` and `WavelengthSolution1D.from_asdf` methods to serialize a 1D wavelength solution into an ASDF file. 

AI/LLM disclaimer: similarly to #316, I used Claude Fable to speed up the development.